### PR TITLE
adds checking for the planbuilder service on the container API

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Prefs.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Prefs.java
@@ -302,8 +302,7 @@ public class Prefs implements ServletContextListener {
 			String planBuilderURI = "http://localhost:1339/planbuilder";
 			this.isPlanBuilderAvailable = Utils.isResourceAvailable(planBuilderURI);
 		}
-		
-		if(!this.isPlanBuilderAvailable){
+		if (!this.isPlanBuilderAvailable) {
 			String containerPlanBuilderURI = "http://localhost:1337/containerapi/planbuilder";
 			this.isPlanBuilderAvailable = Utils.isResourceAvailable(containerPlanBuilderURI);
 		}

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Prefs.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Prefs.java
@@ -302,6 +302,12 @@ public class Prefs implements ServletContextListener {
 			String planBuilderURI = "http://localhost:1339/planbuilder";
 			this.isPlanBuilderAvailable = Utils.isResourceAvailable(planBuilderURI);
 		}
+		
+		if(!this.isPlanBuilderAvailable){
+			String containerPlanBuilderURI = "http://localhost:1337/containerapi/planbuilder";
+			this.isPlanBuilderAvailable = Utils.isResourceAvailable(containerPlanBuilderURI);
+		}
+		
 		return this.isPlanBuilderAvailable;
 	}
 	

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
@@ -200,8 +200,14 @@ public class TopologyTemplateResource {
 		request += "</PLANPOSTURL></generatePlanForTopology>";
 		
 		Client client = Client.create();
-		Builder wr = client.resource("http://localhost:1339/planbuilder/sync").type(MediaType.APPLICATION_XML);
-		
+
+		Builder wr = null;
+		if (Utils.isResourceAvailable("http://localhost:1339/planbuilder")) {
+			wr = client.resource("http://localhost:1339/planbuilder/sync").type(MediaType.APPLICATION_XML);
+		} else if(Utils.isResourceAvailable("http://localhost:1337/containerapi/planbuilder")){
+			wr = client.resource("http://localhost:1337/containerapi/planbuilder/sync").type(MediaType.APPLICATION_XML);
+		}
+
 		try {
 			wr.post(String.class, request);
 		} catch (com.sun.jersey.api.client.UniformInterfaceException e) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
@@ -200,14 +200,14 @@ public class TopologyTemplateResource {
 		request += "</PLANPOSTURL></generatePlanForTopology>";
 		
 		Client client = Client.create();
-
+		
 		Builder wr = null;
 		if (Utils.isResourceAvailable("http://localhost:1339/planbuilder")) {
 			wr = client.resource("http://localhost:1339/planbuilder/sync").type(MediaType.APPLICATION_XML);
-		} else if(Utils.isResourceAvailable("http://localhost:1337/containerapi/planbuilder")){
+		} else if (Utils.isResourceAvailable("http://localhost:1337/containerapi/planbuilder")) {
 			wr = client.resource("http://localhost:1337/containerapi/planbuilder/sync").type(MediaType.APPLICATION_XML);
 		}
-
+		
 		try {
 			wr.post(String.class, request);
 		} catch (com.sun.jersey.api.client.UniformInterfaceException e) {


### PR DESCRIPTION
The OpenTOSCA Container exposes the PlanBuilder Service inside it's API, this commit enables the winery to check either for the external service (as it was up to now) or the integrated service inside the API of the TOSCA Runtime

Signed-off-by: Kálmán Képes <kalman.kepes@iaas.uni-stuttgart.de>