### PR TITLE
Revert "Replace select2 with bootstrap3-typeahead"

### DIFF
--- a/org.eclipse.winery.repository/about.html
+++ b/org.eclipse.winery.repository/about.html
@@ -388,19 +388,19 @@ This library is required by jsPlumb only
 	</tr>
 </table>
 
-<h5>Bootstrap-3-Typeahead &ndash; Version 4.0.2</h5>
+<h5>Select2 &ndash; Version 3.4.5</h5>
 <table>
 	<tr>
 		<td>Files</td>
-		<td>src/main/webapp/components/bootstrap3-typeahead</td>
+		<td>src/main/webapp/components/select2</td>
 	</tr>
 	<tr>
 		<td>URL</td>
-		<td><a href="https://github.com/bassjobsen/Bootstrap-3-Typeahead">https://github.com/bassjobsen/Bootstrap-3-Typeahead</a></td>
+		<td><a href="http://ivaynberg.github.io/select2/">http://ivaynberg.github.io/select2/</a></td>
 	</tr>
 	<tr>
 		<td>License</td>
-		<td>Apache 2.0 (<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>).
+		<td>Apache 2.0 (<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>) and GPL2 (<a href="http://www.gnu.org/licenses/gpl-2.0.html">http://www.gnu.org/licenses/gpl-2.0.html</a>).
 		The Eclipse Foundation elects to include this software in this distribution under the Apache 2.0 license.
 		A copy of the license is contained in the file <a href="about_files/Apache-LICENSE-2.0.txt" target="_blank">Apache-LICENSE-2.0.txt</a>.</td>
 	</tr>

--- a/org.eclipse.winery.repository/bower.json
+++ b/org.eclipse.winery.repository/bower.json
@@ -17,9 +17,6 @@
     },
     {
       "name": "Jerome Tagliaferri"
-    },
-    {
-      "name": "Niko Stadelmaier"
     }
   ],
   "licenses": [
@@ -46,7 +43,7 @@
     "KeyboardJS": "git://github.com/RobertWHurst/KeyboardJS.git#v0.4.2",
     "pnotify": "1.3.1",
     "requirejs": "2.1.5",
-	"bootstrap3-typeahead": "git://github.com/bassjobsen/Bootstrap-3-Typeahead.git#4.0.2",
+    "select2": "https://github.com/ivaynberg/select2/archive/3.4.5.zip",
     "uri.js": "v1.12.0",
     "x-editable": "1.5.1",
     "bootstrap3-wysihtml5-bower": "0.2.8",

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/addComponentInstance.tag
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/addComponentInstance.tag
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2012-2016 University of Stuttgart.
+ * Copyright (c) 2012-2013 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -9,7 +9,6 @@
  *
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
- *    Niko Stadelmaier - removal of select2 library
  *******************************************************************************/
 --%>
 <%@tag description="used by genericcomponentpage.jsp and by implementations.jsp to create a component instance" pageEncoding="UTF-8"%>
@@ -51,7 +50,7 @@ function createResource(nameOfResource, fields, url, onSuccess) cannot be used a
 				<%-- Either directly given ... --%>
 				<c:when test="${not empty type}">
 					<%-- then, we just submit it together with the other data --%>
-					<input id="ciType" type="text" class="form-control" name="type" value="${type}"/>
+					<input id="ciType" type="hidden" class="form-control" name="type" value="${type}"/>
 				</c:when>
 				<%-- ... or a list is given given. --%>
 				<%-- This is somewhat ugly as the UI displays no type dialog if no types are existing, but a template is to be created.
@@ -62,11 +61,11 @@ function createResource(nameOfResource, fields, url, onSuccess) cannot be used a
 					<div class="form-group">
 						<label for="ciType" class="control-label">Type</label>
 						<%-- similar code to artifacts.jsp.openLink${name}ArtifactDiag().ajax.success --%>
-						<input id="ciType" name="type" class="form-control">
-							<%-- <c:forEach var="typeId" items="${typeSelectorData}">
+						<select id="ciType" name="type" class="form-control">
+							<c:forEach var="typeId" items="${typeSelectorData}">
 								<option value="${typeId.QName}">${typeId.xmlId.decoded}</option>
-							</c:forEach> --%>
-						</input>
+							</c:forEach>
+						</select>
 					</div>
 				</c:when>
 			</c:choose>
@@ -85,20 +84,7 @@ function createResource(nameOfResource, fields, url, onSuccess) cannot be used a
 
 <script>
 <c:if test="${empty type and not empty typeSelectorData}">
-	require(["bootstrap3-typeahead"], function(){
-
-
-		$("#ciType").typeahead({
-			source : [
-				<c:forEach var="typeId" items="${typeSelectorData}" varStatus="loop">
-				{id:"${typeId.QName}",name:"${typeId.xmlId.decoded}"}<c:if test="${!loop.last}">,</c:if>
-				</c:forEach>
-			],
-			autoSelect: true,
-			showHintOnFocus: true
-		});
-	});
-
+$("#ciType").select2();
 </c:if>
 
 $("#addComponentInstanceDiag").on("shown.bs.modal", function() {

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/entitytypes/nodetypes/reqandcapdefs/reqandcapdefs.tag
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/entitytypes/nodetypes/reqandcapdefs/reqandcapdefs.tag
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2012-2016 University of Stuttgart.
+ * Copyright (c) 2012-2014 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -10,8 +10,6 @@
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
  *    Yves Schubert - switch to bootstrap 3, integration with spinnerwithinphty
- *    Niko Stadelmaier - removal of select2 library
- *    Philipp Meyer - removal of select2 library
  *******************************************************************************/
 --%>
 <%@tag description="Models Requirement and Capability Definitions" pageEncoding="UTF-8"%>
@@ -322,7 +320,7 @@ function createReqOrCapDef() {
 			// Data has been validated at the server
 			// We can just add the local data
 			var name = $('#reqorcapname').val();
-			var type = $('#type :selected').text(); // TODO: make href to be consistent with other lines
+			var type = $('#type').select2("data").text; // TODO: make href to be consistent with other lines
 			var lbound = $('#lowerbound').val();
 			var ubound = $('#upperbound').val();
 			var constraints = "<button class=\"btn btn-xs\" onclick=\"editConstraints('" + name + "');\">Constraints...</button>";

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/genericpage.tag
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/genericpage.tag
@@ -10,7 +10,6 @@
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
  *    Yves Schubert - switch to bootstrap 3
- *    Niko Stadelmaier - removal of select2 library
  *    Lukas Balzer, Nicole Keppler - switch to bootstrap-touchspin
  *******************************************************************************/
 --%>
@@ -47,6 +46,8 @@
 	<link type="text/css" href="${pageContext.request.contextPath}/css/winery-repository.css" rel="Stylesheet" />
 	<link type="text/css" href="${pageContext.request.contextPath}/components/pnotify/jquery.pnotify.default.css" media="all" rel="stylesheet" />
 	<link type="text/css" href="${pageContext.request.contextPath}/components/pnotify/jquery.pnotify.default.icons.css" media="all" rel="stylesheet" />
+	<link type="text/css" href="${pageContext.request.contextPath}/components/select2/select2.css" media="all" rel="stylesheet" />
+	<link type="text/css" href="${pageContext.request.contextPath}/components/select2/select2-bootstrap.css" media="all" rel="stylesheet" />
 
 	<link type="text/css" href="${pageContext.request.contextPath}/components/bootstrap3-wysihtml5-bower/dist/bootstrap3-wysihtml5.css" media="all" rel="stylesheet" />
 	<link type="text/css" href="${pageContext.request.contextPath}/components/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css" media="all" rel="stylesheet" />
@@ -86,7 +87,7 @@
 
 				"pnotify": "../components/pnotify/jquery.pnotify",
 
-				"bootstrap3-typeahead": "../components/bootstrap3-typeahead/bootstrap3-typeahead",
+				"select2": "../components/select2/select2",
 
 				"tmpl": "../components/blueimp-tmpl/js/tmpl",
 
@@ -103,12 +104,14 @@
 	<script type='text/javascript' src='${pageContext.request.contextPath}/components/bootstrap/dist/js/bootstrap.js'></script>
 
 	<script type="text/javascript" src="${pageContext.request.contextPath}/components/jquery-typing/plugin/jquery.typing-0.3.2.js"></script>
+	<script type="text/javascript" src="${pageContext.request.contextPath}/components/select2/select2.js"></script>
 
 	<script type="text/javascript" src="${pageContext.request.contextPath}/components/wysihtml5/dist/wysihtml5-0.3.0.js"></script>
 	<script type="text/javascript" src="${pageContext.request.contextPath}/components/handlebars/handlebars.min.js"></script>
 	<script type="text/javascript" src="${pageContext.request.contextPath}/components/bootstrap3-wysihtml5-bower/dist/bootstrap3-wysihtml5.min.js"></script>
 	<script type="text/javascript" src="${pageContext.request.contextPath}/components/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.js"></script>
 	<script type="text/javascript" src="${pageContext.request.contextPath}/components/x-editable/dist/inputs-ext/wysihtml5/wysihtml5.js"></script>
+
 	<script type='text/javascript' src='${pageContext.request.contextPath}/components/bootstrap-touchspin/dist/jquery.bootstrap-touchspin.js'></script>
 	<script type="text/javascript" src="${pageContext.request.contextPath}/js/winery-support-non-AMD.js"></script>
 	<script type="text/javascript" src="${w:topologyModelerURI()}/js/winery-common.js"></script>

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
@@ -9,7 +9,6 @@
  *
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
- *    Niko Stadelmaier - removal of select2 library
  *******************************************************************************/
 --%>
 <%@tag description="places a bootstrap form control to chooose a namespace. A new namespace can be created" pageEncoding="UTF-8"%>
@@ -34,24 +33,20 @@
 <!-- createArtifactTemplate class is required for artifactcreationdialog -->
 <div class="form-group createArtifactTemplate">
 	<label for="${idOfInput}" class="control-label">Namespace</label>
-	<input type="select" class="form-control" name="${nameOfInput}" id="${idOfInput}"></input>
+	<input type="hidden" class="form-control" name="${nameOfInput}" id="${idOfInput}"></input>
 </div>
 
 <script>
-
-require(["bootstrap3-typeahead"], function () {
-
-    $("#${idOfInput}").typeahead({
-
-        source:[
-            <c:forEach var="ns" items="${allNamespaces}" varStatus="loop">
-            {id:"${ns.decoded}",name:"${ns.decoded}"}<c:if test="${!loop.last}">,</c:if>
-            </c:forEach>
-        ],
-        autoSelect : true,
-        showHintOnFocus: true
-    });
-            <%--.typeahead("val", "${selected}");--%>
-})
-
+// we have to use data as select2 does not allow "createSearchChoice" when using <select> as underlying html element
+$("#${idOfInput}").select2({
+	createSearchChoice: function(term) {
+		// enables creation of new namespaces
+		return {id:term, text:term};
+	},
+	data:[
+		<c:forEach var="ns" items="${allNamespaces}" varStatus="loop">
+			{id:"${ns.decoded}",text:"${ns.decoded}"}<c:if test="${!loop.last}">,</c:if>
+		</c:forEach>
+	]
+}).select2("val", "${selected}");
 </script>

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/entitytypes/properties/propertiesDefinition.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/entitytypes/properties/propertiesDefinition.jsp
@@ -10,7 +10,6 @@
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation, maintainance
  *    Yves Schubert - switch to bootstrap 3
- *    Niko Stadelmaier - removal of select2 library
  *******************************************************************************/
 --%>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
@@ -273,7 +272,7 @@ $(function() {
 			async: true,
 			contentType: "text/plain",
 			processData: false,
-			data: $(this).val(),
+			data: e.val,
 			error: function(jqXHR, textStatus, errorThrown) {
 				vShowAJAXError("Could not update namespace", jqXHR, errorThrown);
 			},

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/entitytypes/relationshiptypes/visualappearance.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/entitytypes/relationshiptypes/visualappearance.jsp
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2012-2016 University of Stuttgart.
+ * Copyright (c) 2012-2013 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -10,7 +10,6 @@
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
  *    Yves Schubert - switch to bootstrap 3
- *    Niko Stadelmaier - removal of select2 library
  *******************************************************************************/
 --%>
 <%@page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
@@ -54,50 +53,37 @@
 				<div class="form-group">
 					<label for="arrow">Arrow appearance</label>
 					<div style="width:100%" id="arrow">
-						<div style="float:left; ">
+						<div style="float:left; width:50px;">
 							<!-- Same values as the beginning of the file names in src\main\webapp\images\relationshiptype -->
-							<div id="dropDownSourceHead">
-							<input type="radio" id="dropDownSourceHeadNone" name="sourceHead" value="none">
-							<label for="dropDownSourceHeadNone"></label>
-							<br>
-							<input type="radio" id="dropDownSourceHeadPain" name="sourceHead" value="PlainArrow">
-							<label for="dropDownSourceHeadPain"></label>
-							<br>
-							<input type="radio" id="dropDownSourceHeadDiamond" name="sourceHead" value="Diamond">
-							<label for="dropDownSourceHeadDiamond"></label>
-							</div>
-						</div>
-						<div id="lineSelect" style="float:left; margin-left: 2rem">
-
-							<input type="radio" id="lineSelectPlain" name="lineRadio" value="plain">
-							<!--  not yet supported
-                            <option value="simpleArrow"></option>
-                            <option value="doubleArrow"></option>
-                            <option value="circle"></option>
-                            <option value="square"></option> -->
-							</input>
-							<label for="lineSelectPlain"></label>
-							<br>
-							<input type="radio" id="lineSelectDotted" name="lineRadio" value="dotted">
-							<label for="lineSelectDotted"></label>
-							<br>
-							<input type="radio" id="lineSelectDotted2" name="lineRadio" value="dotted2">
-							<label for="lineSelectDotted2"></label>
-						</div>
-						<div id="dropDownTargetHead" style="float:left; margin-left: 2rem">
-							<input type="radio" id="dropDownTargetHeadNone" name="targetRadio" value="none">
+							<select id="dropDownSourceHead">
+								<option value="none"></option>
+								<option value="PlainArrow"></option>
+								<option value="Diamond"></option>
 								<!--  not yet supported
 								<option value="simpleArrow"></option>
 								<option value="doubleArrow"></option>
 								<option value="circle"></option>
 								<option value="square"></option> -->
-							<label for="dropDownTargetHeadNone"></label>
-							<br>
-							<input type="radio" name="targetRadio" id="dropDownTargetHeadPlain" value="PlainArrow">
-							<label for="dropDownTargetHeadPlain"></label>
-							<br>
-							<input type="radio" id="dropDownTargetHeadDiamond" name="targetRadio" value="Diamond">
-							<label for="dropDownTargetHeadDiamond"></label>
+							</select>
+						</div>
+						<div style="float:left; width:80px;">
+							<select id="lineSelect">
+								<option value="plain"></option>
+								<option value="dotted"></option>
+								<option value="dotted2"></option>
+							</select>
+						</div>
+						<div style="float:left; width:50px;">
+							<select id="dropDownTargetHead">
+								<option value="none"></option>
+								<option value="PlainArrow"></option>
+								<option value="Diamond"></option>
+								<!--  not yet supported
+								<option value="simpleArrow"></option>
+								<option value="doubleArrow"></option>
+								<option value="circle"></option>
+								<option value="square"></option> -->
+							</select>
 						</div>
 					</div>
 				</div>
@@ -117,7 +103,7 @@ $('#myTab a').click(function (e) {
  */
 function formatArrow(config, sourceOrTarget) {
 	var path = "${pageContext.request.contextPath}/images/relationshiptype/" + config.id + sourceOrTarget + ".png";
-	return "<img width='16px' src='" + path +"' />";
+	return "<img src='" + path +"' />";
 }
 
 var globalAJAXParamsForSelect2VisualAppearance = {
@@ -129,26 +115,7 @@ var globalAJAXParamsForSelect2VisualAppearance = {
 	error : function(jqXHR, textStatus, errorThrown) {
 		vShowAJAXError("Could not supdate arrow appearance", jqXHR, errorThrown);
 	}
-};
-
-$(function(){
-
-   $("#dropDownSourceHead label").each(function(){
-		var radioVal = $("#" + $(this).attr("for")).val();
-	   $(this).html(formatArrowSource({id: radioVal}));
-   });
-
-	$("#lineSelect label").each(function(){
-		var radioVal = $("#" + $(this).attr("for")).val();
-		$(this).html(formatLine({id: radioVal}));
-	});
-
-	$("#dropDownTargetHead label").each(function(){
-		var radioVal = $("#" + $(this).attr("for")).val();
-		$(this).html(formatArrowTarget({id: radioVal}));
-	});
-
-});
+}
 
 /* source arrow head */
 
@@ -157,14 +124,22 @@ function formatArrowSource(config) {
 }
 
 // set stored value
-$("input[name='sourceHead'][value='${it.sourceArrowHead}']").prop('checked', true);
+$("#dropDownSourceHead").val("${it.sourceArrowHead}")
 // enable storage on change of element
-$("#dropDownSourceHead input[name='sourceHead']").on("change", function(e) {
+.on("change", function(e) {
 	params = globalAJAXParamsForSelect2VisualAppearance;
 	params.url = "visualappearance/sourcearrowhead";
-	params.data = $(this).val();
+	params.data = e.val;
 	$.ajax(params);
+})
+// make the selection box show arrows
+.select2({
+	formatResult: formatArrowSource,
+	formatSelection: formatArrowSource,
+	escapeMarkup: function(m) { return m; },
+	minimumResultsForSearch: -1
 });
+
 
 /* line */
 function formatLine(config) {
@@ -173,13 +148,23 @@ function formatLine(config) {
 }
 
 //set stored value
-$("input[name='lineRadio'][value='${it.dash}']").prop('checked', true);//enable storage on change of element
-$("#lineSelect input[name='lineRadio']").on("change", function(e) {
-	var params = globalAJAXParamsForSelect2VisualAppearance;
+$("#lineSelect").val("${it.dash}")
+//enable storage on change of element
+.on("change", function(e) {
+	params = globalAJAXParamsForSelect2VisualAppearance;
 	params.url = "visualappearance/dash";
-	params.data = $(this).val();
+	params.data = e.val;
 	$.ajax(params);
+})
+//make the selection box show arrows
+.select2({
+	formatResult: formatLine,
+	formatSelection: formatLine,
+	escapeMarkup: function(m) { return m; },
+	minimumResultsForSearch: -1
 });
+
+
 
 /* target arrow head */
 
@@ -188,13 +173,21 @@ function formatArrowTarget(config) {
 }
 
 //set stored value
-$("input[name='targetRadio'][value='${it.targetArrowHead}']").prop('checked', true);
+$("#dropDownTargetHead").val("${it.targetArrowHead}")
 //enable storage on change of element
-$("#dropDownTargetHead input[name='targetRadio']").on("change", function(e) {
-	var params = globalAJAXParamsForSelect2VisualAppearance;
+.on("change", function(e) {
+	params = globalAJAXParamsForSelect2VisualAppearance;
 	params.url = "visualappearance/targetarrowhead";
-	params.data = $(this).val();
+	params.data = e.val;
 	$.ajax(params);
+})
+//make the selection box show arrows
+.select2({
+	formatResult: formatArrowTarget,
+	formatSelection: formatArrowTarget,
+	escapeMarkup: function(m) { return m; },
+	minimumResultsForSearch: -1
 });
+
 </script>
 

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/servicetemplates/boundarydefinitions/boundarydefinitions.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/servicetemplates/boundarydefinitions/boundarydefinitions.jsp
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2016 University of Stuttgart.
+ * Copyright (c) 2013 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -10,7 +10,6 @@
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
  *    Tobias Binz - communication with the nested iframe
- *    Niko Stadelmaier - removal of select2 library
  *******************************************************************************/
 --%>
 
@@ -27,7 +26,7 @@
 <pol:policydiag allPolicyTypes="${it.allPolicyTypes}" repositoryURL="${it.repositoryURL}" />
 
 <b:browseForServiceTemplatePropertyReqOrCap definedPropertiesAsJSONString="${it.definedPropertiesAsJSONString}" />
-<%-- TODO: check refactoring for select2--%>
+
 <div class="modal fade" id="propertyMappingDiag">
 	<div class="modal-dialog">
 		<div class="modal-content">
@@ -422,14 +421,6 @@
 
 	</div>
 
-	<script type="text/x-tmpl" id="select-template">
-
-		{% for (var i=0; i<o.source.length; i++) { %}
-    		<option value={% o.source[i].id %}>{%=o.source[i].name%}</option>
-		{% } %}
-
-	</script>
-
 	<script>
 	// initialize interface selection
 	require(["winery-support-common"], function(wsc) {
@@ -437,14 +428,14 @@
 			$("#interface").on("change", function() {
 				updateOperationsField();
 			});
-			if ($("#interface").val()!= "") {
+			if ($("#interface").select2("val") != "") {
 				updateOperationsField();
 			}
 		}, true);
 	});
 
 	function getInterfacesAndInterfaceURLs() {
-		var iface = $("#interface").val();
+		var iface = $("#interface").select2("val");
 		iface = encodeID(iface);
 
 		var ifacesURL = "boundarydefinitions/interfaces/";
@@ -457,7 +448,7 @@
 
 	function getOperationsAndOperationURLs() {
 		var ifaceURL = getInterfacesAndInterfaceURLs().ifaceURL;
-		var operation = $("#operation").val();
+		var operation = $("#operation").select2("val");
 		operation = encodeID(operation);
 
 		var operationsURL = ifaceURL + "exportedoperations/";
@@ -472,7 +463,7 @@
 	 * Updates the field of the exported operation
 	 */
 	function updateOperationsField() {
-		var iface = $("#interface").val();
+		var iface = $("#interface").select2("val");
 		var urls = getInterfacesAndInterfaceURLs();
 
 		$.ajax({
@@ -506,7 +497,7 @@
 	}
 
 	$("#operation").on("change", function() {
-		var operation = $("#operation").val();
+		var operation = $("#operation").select2("val");
 		var urls = getOperationsAndOperationURLs();
 		$.ajax({
 			url: urls.operationURL,
@@ -533,13 +524,13 @@
 		});
 
 		updateTarget();
-	});
+	})
 
 	/**
 	 * Updates the content at "Target": Reference and Target Interface/Operation
 	 */
 	function updateTarget() {
-		var operation = $("#operation").val();
+		var operation = $("#operation").select2("val");
 		if (operation != "") {
 			var urls = getOperationsAndOperationURLs();
 			// At the beginning of the usage, there is no operation selected
@@ -907,11 +898,9 @@ function updateTargetOperation(operationNameToSelect) {
 	}
 
 	if (select2data != null) {
-	var convDataArray = select2data.map(function(item){
-		return {id: item.id, name: item.text};
-	});
-
-		$("#TargetOperation").html(tmpl("select-template", convDataArray));
+		$("#TargetOperation").select2({
+			data:select2data
+		});
 		var valueToSelect = null;
 		if ((typeof operationNameToSelect !== "undefined") && (operationNameToSelect != null)) {
 			valueToSelect = operationNameToSelect;
@@ -923,7 +912,7 @@ function updateTargetOperation(operationNameToSelect) {
 			}
 		}
 		if (valueToSelect != null) {
-			$("#TargetOperation").val(valueToSelect);
+			$("#TargetOperation").select2('val', valueToSelect);
 		}
 	}
 
@@ -943,10 +932,7 @@ function updateTargetInterfaceAndOperationFromInterfaceURL(ifaceURL, interfaceNa
 		$("#TargetInterface").data("url1", ifaceURL[0]);
 		$("#TargetInterface").data("url2", ifaceURL[1]);
 	}
-	var convDataArray = select2data.map(function(item){
-		return {id: item.id, name: item.text};
-	});
-	$("#TargetInterface").html(tmpl("select-template", convDataArray));
+	$("#TargetInterface").select2({data:select2data});
 
 	var valueToSelect = null;
 	if ((typeof interfaceNameToSelect !== "undefined") && (interfaceNameToSelect != null)) {
@@ -959,7 +945,7 @@ function updateTargetInterfaceAndOperationFromInterfaceURL(ifaceURL, interfaceNa
 		}
 	}
 	if (valueToSelect != null) {
-		$("#TargetInterface").val(valueToSelect);
+		$("#TargetInterface").select2('val', valueToSelect);
 	}
 
 	updateTargetOperation(operationNameToSelect);
@@ -1015,7 +1001,7 @@ $("#relationshipTemplateRefForOperation").on("change", function() {
 });
 
 function storeTargetInterface(val) {
-	val = val || $("#TargetInterface").val();
+	val = val || $("#TargetInterface").select2("val");
 	var url = $("#operation").data("url") + "interfacename";
 	 // when selecting a new operation, both targetinterface and targetoperation are updated; this leads to race conditions at the backend and one chang would be lost. Therefore, we do the calls synchronously
 	$.ajax({
@@ -1032,7 +1018,7 @@ function storeTargetInterface(val) {
 }
 
 function storeTargetOperation(val) {
-	val = val || $("#TargetOperation").val();
+	val = val || $("#TargetOperation").select2("val");
 	var url = $("#operation").data("url") + "operationname";
 	// when selecting a new operation, both targetinterface and targetoperation are updated; this leads to race conditions at the backend and one chang would be lost. Therefore, we do the calls synchronously
 	$.ajax({
@@ -1065,7 +1051,7 @@ function deleteCurrentlySelectedInterface() {
 			type: "DELETE"
 		}).done(function () {
 			require(["winery-support-common"], function (wsc) {
-				wsc.removeItemFromSelect2Field($("#interface"), $("#interface").val())
+				wsc.removeItemFromSelect2Field($("#interface"), $("#interface").select2("data").id);
 				vShowSuccess("Successfully deleted interface");
 			});
 		}).fail(function(jqXHR, textStatus, errorThrown) {
@@ -1082,7 +1068,7 @@ function deleteCurrentlySelectedOperation() {
 			type: "DELETE"
 		}).done(function () {
 			require(["winery-support-common"], function (wsc) {
-				wsc.removeItemFromSelect2Field($("#operation"), $("#operation").val());
+				wsc.removeItemFromSelect2Field($("#operation"), $("#operation").select2("data").id);
 				vShowSuccess("Successfully deleted operation");
 			});
 		}).fail(function(jqXHR, textStatus, errorThrown) {

--- a/org.eclipse.winery.topologymodeler/about.html
+++ b/org.eclipse.winery.topologymodeler/about.html
@@ -301,21 +301,21 @@ This library is required by jsPlumb only
 	</tr>
 </table>
 
-<h5>Bootstrap-3-Typeahead &ndash; Version 4.0.2</h5>
+<h5>Select2 &ndash; Version 3.4.5</h5>
 <table>
 	<tr>
 		<td>Files</td>
-		<td>src/main/webapp/components/bootstrap3-typeahead</td>
+		<td>src/main/webapp/components/select2</td>
 	</tr>
 	<tr>
 		<td>URL</td>
-		<td><a href="https://github.com/bassjobsen/Bootstrap-3-Typeahead">https://github.com/bassjobsen/Bootstrap-3-Typeahead</a></td>
+		<td><a href="http://ivaynberg.github.io/select2/">http://ivaynberg.github.io/select2/</a></td>
 	</tr>
 	<tr>
 		<td>License</td>
-		<td>Apache 2.0 (<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>).
-			The Eclipse Foundation elects to include this software in this distribution under the Apache 2.0 license.
-			A copy of the license is contained in the file <a href="about_files/Apache-LICENSE-2.0.txt" target="_blank">Apache-LICENSE-2.0.txt</a>.</td>
+		<td>Apache 2.0 (<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>) and GPL2 (<a href="http://www.gnu.org/licenses/gpl-2.0.html">http://www.gnu.org/licenses/gpl-2.0.html</a>).
+		The Eclipse Foundation elects to include this software in this distribution under the Apache 2.0 license.
+		A copy of the license is contained in the file <a href="about_files/Apache-LICENSE-2.0.txt" target="_blank">Apache-LICENSE-2.0.txt</a>.</td>
 	</tr>
 </table>
 

--- a/org.eclipse.winery.topologymodeler/bower.json
+++ b/org.eclipse.winery.topologymodeler/bower.json
@@ -11,13 +11,7 @@
     },
     {
       "name": "Yves Schubert"
-    },
-	{
-	  "name": "Niko Stadelmaier"
-	},
-	{
-	  "name": "Philipp Meyer"
-	}
+    }
   ],
   "licenses": [
     {
@@ -40,7 +34,7 @@
     "KeyboardJS": "https://github.com/RobertWHurst/KeyboardJS.git#v0.4.2",
     "pnotify": "1.3.1",
     "requirejs": "2.1.5",
-	"bootstrap3-typeahead": "git://github.com/bassjobsen/Bootstrap-3-Typeahead.git#4.0.2",
+    "select2": "https://github.com/ivaynberg/select2/archive/3.4.5.zip",
     "x-editable": "1.5.1",
     "XMLWriter": "1.0.2"
   },

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/common/QNameChooser.tag
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/common/QNameChooser.tag
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2012-2016 University of Stuttgart.
+ * Copyright (c) 2012-2014 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -9,7 +9,6 @@
  *
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
- *	  Niko Stadelmaier - removal of select2 library
  *******************************************************************************/
 --%>
 <%@tag description="Dialog parts for choosing a QName" pageEncoding="UTF-8"%>
@@ -39,8 +38,9 @@
 
 <script>
 $(function(){
+	$("#${idOfSelectField}").select2();
 	<c:if test="${not empty selected}">
-		$("#${idOfSelectField}").val(${selected});
+		$("#${idOfSelectField}").select2("val", "${selected}");
 	</c:if>
 });
 </script>

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/common/artifactcreationdialog.tag
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/common/artifactcreationdialog.tag
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2016 University of Stuttgart.
+ * Copyright (c) 2013 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -9,8 +9,6 @@
  *
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
- *    Niko Stadelmaier - removal of select2 library
- *    Philipp Meyer - removal of select2 library
  *******************************************************************************/
 --%>
 <%@tag description="Dialog for adding an implementation / deployment artifact" pageEncoding="UTF-8"%>
@@ -70,7 +68,7 @@ function addArtifact() {
 
 	// make a clean form
 	disabledFields.forEach(function(element) {
-		$("#"+element).prop("disabled", "true");
+		$("#"+element).attr("disabled", "disabled");
 	});
 	$("input[name='artifactTemplateCreation']").attr("disabled", "disabled");
 
@@ -335,9 +333,16 @@ function openAdd${name}ArtifactDiag() {
 		}
 	});
 }
+
+requirejs(["select2"], function() {
+	$("#interfaceName").select2();
 	<c:if test="${not isDeploymentArtifact}">
 	// the dependend select cannot be a select2 until https://github.com/ivaynberg/select2/issues/1656 is resolved
+	//$("#operationName").select2();
 	</c:if>
+	$("#artifactType").select2();
+	$("#artifactTemplateToLink").select2();
+});
 
 requirejs(['tmpl', 'jquery.ui.widget', 'jquery.fileupload', 'jquery.fileupload-ui'], function() {
 	$('#fileupload').fileupload({

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2012-2016 University of Stuttgart.
+ * Copyright (c) 2012-2013 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -9,7 +9,6 @@
  *
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
- *    Niko Stadelmaier - removal of select2 library
  *******************************************************************************/
 --%>
 <%@tag description="places a bootstrap form control to chooose a namespace. A new namespace can be created" pageEncoding="UTF-8"%>
@@ -38,19 +37,16 @@
 </div>
 
 <script>
-	// we have to use data as select2 does not allow "createSearchChoice" when using <select> as underlying html element
-require("bootstrap3-typeahead", function(){
-	$("#${idOfInput}").typeahead({
-
-		source:[
-			<c:forEach var="ns" items="${allNamespaces}" varStatus="loop">
-			{id:"${ns}",name:"${ns}"}<c:if test="${!loop.last}">,</c:if>
-			</c:forEach>
-		],
-		autoSelect : true,
-		showHintOnFocus: true
-	});
-	$("#${idOfInput}").val("${selected}");
-	$("#${idOfInput}").typeahead("lookup", "${selected}");
-})
+// we have to use data as select2 does not allow "createSearchChoice" when using <select> as underlying html element
+$("#${idOfInput}").select2({
+	createSearchChoice: function(term) {
+		// enables creation of new namespaces
+		return {id:term, text:term};
+	},
+	data:[
+		<c:forEach var="ns" items="${allNamespaces}" varStatus="loop">
+			{id:"${ns}",text:"${ns}"}<c:if test="${!loop.last}">,</c:if>
+		</c:forEach>
+	]
+}).select2("val", "${selected}");
 </script>

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/templates/nodetemplates/reqscaps/addorupdatereqorcap.tag
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/templates/nodetemplates/reqscaps/addorupdatereqorcap.tag
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2012-2016 University of Stuttgart.
+ * Copyright (c) 2012-2014 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -9,7 +9,6 @@
  *
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
- *    Niko Stadelmaier - removal of select2 library
  *******************************************************************************/
 --%>
 <%@tag description="Dialog to change a req or cap. Offers function showEditDiagFor${shortName}(id)" pageEncoding="UTF-8"%>
@@ -42,7 +41,7 @@
 
 						<div class="form-group">
 							<label for="${shortName}NameChooser" class="control-label">Definition Name:</label>
-							<select  id="${shortName}NameChooser" class="form-control" type="text" required="required"> </select>
+							<input  id="${shortName}NameChooser" class="form-control" type="text" required="required" />
 						</div>
 
 						<div class="form-group">
@@ -89,18 +88,16 @@ function update${shortName}PropertiesContainerWithClone(propertiesContainerToClo
 }
 
 function update${shortName}PropertiesFromSelectedType() {
-	var data = $("#${shortName}NameChooser :selected");
-	var name = data.text();
-	var type = data.val();
+	var data = $("#${shortName}NameChooser").select2("data");
+	var name = data.text;
+	var type = data.id;
 
 	// fill in type
 	// TODO: use qname2href and store QName in data-qname for later consumption -- possibly qname2href should always store the qname in data-qname
 	$("#${shortName}TypeDisplay").val(type);
 
 	// fill in properties (derived from type)
-	var propertiesContainer= $(".skelettonPropertyEditorFor${shortName} > span").filter(function(){
-	    return $(this).text() === "" + type;
-	}).parent().children("div");
+	var propertiesContainer= $(".skelettonPropertyEditorFor${shortName} > span:contains('" + type + "')").parent().children("div");
 	update${shortName}PropertiesContainerWithClone(propertiesContainer);
 }
 
@@ -159,10 +156,10 @@ function showAddOrUpdateDiagFor${shortName}(nodeTemplateId, reqOrCapIdToUpdate) 
 					select2Data.push(item);
 				});
 			});
-			$("#${shortName}NameChooser").empty();
-			<%--$("#${shortName}NameChooser").append("<option selected disabled>Select Name</option>");--%>
-			$.each(select2Data, function(index, element){
-				$("#${shortName}NameChooser").append("<option value='" + element.id + "'>" + element.text + "</option>")
+
+			$("#${shortName}NameChooser").select2({
+				placeholder: "Select name",
+				data: select2Data
 			});
 
 			if (update) {
@@ -176,6 +173,7 @@ function showAddOrUpdateDiagFor${shortName}(nodeTemplateId, reqOrCapIdToUpdate) 
 				var name = nodeTemplateEditedReqOrCap.children(".name").text();
 				var type = nodeTemplateEditedReqOrCap.children(".type").children("a").data("qname");
 				var propertiesContainer = nodeTemplateEditedReqOrCap.children(".propertiesContainer");
+
 				// update displays
 
 				// id
@@ -183,9 +181,9 @@ function showAddOrUpdateDiagFor${shortName}(nodeTemplateId, reqOrCapIdToUpdate) 
 
 				// name
 				// we use the type as key at NameChooser. We hope that there are no duplicates. Otherwise, update won't work.
-				$("#${shortName}NameChooser").val(type);
+				$("#${shortName}NameChooser").select2("val", type);
 				// make consistency check
-				var data = {id: $("#${shortName}NameChooser :selected").val(), text: $("#${shortName}NameChooser :selected").text()};
+				var data = $("#${shortName}NameChooser").select2("data");
 				if (data == null) {
 					vShowError("type " + type + " could not be selected.")
 				} else if (name != (data.text)) {
@@ -204,8 +202,8 @@ function showAddOrUpdateDiagFor${shortName}(nodeTemplateId, reqOrCapIdToUpdate) 
 				$("#headerAddOrUpdate").text("Add");
 
 				// QUICK HACK if dialog has been shown before -> show properties of selected type
-				if ($("#${shortName}NameChooser :selected").val() != []) {
-					<%--update${shortName}PropertiesFromSelectedType();--%>
+				if ($("#${shortName}NameChooser").select2("data") != null) {
+					update${shortName}PropertiesFromSelectedType();
 				}
 			}
 
@@ -224,12 +222,12 @@ function addOrUpdate${shortName}(update) {
 	}
 	require(["tmpl"], function(tmpl) {
 		// Generate skeletton div
-		var sel2data = { id: $("#${shortName}NameChooser :selected").val(), text: $("#${shortName}NameChooser :selected").text()};
+		var sel2data = $("#${shortName}NameChooser").select2("data");
 		var data = {
 			id: $("#${shortName}Id").val(),
 			name: sel2data.text,
 			type: sel2data.id
-		};
+		}
 		// tmpl-${shortName} is defined in reqsorcaps.tag
 		var div = tmpl("tmpl-${shortName}", data);
 

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/index.jsp
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/index.jsp
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2012-2017 University of Stuttgart.
+ * Copyright (c) 2012-2016 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -11,8 +11,6 @@
  *    Uwe Breitenbücher - initial API and implementation and/or initial documentation
  *    Oliver Kopp - integration with the repository, adapted to TOSCA v1.0
  *    Yves Schubert - switch to bootstrap 3
- *    Niko Stadelmaier - removal of select2 library
- *    Philipp Meyer - removal of select2 library
  *    Lukas Balzer, Nicole Keppler - switch to bootstrap-touchspin
  *******************************************************************************/
 --%>
@@ -153,6 +151,10 @@
 	<link type="text/css" href="components/pnotify/jquery.pnotify.default.css" media="all" rel="stylesheet" />
 	<link type="text/css" href="components/pnotify/jquery.pnotify.default.icons.css" media="all" rel="stylesheet" />
 
+	<!-- select2 -->
+	<link type="text/css" href="components/select2/select2.css" media="all" rel="stylesheet" />
+	<link type="text/css" href="components/select2/select2-bootstrap.css" media="all" rel="stylesheet" />
+
 	<!-- x-editable -->
 	<link type="text/css" href="components/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css" media="all" rel="stylesheet" />
 
@@ -188,7 +190,7 @@
 			"keyboardjs": "../components/KeyboardJS/keyboard",
 			"orioneditor": "http://eclipse.org/orion/editor/releases/6.0/built-editor-amd",
 			"pnotify": "../components/pnotify/jquery.pnotify",
-			"bootstrap3-typeahead": "../components/bootstrap3-typeahead/bootstrap3-typeahead",
+			"select2": "../components/select2/select2",
 			"tmpl": "../components/blueimp-tmpl/js/tmpl",
 			"XMLWriter": "../components/XMLWriter/XMLWriter"
 		}
@@ -209,6 +211,8 @@
 <script type='text/javascript' src='components/jsPlumb/dist/js/jquery.jsPlumb-1.5.4.js'></script>
 
 <script type="text/javascript" src="components/jquery-typing/plugin/jquery.typing-0.3.2.js"></script>
+
+<script type="text/javascript" src="components/select2/select2.js"></script>
 
 <script type="text/javascript" src="components/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.js"></script>
 

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-support-common.js
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-support-common.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2016 University of Stuttgart.
+ * Copyright (c) 2012-2014 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -8,7 +8,6 @@
  *
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
- *    Niko Stadelmaier - removal of select2 library
  *******************************************************************************/
 
 /**
@@ -154,7 +153,7 @@ define([], function() {
 			// see https://github.com/ivaynberg/select2/issues/535#issuecomment-30210641 for a disucssion
 			vShowNotification("The select field shows stale data. Refresh the page to get rid of that.")
 		}
-	
+
 		/**
 		 * Fetches select2 data from the given URL and initializes the field provided by the fieldId
 		 *
@@ -168,30 +167,21 @@ define([], function() {
 				url: url,
 				dataType: "json"
 			}).done(function (result) {
-
-				var convResult = result.map(function(item){
-					return {id: item.id, name: item.text};
-				});
-				var params = {"source": convResult,
-					showHintOnFocus: "all"
-				};
+				var params = {"data": result};
 				if (typeof allowAdditions === "boolean") {
-					// params.createSearchChoice = function(term) {
-					// 	// enables creation of new namespaces
-					// 	return {id:term, text:term};
-					// }
-				}
-				// console.log("params", params);
-				// init select2 and select first item
-				require(["bootstrap3-typeahead"], function(){
-					$("#" + fieldId).typeahead(params);
-					if (result.length === 0) {
-						$("#" + fieldId).val("");
-					} else {
-						$("#" + fieldId).val(result[0].id);
-						$("#" + fieldId).typeahead("lookup", result[0].name);
+					params.createSearchChoice = function(term) {
+						// enables creation of new namespaces
+						return {id:term, text:term};
 					}
-				});
+				}
+
+				// init select2 and select first item
+				$("#" + fieldId).select2(params);
+				if (result.length === 0) {
+					$("#" + fieldId).select2("val", null);
+				} else {
+					$("#" + fieldId).select2("val", result[0].id);
+				}
 
 				if (typeof onSuccess === "function") {
 					onSuccess();
@@ -241,11 +231,11 @@ define([], function() {
 			}
 		}
 
-		/**
+				/**
 		 * Updates the XML in the orion editor based on the values given in the input fields.
 		 * Shows error if XML is invalid
 		 *
-		 * changed to work with standard html select fields - select2 has been removed
+		 * Works only with SELECT2 fields
 		 *
 		 * @param idPrefix: (new|edit)${shortName}, derived names: [idPrefix]Name, [idPrefix]Id, Orion[idPrefix]XML
 		 * @param hasIdField: whether the Id should be read and written
@@ -292,13 +282,13 @@ define([], function() {
 				// write each selectField to xml
 				// for that, we have to determine the QName
 				$(selectFields).each(function(i, m) {
-
-					var content = $("#" + idPrefix + m.fieldSuffix).val();
+					var content = $("#" + idPrefix + m.fieldSuffix).select2("val");
 
 					if (content == VALUE_OF_NONE_CHOOSEN) {
 						// if nothing is chosen do not put it into the result
 						return;
 					}
+
 					// determine qname of type
 					//getQNameOutOfFullQName(type, xmlDoc.firstChild) does not always work as xmlDoc.firstChild does not have ALL *available* namespace prefixes
 					var typeNSAndId = getNamespaceAndLocalNameFromQName(content);


### PR DESCRIPTION
Reverts eclipse/winery#32

Does not work properly at boundary definitions. Have to check each and every UI element whether the new way is OK. Until then, the old state is better than the new one.

![grabbed_20170207-084511](https://cloud.githubusercontent.com/assets/1366654/22682193/c695b2d2-ed11-11e6-93e7-3e581c6fc4a8.png)
