### PR TITLE
Add JRebel dependecy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,20 @@
 				<artifactId>versions-maven-plugin</artifactId>
 				<version>2.1</version>
 			</plugin>
+			<plugin>
+				<groupId>org.zeroturnaround</groupId>
+				<artifactId>jrebel-maven-plugin</artifactId>
+				<version>1.1.6</version>
+				<executions>
+					<execution>
+						<id>generate-rebel-xml</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
This adds http://manuals.zeroturnaround.com/jrebel/standalone/maven.html to enable smooth integration with JRebel.