### PR TITLE
Enabled Git support for the winery-repository

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/FilebasedRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/FilebasedRepository.java
@@ -127,7 +127,7 @@ public class FilebasedRepository extends AbstractRepository implements IReposito
 		this.provider = this.fileSystem.provider();
 	}
 	
-	private Path determineRepositoryPath(String repositoryLocation) {
+	protected Path determineRepositoryPath(String repositoryLocation) {
 		Path repositoryPath;
 		if (repositoryLocation == null) {
 			if (SystemUtils.IS_OS_WINDOWS) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Oliver Kopp - initial API and implementation
+ *     Armin Hüneburg - improved API and implementation
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
@@ -38,153 +39,99 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.winery.common.RepositoryFileReference;
 import org.eclipse.winery.repository.Prefs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.MediaType;
+
 /**
- * Used for testing only.
- * 
  * Allows to reset repository to a certain commit id
  */
 public class GitBasedRepository extends FilebasedRepository {
-	
+
+	/**
+	 * Used for synchronizing the method {@link GitBasedRepository#addCommit()}
+	 */
+	private static final Object commitLock = new Object();
 	private static final Logger logger = LoggerFactory.getLogger(GitBasedRepository.class);
 	
 	private final Repository gitRepo;
 	private final Git git;
-	private final CredentialsProvider cp;
-	
-	public static final String PREFERENCE_GIT_USERNAME = "git.username";
-	public static final String PREFERENCE_GIT_PASSWORD = "git.password";
-	
-	
+
+
 	/**
 	 * @param repositoryLocation the location of the repository
 	 * @throws IOException thrown if repository does not exist
+	 * @throws GitAPIException thrown if there was an error while checking the status of the repository
+	 * @throws NoWorkTreeException thrown if the directory is not a git work tree
 	 */
-	public GitBasedRepository(String repositoryLocation) throws IOException {
+	public GitBasedRepository(String repositoryLocation) throws IOException, NoWorkTreeException, GitAPIException {
 		super(repositoryLocation);
 		FileRepositoryBuilder builder = new FileRepositoryBuilder();
-		this.gitRepo = builder.setWorkTree(this.repositoryRoot.toFile()).setMustExist(true).build();
+		this.gitRepo = builder.setWorkTree(this.repositoryRoot.toFile()).setMustExist(false).build();
+		if (!new File(this.determineRepositoryPath(repositoryLocation) + "/.git").exists()) {
+		    this.gitRepo.create();
+		}
 		this.git = new Git(this.gitRepo);
-		
-		this.cp = this.initializeCredentialsProvider();
-	}
-	
-	/**
-	 * Reads the properties stored in ".winery" in the repository
-	 */
-	private Properties dotWineryProperties() {
-		Properties p = new Properties();
-		File f = new File(this.repositoryRoot.toFile(), ".winery");
-		InputStream is;
-		try {
-			is = new FileInputStream(f);
-		} catch (FileNotFoundException e1) {
-			// .winery does not exist in the file-based repository
-			return p;
+		if (!this.git.status().call().isClean()) {
+            this.addCommit();
 		}
-		if (is != null) {
-			try {
-				p.load(is);
-			} catch (IOException e) {
-				GitBasedRepository.logger.debug(e.getMessage(), e);
-			}
-		}
-		return p;
 	}
-	
+
 	/**
-	 * Uses git.username und git.password from .winery and winery.properties
+	 * This method is is synchronized with an extra static object (meaning all instances are locked).
+	 * This is to ensure that every commit only has one change.
 	 * 
-	 * Considering .winery is useful if the same war file is used on a dev
-	 * server and a stable server. The WAR file cannot contain the credentials
-	 * if committing is only allowed on only one of these servers
+	 * @throws GitAPIException thrown when anything with adding or committing goes wrong.
 	 */
-	private CredentialsProvider initializeCredentialsProvider() {
-		CredentialsProvider cp;
-		
-		Properties wp = this.dotWineryProperties();
-		
-		String gitUserName = wp.getProperty(GitBasedRepository.PREFERENCE_GIT_USERNAME);
-		if (gitUserName == null) {
-			gitUserName = Prefs.INSTANCE.getProperties().getProperty(GitBasedRepository.PREFERENCE_GIT_USERNAME);
+	public void addCommit() throws GitAPIException {
+		synchronized (commitLock) {
+			AddCommand add = this.git.add();
+			add.addFilepattern(".");
+			add.call();
+
+			CommitCommand commit = this.git.commit();
+			commit.setMessage("Commit through Winery");
+			commit.call();
 		}
-		
-		String gitPassword = wp.getProperty(GitBasedRepository.PREFERENCE_GIT_PASSWORD);
-		if (gitPassword == null) {
-			gitPassword = Prefs.INSTANCE.getProperties().getProperty(GitBasedRepository.PREFERENCE_GIT_PASSWORD);
-		}
-		
-		if (gitUserName == null) {
-			cp = null;
-		} else if (gitPassword == null) {
-			cp = null;
-		} else {
-			cp = new UsernamePasswordCredentialsProvider(gitUserName, gitPassword);
-		}
-		return cp;
 	}
-	
-	public void addCommitPush() throws NoHeadException, NoMessageException, UnmergedPathsException, ConcurrentRefUpdateException, WrongRepositoryStateException, GitAPIException {
-		AddCommand add = this.git.add();
-		add.addFilepattern(".");
-		add.call();
-		
-		CommitCommand commit = this.git.commit();
-		commit.setMessage("Commit through Winery");
-		commit.call();
-		
-		PushCommand push = this.git.push();
-		if (this.cp != null) {
-			push.setCredentialsProvider(this.cp);
-		}
-		push.call();
-	}
-	
+
 	private void clean() throws NoWorkTreeException, GitAPIException {
-		GitBasedRepository.logger.trace("git clean");
 		// remove untracked files
 		CleanCommand clean = this.git.clean();
 		clean.setCleanDirectories(true);
 		clean.call();
 	}
-	
+
 	public void cleanAndResetHard() throws NoWorkTreeException, GitAPIException {
 		// enable updating by resetting the content of the repository
 		this.clean();
-		
-		// fetch the newest thing from upstream
-		GitBasedRepository.logger.trace("git fetch");
-		FetchCommand fetch = this.git.fetch();
-		if (this.cp != null) {
-			fetch.setCredentialsProvider(this.cp);
-		}
-		fetch.call();
-		
-		// after fetching, reset to the latest version
-		GitBasedRepository.logger.trace("git reset --hard");
+
+		// reset to the latest version
 		ResetCommand reset = this.git.reset();
 		reset.setMode(ResetType.HARD);
 		reset.call();
 	}
-	
-	public void setRevisionTo(String ref) throws CheckoutConflictException, GitAPIException {
+
+	public void setRevisionTo(String ref) throws GitAPIException {
 		this.clean();
-		
+
 		// reset repository to the desired reference
 		ResetCommand reset = this.git.reset();
 		reset.setMode(ResetType.HARD);
 		reset.setRef(ref);
 		reset.call();
 	}
-	
-	/**
-	 * Returns true if authentification information (for instance, to push to
-	 * upstream) is available
-	 */
-	public boolean authenticationInfoAvailable() {
-		return this.cp != null;
+
+	@Override
+	public void putContentToFile(RepositoryFileReference ref, InputStream inputStream, MediaType mediaType) throws IOException {
+		super.putContentToFile(ref, inputStream, mediaType);
+		try {
+			this.addCommit();
+		} catch (GitAPIException e) {
+			logger.trace(e.getMessage(), e);
+		}
 	}
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/admin/RepositoryAdminResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/admin/RepositoryAdminResource.java
@@ -67,7 +67,7 @@ public class RepositoryAdminResource {
 			return Response.noContent().build();
 		} else if (commit != null) {
 			try {
-				((GitBasedRepository) Prefs.INSTANCE.getRepository()).addCommitPush();
+				((GitBasedRepository) Prefs.INSTANCE.getRepository()).addCommit();
 			} catch (Exception e) {
 				Response res;
 				res = Response.serverError().entity(e.getMessage()).build();

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/admin/repository.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/admin/repository.jsp
@@ -28,16 +28,10 @@ org.eclipse.winery.repository.backend.IRepository rep;
 rep = org.eclipse.winery.repository.Prefs.INSTANCE.getRepository();
 boolean isGitBasedRepo = (rep instanceof org.eclipse.winery.repository.backend.filebased.GitBasedRepository);
 
-org.eclipse.winery.repository.backend.filebased.GitBasedRepository repo = null;
-if (isGitBasedRepo) {
-	repo = (org.eclipse.winery.repository.backend.filebased.GitBasedRepository) rep;
-}
-
 // We only support the commit and reset buttons if we can authenticate at the repository
 // This is a hack to offer different versions of winery at dev.winery.opentosca.org and winery.opentosca.org
-isGitBasedRepo = isGitBasedRepo && (repo.authenticationInfoAvailable());
 
-if (isGitBasedRepo) {
+	if (isGitBasedRepo) {
 %>
 <h4>Versioning</h4>
 <div>

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/PrefsTestEnabledGitBackedRepository.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/PrefsTestEnabledGitBackedRepository.java
@@ -13,11 +13,13 @@ package org.eclipse.winery.repository;
 
 import java.io.IOException;
 
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.NoWorkTreeException;
 import org.eclipse.winery.repository.backend.filebased.GitBasedRepository;
 
 public class PrefsTestEnabledGitBackedRepository extends PrefsTestEnabled {
 	
-	public PrefsTestEnabledGitBackedRepository() throws IOException {
+	public PrefsTestEnabledGitBackedRepository() throws IOException, NoWorkTreeException, GitAPIException {
 		super(false);
 		// TODO: we should to a new clone of the repository
 		// currently, we rely on the right configuration of the preferences to use a file-based repository


### PR DESCRIPTION
In FilebasedRepository.java, determineRepositoryPath became protected so it can be used in derived classes.
It is used in GitBasedRepository.java to get the path of the local winery-repository.

The old GitBasedRepository.java is updated so that it doesn't use a remote anymore.
Thus the settings for user and password on the remote were removed.
Every save action is committed. The committing is blocking.

Renamed addCommitPush to addCommit since there is no pushing anymore.
All references to the method were updated.

Signed-off-by: Armin Hueneburg <hueneburg.armin@gmail.com>