### PR TITLE
Add YAML model to support service template in TOSCA simple YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Each of these projects are versioned separately.
 * org.eclipse.winery.model.csar.toscametafile: model for TOSCA meta files contained in a CSAR
 * org.eclipse.winery.model.selfservice: model for the self service portal
 * org.eclipse.winery.model.tosca: model for TOCSA
+* org.eclipse.winery.model.tosca.yaml: model for TOCSA Simple Profile in YAML
 
 ### Support projects
 * org.eclipse.winery.highlevelrestapi: support library to REST calls.

--- a/org.eclipse.winery.model.tosca.yaml/.gitignore
+++ b/org.eclipse.winery.model.tosca.yaml/.gitignore
@@ -1,0 +1,8 @@
+.classpath
+.project
+/.settings
+build.properties
+/bin
+/build
+/src/main/resources/rebel.xml
+/target

--- a/org.eclipse.winery.model.tosca.yaml/LICENSE-ASL.txt
+++ b/org.eclipse.winery.model.tosca.yaml/LICENSE-ASL.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/org.eclipse.winery.model.tosca.yaml/LICENSE-EPL.txt
+++ b/org.eclipse.winery.model.tosca.yaml/LICENSE-EPL.txt
@@ -1,0 +1,227 @@
+Eclipse Public License - v 1.0
+
+   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF
+   THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+   1. DEFINITIONS
+
+   "Contribution" means:
+
+   a) in the case of the initial Contributor, the initial code and
+   documentation distributed under this Agreement, and
+
+   b) in the case of each subsequent Contributor:
+
+   i) changes to the Program, and
+
+   ii) additions to the Program;
+
+   where such changes and/or additions to the Program originate from and
+   are distributed by that particular Contributor. A Contribution
+   'originates' from a Contributor if it was added to the Program by such
+   Contributor itself or anyone acting on such Contributor's behalf.
+   Contributions do not include additions to the Program which: (i) are
+   separate modules of software distributed in conjunction with the
+   Program under their own license agreement, and (ii) are not derivative
+   works of the Program.
+
+   "Contributor" means any person or entity that distributes the Program.
+
+   "Licensed Patents" mean patent claims licensable by a Contributor which
+   are necessarily infringed by the use or sale of its Contribution alone
+   or when combined with the Program.
+
+   "Program" means the Contributions distributed in accordance with this
+   Agreement.
+
+   "Recipient" means anyone who receives the Program under this Agreement,
+   including all Contributors.
+
+   2. GRANT OF RIGHTS
+
+   a) Subject to the terms of this Agreement, each Contributor hereby
+   grants Recipient a non-exclusive, worldwide, royalty-free copyright
+   license to reproduce, prepare derivative works of, publicly display,
+   publicly perform, distribute and sublicense the Contribution of such
+   Contributor, if any, and such derivative works, in source code and
+   object code form.
+
+   b) Subject to the terms of this Agreement, each Contributor hereby
+   grants Recipient a non-exclusive, worldwide, royalty-free patent
+   license under Licensed Patents to make, use, sell, offer to sell,
+   import and otherwise transfer the Contribution of such Contributor, if
+   any, in source code and object code form. This patent license shall
+   apply to the combination of the Contribution and the Program if, at the
+   time the Contribution is added by the Contributor, such addition of the
+   Contribution causes such combination to be covered by the Licensed
+   Patents. The patent license shall not apply to any other combinations
+   which include the Contribution. No hardware per se is licensed
+   hereunder.
+
+   c) Recipient understands that although each Contributor grants the
+   licenses to its Contributions set forth herein, no assurances are
+   provided by any Contributor that the Program does not infringe the
+   patent or other intellectual property rights of any other entity. Each
+   Contributor disclaims any liability to Recipient for claims brought by
+   any other entity based on infringement of intellectual property rights
+   or otherwise. As a condition to exercising the rights and licenses
+   granted hereunder, each Recipient hereby assumes sole responsibility to
+   secure any other intellectual property rights needed, if any. For
+   example, if a third party patent license is required to allow Recipient
+   to distribute the Program, it is Recipient's responsibility to acquire
+   that license before distributing the Program.
+
+   d) Each Contributor represents that to its knowledge it has sufficient
+   copyright rights in its Contribution, if any, to grant the copyright
+   license set forth in this Agreement.
+
+   3. REQUIREMENTS
+
+   A Contributor may choose to distribute the Program in object code form
+   under its own license agreement, provided that:
+
+   a) it complies with the terms and conditions of this Agreement; and
+
+   b) its license agreement:
+
+   i) effectively disclaims on behalf of all Contributors all warranties
+   and conditions, express and implied, including warranties or conditions
+   of title and non-infringement, and implied warranties or conditions of
+   merchantability and fitness for a particular purpose;
+
+   ii) effectively excludes on behalf of all Contributors all liability
+   for damages, including direct, indirect, special, incidental and
+   consequential damages, such as lost profits;
+
+   iii) states that any provisions which differ from this Agreement are
+   offered by that Contributor alone and not by any other party; and
+
+   iv) states that source code for the Program is available from such
+   Contributor, and informs licensees how to obtain it in a reasonable
+   manner on or through a medium customarily used for software exchange.
+
+   When the Program is made available in source code form:
+
+   a) it must be made available under this Agreement; and
+
+   b) a copy of this Agreement must be included with each copy of the
+   Program.
+
+   Contributors may not remove or alter any copyright notices contained
+   within the Program.
+
+   Each Contributor must identify itself as the originator of its
+   Contribution, if any, in a manner that reasonably allows subsequent
+   Recipients to identify the originator of the Contribution.
+
+   4. COMMERCIAL DISTRIBUTION
+
+   Commercial distributors of software may accept certain responsibilities
+   with respect to end users, business partners and the like. While this
+   license is intended to facilitate the commercial use of the Program,
+   the Contributor who includes the Program in a commercial product
+   offering should do so in a manner which does not create potential
+   liability for other Contributors. Therefore, if a Contributor includes
+   the Program in a commercial product offering, such Contributor
+   ("Commercial Contributor") hereby agrees to defend and indemnify every
+   other Contributor ("Indemnified Contributor") against any losses,
+   damages and costs (collectively "Losses") arising from claims, lawsuits
+   and other legal actions brought by a third party against the
+   Indemnified Contributor to the extent caused by the acts or omissions
+   of such Commercial Contributor in connection with its distribution of
+   the Program in a commercial product offering. The obligations in this
+   section do not apply to any claims or Losses relating to any actual or
+   alleged intellectual property infringement. In order to qualify, an
+   Indemnified Contributor must: a) promptly notify the Commercial
+   Contributor in writing of such claim, and b) allow the Commercial
+   Contributor to control, and cooperate with the Commercial Contributor
+   in, the defense and any related settlement negotiations. The
+   Indemnified Contributor may participate in any such claim at its own
+   expense.
+
+   For example, a Contributor might include the Program in a commercial
+   product offering, Product X. That Contributor is then a Commercial
+   Contributor. If that Commercial Contributor then makes performance
+   claims, or offers warranties related to Product X, those performance
+   claims and warranties are such Commercial Contributor's responsibility
+   alone. Under this section, the Commercial Contributor would have to
+   defend claims against the other Contributors related to those
+   performance claims and warranties, and if a court requires any other
+   Contributor to pay any damages as a result, the Commercial Contributor
+   must pay those damages.
+
+   5. NO WARRANTY
+
+   EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
+   PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY
+   WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR
+   FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible
+   for determining the appropriateness of using and distributing the
+   Program and assumes all risks associated with its exercise of rights
+   under this Agreement , including but not limited to the risks and costs
+   of program errors, compliance with applicable laws, damage to or loss
+   of data, programs or equipment, and unavailability or interruption of
+   operations.
+
+   6. DISCLAIMER OF LIABILITY
+
+   EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR
+   ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+   WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
+   DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
+   HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+   7. GENERAL
+
+   If any provision of this Agreement is invalid or unenforceable under
+   applicable law, it shall not affect the validity or enforceability of
+   the remainder of the terms of this Agreement, and without further
+   action by the parties hereto, such provision shall be reformed to the
+   minimum extent necessary to make such provision valid and enforceable.
+
+   If Recipient institutes patent litigation against any entity (including
+   a cross-claim or counterclaim in a lawsuit) alleging that the Program
+   itself (excluding combinations of the Program with other software or
+   hardware) infringes such Recipient's patent(s), then such Recipient's
+   rights granted under Section 2(b) shall terminate as of the date such
+   litigation is filed.
+
+   All Recipient's rights under this Agreement shall terminate if it fails
+   to comply with any of the material terms or conditions of this
+   Agreement and does not cure such failure in a reasonable period of time
+   after becoming aware of such noncompliance. If all Recipient's rights
+   under this Agreement terminate, Recipient agrees to cease use and
+   distribution of the Program as soon as reasonably practicable. However,
+   Recipient's obligations under this Agreement and any licenses granted
+   by Recipient relating to the Program shall continue and survive.
+
+   Everyone is permitted to copy and distribute copies of this Agreement,
+   but in order to avoid inconsistency the Agreement is copyrighted and
+   may only be modified in the following manner. The Agreement Steward
+   reserves the right to publish new versions (including revisions) of
+   this Agreement from time to time. No one other than the Agreement
+   Steward has the right to modify this Agreement. The Eclipse Foundation
+   is the initial Agreement Steward. The Eclipse Foundation may assign the
+   responsibility to serve as the Agreement Steward to a suitable separate
+   entity. Each new version of the Agreement will be given a
+   distinguishing version number. The Program (including Contributions)
+   may always be distributed subject to the version of the Agreement under
+   which it was received. In addition, after a new version of the
+   Agreement is published, Contributor may elect to distribute the Program
+   (including its Contributions) under the new version. Except as
+   expressly stated in Sections 2(a) and 2(b) above, Recipient receives no
+   rights or licenses to the intellectual property of any Contributor
+   under this Agreement, whether expressly, by implication, estoppel or
+   otherwise. All rights in the Program not expressly granted under this
+   Agreement are reserved.
+
+   This Agreement is governed by the laws of the State of New York and the
+   intellectual property laws of the United States of America. No party to
+   this Agreement will bring a legal action under this Agreement more than
+   one year after the cause of action arose. Each party waives its rights
+   to a jury trial in any resulting litigation.

--- a/org.eclipse.winery.model.tosca.yaml/about.html
+++ b/org.eclipse.winery.model.tosca.yaml/about.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>February 21, 2017</p>
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&ldquo;Content&rdquo;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+<a href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License Version 1.0 (&ldquo;EPL&rdquo;)</a>
+and <a href="http://www.opensource.org/licenses/apache2.0.php">Apache License Version 2.0</a>.
+A copy of the EPL is available at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>
+and a copy of the Apache License Version 2.0 is available at <a href="http://www.opensource.org/licenses/apache2.0.php">http://www.opensource.org/licenses/apache2.0.php</a>.
+You may elect to redistribute this code under either of these licenses.
+For purposes of the EPL, &ldquo;Program&rdquo; will mean the Content.
+</p>
+
+<p>
+If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&ldquo;Redistributor&rdquo;) and different terms and conditions may
+apply to your use of any object code in the Content. Check the Redistributor&rsquo;s license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL and Apache License 2.0 still apply to any source code
+in the Content and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/org.eclipse.winery.model.tosca.yaml/notice.html
+++ b/org.eclipse.winery.model.tosca.yaml/notice.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<p>All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 and Apache License v2.0 which accompanies this distribution.
+The Eclipse Public License is available at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a> and the Apache License v2.0 is available at <a href="http://www.opensource.org/licenses/apache2.0.php">http://www.opensource.org/licenses/apache2.0.php</a>.
+You may elect to redistribute this code under either of these licenses.</p>
+</body>
+</html>

--- a/org.eclipse.winery.model.tosca.yaml/pom.xml
+++ b/org.eclipse.winery.model.tosca.yaml/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2016 ZTE Corporation.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.winery</groupId>
+	<artifactId>org.eclipse.winery.model.yaml</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<url>http://www.eclipse.org/winery</url>
+	<organization>
+		<name>Eclipse.org - Winery Project</name>
+		<url>http://www.eclipse.org/winery</url>
+	</organization>
+	<issueManagement>
+		<system>bugzilla</system>
+		<url>https://bugs.eclipse.org/bugs</url>
+	</issueManagement>
+	<inceptionYear>2017</inceptionYear>
+	<mailingLists>
+		<mailingList>
+			<name>Winery Developer List</name>
+			<post>winery-dev@eclipse.org</post>
+			<archive>http://dev.eclipse.org/mhonarc/lists/winery-dev</archive>
+		</mailingList>
+	</mailingLists>
+	<licenses>
+		<license>
+			<name>Eclipse Public License v1.0</name>
+			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<distribution>repo</distribution>
+			<comments>Standard Eclipse Licence</comments>
+		</license>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+    <build>
+	    <plugins>
+		    <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		    <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
+    <dependencies>
+        <!-- lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+			<version>1.16.12</version>
+        </dependency>
+        <!-- gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+			<version>2.8.0</version>
+        </dependency>
+		<dependency>
+	        <groupId>junit</groupId>
+	        <artifactId>junit</artifactId>
+	        <version>4.12</version>
+			<scope>test</scope>
+</dependency>
+    </dependencies>
+</project>

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ArtifactDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ArtifactDefinition.java
@@ -1,71 +1,35 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- * Currently not used, but should be used in the future for type definitions!
- * @author Sebi
+ *  
+ * @author Huabing Zhao
+ *
  */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ArtifactDefinition extends YAMLElement {
     private String type = "";
     private String file = "";
     private String repository = "";
     private String deploy_path = "";
-    
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        if (type != null) {
-            this.type = type;
-        }
-    }
-
-    public String getFile() {
-      return file;
-    }
-
-    public void setFile(String file) {
-      this.file = file;
-    }
-
-    public String getRepository() {
-      return repository;
-    }
-
-    public void setRepository(String repository) {
-      this.repository = repository;
-    }
-
-    public String getDeploy_path() {
-      return deploy_path;
-    }
-
-    public void setDeploy_path(String deploy_path) {
-      this.deploy_path = deploy_path;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-
-        ArtifactDefinition that = (ArtifactDefinition) o;
-
-        if (!type.equals(that.type)) return false;
-        if (!file.equals(that.file)) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + type.hashCode();
-        result = 31 * result + file.hashCode();
-        return result;
-    }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ArtifactDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ArtifactDefinition.java
@@ -1,0 +1,71 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+/**
+ * Currently not used, but should be used in the future for type definitions!
+ * @author Sebi
+ */
+public class ArtifactDefinition extends YAMLElement {
+    private String type = "";
+    private String file = "";
+    private String repository = "";
+    private String deploy_path = "";
+    
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        if (type != null) {
+            this.type = type;
+        }
+    }
+
+    public String getFile() {
+      return file;
+    }
+
+    public void setFile(String file) {
+      this.file = file;
+    }
+
+    public String getRepository() {
+      return repository;
+    }
+
+    public void setRepository(String repository) {
+      this.repository = repository;
+    }
+
+    public String getDeploy_path() {
+      return deploy_path;
+    }
+
+    public void setDeploy_path(String deploy_path) {
+      this.deploy_path = deploy_path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        ArtifactDefinition that = (ArtifactDefinition) o;
+
+        if (!type.equals(that.type)) return false;
+        if (!file.equals(that.file)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + type.hashCode();
+        result = 31 * result + file.hashCode();
+        return result;
+    }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ArtifactType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ArtifactType.java
@@ -1,0 +1,101 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ArtifactType extends YAMLElement {
+
+	private String derived_from = "";
+	private String mime_type = "";
+	private String[] file_ext = new String[0];
+	private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
+	private String version = "";
+	private String description = "";
+	
+	
+	public String getDerived_from() {
+		return derived_from;
+	}
+
+	public void setDerived_from(String derived_from) {
+		this.derived_from = derived_from;
+	}
+
+	public String getMime_type() {
+		return mime_type;
+	}
+
+	public void setMime_type(String mime_type) {
+		if (mime_type != null) {
+			this.mime_type = mime_type;
+		}
+	}
+
+	public String[] getFile_ext() {
+		return file_ext;
+	}
+
+	public void setFile_ext(String[] file_ext) {
+		if (file_ext != null) {
+			this.file_ext = file_ext;
+		}
+	}
+
+	public Map<String, PropertyDefinition> getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Map<String, PropertyDefinition> properties) {
+		if (properties != null) {
+			this.properties = properties;
+		}
+	}
+	
+	
+
+	public String getVersion() {
+	  return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = version;
+    }
+  
+    public String getDescription() {
+      return description;
+    }
+  
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+  @Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		ArtifactType that = (ArtifactType) o;
+
+		if (!derived_from.equals(that.derived_from)) return false;
+		if (!Arrays.equals(file_ext, that.file_ext)) return false;
+		if (!mime_type.equals(that.mime_type)) return false;
+		if (!properties.equals(that.properties)) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + derived_from.hashCode();
+		result = 31 * result + mime_type.hashCode();
+		result = 31 * result + Arrays.hashCode(file_ext);
+		result = 31 * result + properties.hashCode();
+		return result;
+	}
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ArtifactType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ArtifactType.java
@@ -1,101 +1,40 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ArtifactType extends YAMLElement {
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ArtifactType extends YAMLElement {
 	private String derived_from = "";
 	private String mime_type = "";
 	private String[] file_ext = new String[0];
 	private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
 	private String version = "";
 	private String description = "";
-	
-	
-	public String getDerived_from() {
-		return derived_from;
-	}
-
-	public void setDerived_from(String derived_from) {
-		this.derived_from = derived_from;
-	}
-
-	public String getMime_type() {
-		return mime_type;
-	}
-
-	public void setMime_type(String mime_type) {
-		if (mime_type != null) {
-			this.mime_type = mime_type;
-		}
-	}
-
-	public String[] getFile_ext() {
-		return file_ext;
-	}
-
-	public void setFile_ext(String[] file_ext) {
-		if (file_ext != null) {
-			this.file_ext = file_ext;
-		}
-	}
-
-	public Map<String, PropertyDefinition> getProperties() {
-		return properties;
-	}
-
-	public void setProperties(Map<String, PropertyDefinition> properties) {
-		if (properties != null) {
-			this.properties = properties;
-		}
-	}
-	
-	
-
-	public String getVersion() {
-	  return version;
-    }
-
-    public void setVersion(String version) {
-      this.version = version;
-    }
-  
-    public String getDescription() {
-      return description;
-    }
-  
-    public void setDescription(String description) {
-      this.description = description;
-    }
-
-  @Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-		if (!super.equals(o)) return false;
-
-		ArtifactType that = (ArtifactType) o;
-
-		if (!derived_from.equals(that.derived_from)) return false;
-		if (!Arrays.equals(file_ext, that.file_ext)) return false;
-		if (!mime_type.equals(that.mime_type)) return false;
-		if (!properties.equals(that.properties)) return false;
-
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		int result = super.hashCode();
-		result = 31 * result + derived_from.hashCode();
-		result = 31 * result + mime_type.hashCode();
-		result = 31 * result + Arrays.hashCode(file_ext);
-		result = 31 * result + properties.hashCode();
-		return result;
-	}
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/AttributeDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/AttributeDefinition.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import com.google.gson.annotations.SerializedName;
+
+
+public class AttributeDefinition extends YAMLElement {
+  private String type = "";
+  @SerializedName("default")
+  private Object defaultValue = "";
+  private String status = "supported";
+  private EntrySchema entry_schema;
+
+  public String getType() {
+    return this.type;
+  }
+
+  public void setType(String type) {
+    if (type != null) {
+      this.type = type;
+    }
+  }
+
+  public Object getDefault() {
+    return this.defaultValue;
+  }
+
+  public void setDefault(Object defaultValue) {
+    if (defaultValue != null) {
+      this.defaultValue = defaultValue;
+    }
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+  
+  public EntrySchema getEntry_schema() {
+    return entry_schema;
+  }
+  
+  public void setEntry_schema(EntrySchema entry_schema) {
+    this.entry_schema = entry_schema;
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/AttributeDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/AttributeDefinition.java
@@ -17,48 +17,23 @@ package org.eclipse.winery.model.tosca.yaml;
 
 import com.google.gson.annotations.SerializedName;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class AttributeDefinition extends YAMLElement {
   private String type = "";
   @SerializedName("default")
   private Object defaultValue = "";
   private String status = "supported";
   private EntrySchema entry_schema;
-
-  public String getType() {
-    return this.type;
-  }
-
-  public void setType(String type) {
-    if (type != null) {
-      this.type = type;
-    }
-  }
-
-  public Object getDefault() {
-    return this.defaultValue;
-  }
-
-  public void setDefault(Object defaultValue) {
-    if (defaultValue != null) {
-      this.defaultValue = defaultValue;
-    }
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-  
-  public EntrySchema getEntry_schema() {
-    return entry_schema;
-  }
-  
-  public void setEntry_schema(EntrySchema entry_schema) {
-    this.entry_schema = entry_schema;
-  }
 
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Capability.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Capability.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Capability {
+	private Map<String, Object> properties = new HashMap<String, Object>();
+
+    public Capability() {
+    }
+
+    public Capability(Map<String, Object> properties) {
+        this.properties = properties;
+    }
+
+    public void setProperties(Map<String, Object> properties) {
+		if (properties != null) {
+			this.properties = properties;
+		}
+	}
+
+	public Map<String, Object> getProperties() {
+		return this.properties;
+	}
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Capability.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Capability.java
@@ -18,24 +18,18 @@ package org.eclipse.winery.model.tosca.yaml;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class Capability {
 	private Map<String, Object> properties = new HashMap<String, Object>();
-
-    public Capability() {
-    }
-
-    public Capability(Map<String, Object> properties) {
-        this.properties = properties;
-    }
-
-    public void setProperties(Map<String, Object> properties) {
-		if (properties != null) {
-			this.properties = properties;
-		}
-	}
-
-	public Map<String, Object> getProperties() {
-		return this.properties;
-	}
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityDefinition.java
@@ -1,59 +1,37 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- * Currently not used, but should be used in the future for type definitions!
- * @author Sebi
+ *  
+ * @author Huabing Zhao
+ *
  */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class CapabilityDefinition extends YAMLElement {
 
     private String type = "";
     private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        if (type != null) {
-            this.type = type;
-        }
-    }
-
-    public Map<String, PropertyDefinition> getProperties() {
-        return properties;
-    }
-
-    public void setProperties(Map<String, PropertyDefinition> properties) {
-        if (properties != null) {
-            this.properties = properties;
-        }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-
-        CapabilityDefinition that = (CapabilityDefinition) o;
-
-        if (!properties.equals(that.properties)) return false;
-        if (!type.equals(that.type)) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + type.hashCode();
-        result = 31 * result + properties.hashCode();
-        return result;
-    }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityDefinition.java
@@ -1,0 +1,59 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Currently not used, but should be used in the future for type definitions!
+ * @author Sebi
+ */
+public class CapabilityDefinition extends YAMLElement {
+
+    private String type = "";
+    private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        if (type != null) {
+            this.type = type;
+        }
+    }
+
+    public Map<String, PropertyDefinition> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, PropertyDefinition> properties) {
+        if (properties != null) {
+            this.properties = properties;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        CapabilityDefinition that = (CapabilityDefinition) o;
+
+        if (!properties.equals(that.properties)) return false;
+        if (!type.equals(that.type)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + type.hashCode();
+        result = 31 * result + properties.hashCode();
+        return result;
+    }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityFilter.java
@@ -28,8 +28,6 @@ import lombok.NoArgsConstructor;
  *
  */
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class CapabilityFilter extends HashMap<String, PropertiesFilter> {
 
   public CapabilityFilter(String capabilityName, PropertiesFilter propertiesFilter) {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityFilter.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+
+
+public class CapabilityFilter extends HashMap<String, PropertiesFilter> {
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 1L;
+
+  public CapabilityFilter(String capabilityName, PropertiesFilter propertiesFilter) {
+    super();
+    this.put(capabilityName, propertiesFilter);
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,21 @@
 package org.eclipse.winery.model.tosca.yaml;
 
 import java.util.HashMap;
+import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class CapabilityFilter extends HashMap<String, PropertiesFilter> {
-
-  /**
-   * 
-   */
-  private static final long serialVersionUID = 1L;
 
   public CapabilityFilter(String capabilityName, PropertiesFilter propertiesFilter) {
     super();

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityType.java
@@ -1,54 +1,36 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class CapabilityType extends YAMLElement {
   private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
   private String derived_from = "";
-
-  public Map<String, PropertyDefinition> getProperties() {
-    return properties;
-  }
-
-  public void setProperties(Map<String, PropertyDefinition> properties) {
-    this.properties = properties;
-  }
-
-  public String getDerived_from() {
-    return derived_from;
-  }
-
-  public void setDerived_from(String derived_from) {
-    if (derived_from != null) {
-      this.derived_from = derived_from;
-    }
-  }
-
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-
-    CapabilityType that = (CapabilityType) o;
-
-    if (!derived_from.equals(that.derived_from)) return false;
-    if (!properties.equals(that.properties)) return false;
-
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + properties.hashCode();
-    result = 31 * result + derived_from.hashCode();
-    return result;
-  }
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CapabilityType.java
@@ -1,0 +1,54 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CapabilityType extends YAMLElement {
+  private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
+  private String derived_from = "";
+
+  public Map<String, PropertyDefinition> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Map<String, PropertyDefinition> properties) {
+    this.properties = properties;
+  }
+
+  public String getDerived_from() {
+    return derived_from;
+  }
+
+  public void setDerived_from(String derived_from) {
+    if (derived_from != null) {
+      this.derived_from = derived_from;
+    }
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+
+    CapabilityType that = (CapabilityType) o;
+
+    if (!derived_from.equals(that.derived_from)) return false;
+    if (!properties.equals(that.properties)) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + properties.hashCode();
+    result = 31 * result + derived_from.hashCode();
+    return result;
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ConstraintClause.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ConstraintClause.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+public class ConstraintClause {
+  private Object equal;
+  private Object greater_than;
+  private Object greater_or_equal;
+  private Object less_than;
+  private Object less_or_equal;
+  private Object[] in_range;
+  private Object[] valid_values;
+  private int length;
+  private int min_length;
+  private int max_length;
+  private String pattern;
+  
+  
+  public ConstraintClause() {
+    super();
+  }
+
+  public ConstraintClause(Object equal) {
+    super();
+    this.equal = equal;
+  }
+  
+  public Object getEqual() {
+    return equal;
+  }
+  public void setEqual(Object equal) {
+    this.equal = equal;
+  }
+  public Object getGreater_than() {
+    return greater_than;
+  }
+  public void setGreater_than(Object greater_than) {
+    this.greater_than = greater_than;
+  }
+  public Object getGreater_or_equal() {
+    return greater_or_equal;
+  }
+  public void setGreater_or_equal(Object greater_or_equal) {
+    this.greater_or_equal = greater_or_equal;
+  }
+  public Object getLess_than() {
+    return less_than;
+  }
+  public void setLess_than(Object less_than) {
+    this.less_than = less_than;
+  }
+  public Object getLess_or_equal() {
+    return less_or_equal;
+  }
+  public void setLess_or_equal(Object less_or_equal) {
+    this.less_or_equal = less_or_equal;
+  }
+  public Object[] getIn_range() {
+    return in_range;
+  }
+  public void setIn_range(Object[] in_range) {
+    this.in_range = in_range;
+  }
+  public Object[] getValid_values() {
+    return valid_values;
+  }
+  public void setValid_values(Object[] valid_values) {
+    this.valid_values = valid_values;
+  }
+  public int getLength() {
+    return length;
+  }
+  public void setLength(int length) {
+    this.length = length;
+  }
+  public int getMin_length() {
+    return min_length;
+  }
+  public void setMin_length(int min_length) {
+    this.min_length = min_length;
+  }
+  public int getMax_length() {
+    return max_length;
+  }
+  public void setMax_length(int max_length) {
+    this.max_length = max_length;
+  }
+  public String getPattern() {
+    return pattern;
+  }
+  public void setPattern(String pattern) {
+    this.pattern = pattern;
+  }
+  
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ConstraintClause.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ConstraintClause.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,18 @@
  */
 package org.eclipse.winery.model.tosca.yaml;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ConstraintClause {
   private Object equal;
   private Object greater_than;
@@ -26,83 +38,5 @@ public class ConstraintClause {
   private int length;
   private int min_length;
   private int max_length;
-  private String pattern;
-  
-  
-  public ConstraintClause() {
-    super();
-  }
-
-  public ConstraintClause(Object equal) {
-    super();
-    this.equal = equal;
-  }
-  
-  public Object getEqual() {
-    return equal;
-  }
-  public void setEqual(Object equal) {
-    this.equal = equal;
-  }
-  public Object getGreater_than() {
-    return greater_than;
-  }
-  public void setGreater_than(Object greater_than) {
-    this.greater_than = greater_than;
-  }
-  public Object getGreater_or_equal() {
-    return greater_or_equal;
-  }
-  public void setGreater_or_equal(Object greater_or_equal) {
-    this.greater_or_equal = greater_or_equal;
-  }
-  public Object getLess_than() {
-    return less_than;
-  }
-  public void setLess_than(Object less_than) {
-    this.less_than = less_than;
-  }
-  public Object getLess_or_equal() {
-    return less_or_equal;
-  }
-  public void setLess_or_equal(Object less_or_equal) {
-    this.less_or_equal = less_or_equal;
-  }
-  public Object[] getIn_range() {
-    return in_range;
-  }
-  public void setIn_range(Object[] in_range) {
-    this.in_range = in_range;
-  }
-  public Object[] getValid_values() {
-    return valid_values;
-  }
-  public void setValid_values(Object[] valid_values) {
-    this.valid_values = valid_values;
-  }
-  public int getLength() {
-    return length;
-  }
-  public void setLength(int length) {
-    this.length = length;
-  }
-  public int getMin_length() {
-    return min_length;
-  }
-  public void setMin_length(int min_length) {
-    this.min_length = min_length;
-  }
-  public int getMax_length() {
-    return max_length;
-  }
-  public void setMax_length(int max_length) {
-    this.max_length = max_length;
-  }
-  public String getPattern() {
-    return pattern;
-  }
-  public void setPattern(String pattern) {
-    this.pattern = pattern;
-  }
-  
+  private String pattern;  
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CsarMeta.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CsarMeta.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * @author 10090474
+ *  
+ * @author Huabing Zhao
  *
  */
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 public class CsarMeta extends YAMLElement {
   private String type;
   private String version;

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CsarMeta.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/CsarMeta.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author 10090474
+ *
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CsarMeta extends YAMLElement {
+  private String type;
+  private String version;
+  private String provider;
+  private String csarId;
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/DataType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/DataType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,36 +15,20 @@
  */
 package org.eclipse.winery.model.tosca.yaml;
 
-import java.util.HashMap;
-import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class DataType extends YAMLElement {
 
     private String derived_from = "tosca.datatypes.Root";
     private String version = "";
-    private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
-
-    public String getDerived_from() {
-        return derived_from;
-    }
-
-    public void setDerived_from(String derived_from) {
-        this.derived_from = derived_from;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public Map<String, PropertyDefinition> getProperties() {
-        return properties;
-    }
-
-    public void setProperties(Map<String, PropertyDefinition> properties) {
-        this.properties = properties;
-    }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/DataType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/DataType.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DataType extends YAMLElement {
+
+    private String derived_from = "tosca.datatypes.Root";
+    private String version = "";
+    private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
+
+    public String getDerived_from() {
+        return derived_from;
+    }
+
+    public void setDerived_from(String derived_from) {
+        this.derived_from = derived_from;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public Map<String, PropertyDefinition> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, PropertyDefinition> properties) {
+        this.properties = properties;
+    }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/EntrySchema.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/EntrySchema.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+public class EntrySchema {
+  private String type = "";
+  
+  public EntrySchema() {
+    
+  }
+
+  public EntrySchema(String type) {
+    super();
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+  
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/EntrySchema.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/EntrySchema.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,18 @@
  */
 package org.eclipse.winery.model.tosca.yaml;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class EntrySchema {
-  private String type = "";
-  
-  public EntrySchema() {
-    
-  }
-
-  public EntrySchema(String type) {
-    super();
-    this.type = type;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-  
+  private String type = "";  
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Group.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Group.java
@@ -1,0 +1,49 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This implementation can be delayed because it's not used yet.
+ */
+public class Group extends YAMLElement {
+    private String type = "";
+    private Map<String, Object> properties = new HashMap<String, Object>();
+    private String[] members = new String[0];
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, Object> properties) {
+        if (properties == null || properties.isEmpty()) {
+            return;
+        }
+        this.properties = properties;
+    }
+
+    public String[] getMembers() {
+      return members;
+    }
+
+    public void setMembers(String[] members) {
+      if (members == null || members.length == 0) {
+        return;
+      }
+      this.members = members;
+    }
+    
+    
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Group.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Group.java
@@ -1,49 +1,37 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- * This implementation can be delayed because it's not used yet.
+ *  
+ * @author Huabing Zhao
+ *
  */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class Group extends YAMLElement {
     private String type = "";
     private Map<String, Object> properties = new HashMap<String, Object>();
     private String[] members = new String[0];
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public Map<String, Object> getProperties() {
-        return properties;
-    }
-
-    public void setProperties(Map<String, Object> properties) {
-        if (properties == null || properties.isEmpty()) {
-            return;
-        }
-        this.properties = properties;
-    }
-
-    public String[] getMembers() {
-      return members;
-    }
-
-    public void setMembers(String[] members) {
-      if (members == null || members.length == 0) {
-        return;
-      }
-      this.members = members;
-    }
-    
-    
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/GroupType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/GroupType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,49 +18,22 @@ package org.eclipse.winery.model.tosca.yaml;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class GroupType extends YAMLElement {
 
 	private String derived_from = "";
 	private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
     private String[] members;
 	private Map<String, Map<String, Map<String, String>>> interfaces = new HashMap<String, Map<String, Map<String, String>>>();
-
-	public String getDerived_from() {
-		return this.derived_from;
-	}
-
-	public void setDerived_from(String derived_from) {
-		if (derived_from != null) {
-			this.derived_from = derived_from;
-		}
-	}
-
-	public Map<String, PropertyDefinition> getProperties() {
-		return this.properties;
-	}
-
-	public void setProperties(Map<String, PropertyDefinition> properties) {
-		if (properties != null) {
-			this.properties = properties;
-		}
-	}
-
-    public String[] getMembers() {
-      return members;
-    }
-
-    public void setMembers(String[] members) {
-      this.members = members;
-    }
-
-    public Map<String, Map<String, Map<String, String>>> getInterfaces() {
-		return this.interfaces;
-	}
-
-	public void setInterfaces(Map<String, Map<String, Map<String, String>>> interfaces) {
-		if (interfaces != null) {
-			this.interfaces = interfaces;
-		}
-	}
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/GroupType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/GroupType.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GroupType extends YAMLElement {
+
+	private String derived_from = "";
+	private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
+    private String[] members;
+	private Map<String, Map<String, Map<String, String>>> interfaces = new HashMap<String, Map<String, Map<String, String>>>();
+
+	public String getDerived_from() {
+		return this.derived_from;
+	}
+
+	public void setDerived_from(String derived_from) {
+		if (derived_from != null) {
+			this.derived_from = derived_from;
+		}
+	}
+
+	public Map<String, PropertyDefinition> getProperties() {
+		return this.properties;
+	}
+
+	public void setProperties(Map<String, PropertyDefinition> properties) {
+		if (properties != null) {
+			this.properties = properties;
+		}
+	}
+
+    public String[] getMembers() {
+      return members;
+    }
+
+    public void setMembers(String[] members) {
+      this.members = members;
+    }
+
+    public Map<String, Map<String, Map<String, String>>> getInterfaces() {
+		return this.interfaces;
+	}
+
+	public void setInterfaces(Map<String, Map<String, Map<String, String>>> interfaces) {
+		if (interfaces != null) {
+			this.interfaces = interfaces;
+		}
+	}
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Input.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Input.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,18 @@ import java.util.Map;
 
 import com.google.gson.annotations.SerializedName;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class Input extends YAMLElement {
   private String type = "";
   @SerializedName("default")
@@ -28,53 +40,4 @@ public class Input extends YAMLElement {
   private boolean required = false;
   private List<Map<String, Object>> constraints = new ArrayList<Map<String, Object>>();
   private EntrySchema entry_schema;
-
-  public String getType() {
-    return this.type;
-  }
-
-  public void setType(String type) {
-    if (type != null) {
-      this.type = type;
-    }
-  }
-
-  public Object getDefault() {
-    return this.defaultValue;
-  }
-
-  public void setDefault(Object defaultValue) {
-    if (defaultValue != null) {
-      this.defaultValue = defaultValue;
-    }
-  }
-
-  public List<Map<String, Object>> getConstraints() {
-    return this.constraints;
-  }
-
-  public void setConstraints(List<Map<String, Object>> constraints) {
-    if (constraints != null) {
-      this.constraints = constraints;
-    }
-  }
-
-  public boolean isRequired() {
-    return required;
-  }
-
-  public void setRequired(boolean required) {
-    this.required = required;
-  }
-
-  public EntrySchema getEntry_schema() {
-    return entry_schema;
-  }
-
-  public void setEntry_schema(EntrySchema entry_schema) {
-    if (entry_schema != null) {
-      this.entry_schema = entry_schema;
-    }
-  }
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Input.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Input.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Input extends YAMLElement {
+  private String type = "";
+  @SerializedName("default")
+  private Object defaultValue = "";
+  private boolean required = false;
+  private List<Map<String, Object>> constraints = new ArrayList<Map<String, Object>>();
+  private EntrySchema entry_schema;
+
+  public String getType() {
+    return this.type;
+  }
+
+  public void setType(String type) {
+    if (type != null) {
+      this.type = type;
+    }
+  }
+
+  public Object getDefault() {
+    return this.defaultValue;
+  }
+
+  public void setDefault(Object defaultValue) {
+    if (defaultValue != null) {
+      this.defaultValue = defaultValue;
+    }
+  }
+
+  public List<Map<String, Object>> getConstraints() {
+    return this.constraints;
+  }
+
+  public void setConstraints(List<Map<String, Object>> constraints) {
+    if (constraints != null) {
+      this.constraints = constraints;
+    }
+  }
+
+  public boolean isRequired() {
+    return required;
+  }
+
+  public void setRequired(boolean required) {
+    this.required = required;
+  }
+
+  public EntrySchema getEntry_schema() {
+    return entry_schema;
+  }
+
+  public void setEntry_schema(EntrySchema entry_schema) {
+    if (entry_schema != null) {
+      this.entry_schema = entry_schema;
+    }
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/InterfaceDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/InterfaceDefinition.java
@@ -26,7 +26,6 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 public class InterfaceDefinition extends YAMLElement {
 
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/InterfaceDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/InterfaceDefinition.java
@@ -1,13 +1,32 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- * This class is just a representational class because the current spec. doesn't define
- * other attributes than 'description' which is derived from {@see YAMLElement}.
- * @author Sebi
+ *  
+ * @author Huabing Zhao
+ *
  */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class InterfaceDefinition extends YAMLElement {
 
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/InterfaceDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/InterfaceDefinition.java
@@ -1,0 +1,13 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+/**
+ * This class is just a representational class because the current spec. doesn't define
+ * other attributes than 'description' which is derived from {@see YAMLElement}.
+ * @author Sebi
+ */
+public class InterfaceDefinition extends YAMLElement {
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +18,19 @@ package org.eclipse.winery.model.tosca.yaml;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class NodeFilter extends PropertiesFilter{
 
   private List<CapabilityFilter> capabilities = new ArrayList<>();
-
-
-  public void setCapabilities(List<CapabilityFilter> capabilities) {
-    if (capabilities != null) {
-        this.capabilities = capabilities;
-    }
-  }
-
-  public List<CapabilityFilter> getCapabilities() {
-    return this.capabilities;
-  }
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeFilter.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NodeFilter extends PropertiesFilter{
+
+  private List<CapabilityFilter> capabilities = new ArrayList<>();
+
+
+  public void setCapabilities(List<CapabilityFilter> capabilities) {
+    if (capabilities != null) {
+        this.capabilities = capabilities;
+    }
+  }
+
+  public List<CapabilityFilter> getCapabilities() {
+    return this.capabilities;
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeTemplate.java
@@ -1,0 +1,85 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NodeTemplate extends YAMLElement {
+  private String type = "";
+  private Map<String, Object> properties = new HashMap<String, Object>();
+  private Map<String, Object> attributes = new HashMap<String, Object>();
+  private List<Map<String, Object>> requirements = new ArrayList<>();  // May be string or org.eclipse.winery.repository.ext.yamlmodel.Requirement
+  private Map<String, Capability> capabilities = new HashMap<>();
+  private Map<String, String> interfaces = new HashMap<String, String>();
+  private Map<String, Object> artifacts = new HashMap<>();  // Maybe String or ArtifactDefinition.
+
+  public void setType(String type) {
+    if (type != null) {
+      this.type = type;
+    }
+  }
+
+  public String getType() {
+    return this.type;
+  }
+
+  public void setProperties(Map<String, Object> properties) {
+    if (properties != null) {
+      this.properties = properties;
+    }
+  }
+
+  public Map<String, Object> getProperties() {
+    return this.properties;
+  }
+
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, Object> attributes) {
+    this.attributes = attributes;
+  }
+
+  public void setRequirements(List<Map<String, Object>> requirements) {
+    if (requirements != null) {
+      this.requirements = requirements;
+    }
+  }
+
+  public List<Map<String, Object>> getRequirements() {
+    return this.requirements;
+  }
+
+  public void setCapabilities(Map<String, Capability> capabilities) {
+    if (capabilities != null) {
+      this.capabilities = capabilities;
+    }
+  }
+
+  public Map<String, Capability> getCapabilities() {
+    return this.capabilities;
+  }
+
+  public Map<String, String> getInterfaces() {
+    return this.interfaces;
+  }
+
+  public void setInterfaces(Map<String, String> interfaces) {
+    if (interfaces != null) {
+      this.interfaces = interfaces;
+    }
+  }
+  
+  public Map<String, Object> getArtifacts() {
+    return artifacts;
+  }
+
+  public void setArtifacts(Map<String, Object> artifacts) {
+    this.artifacts = artifacts;
+  }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeTemplate.java
@@ -1,5 +1,17 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
@@ -8,6 +20,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class NodeTemplate extends YAMLElement {
   private String type = "";
   private Map<String, Object> properties = new HashMap<String, Object>();
@@ -16,70 +40,4 @@ public class NodeTemplate extends YAMLElement {
   private Map<String, Capability> capabilities = new HashMap<>();
   private Map<String, String> interfaces = new HashMap<String, String>();
   private Map<String, Object> artifacts = new HashMap<>();  // Maybe String or ArtifactDefinition.
-
-  public void setType(String type) {
-    if (type != null) {
-      this.type = type;
-    }
-  }
-
-  public String getType() {
-    return this.type;
-  }
-
-  public void setProperties(Map<String, Object> properties) {
-    if (properties != null) {
-      this.properties = properties;
-    }
-  }
-
-  public Map<String, Object> getProperties() {
-    return this.properties;
-  }
-
-  public Map<String, Object> getAttributes() {
-    return attributes;
-  }
-
-  public void setAttributes(Map<String, Object> attributes) {
-    this.attributes = attributes;
-  }
-
-  public void setRequirements(List<Map<String, Object>> requirements) {
-    if (requirements != null) {
-      this.requirements = requirements;
-    }
-  }
-
-  public List<Map<String, Object>> getRequirements() {
-    return this.requirements;
-  }
-
-  public void setCapabilities(Map<String, Capability> capabilities) {
-    if (capabilities != null) {
-      this.capabilities = capabilities;
-    }
-  }
-
-  public Map<String, Capability> getCapabilities() {
-    return this.capabilities;
-  }
-
-  public Map<String, String> getInterfaces() {
-    return this.interfaces;
-  }
-
-  public void setInterfaces(Map<String, String> interfaces) {
-    if (interfaces != null) {
-      this.interfaces = interfaces;
-    }
-  }
-  
-  public Map<String, Object> getArtifacts() {
-    return artifacts;
-  }
-
-  public void setArtifacts(Map<String, Object> artifacts) {
-    this.artifacts = artifacts;
-  }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeType.java
@@ -1,5 +1,17 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
@@ -8,6 +20,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class NodeType extends YAMLElement {
 
   private String derived_from = "";
@@ -18,155 +42,4 @@ public class NodeType extends YAMLElement {
   private Map<String, Map<String, Map<String, String>>> interfaces = new HashMap<>();
   private Map<String, ArtifactDefinition> artifacts = new HashMap<>();
   
-  public Map<String, ArtifactDefinition> getArtifacts() {
-    return artifacts;
-  }
-
-  public void setArtifacts(Map<String, ArtifactDefinition> artifacts) {
-    this.artifacts = artifacts;
-  }
-
-  public String getDerived_from() {
-    return this.derived_from;
-  }
-
-  public void setDerived_from(String derived_from) {
-      if (derived_from != null) {
-          this.derived_from = derived_from;
-      }
-  }
-
-  public Map<String, PropertyDefinition> getProperties() {
-      return this.properties;
-  }
-
-  public void setProperties(Map<String, PropertyDefinition> properties) {
-      if (properties != null) {
-          this.properties = properties;
-      }
-  }
-
-  public Map<String, AttributeDefinition> getAttributes() {
-      return attributes;
-  }
-
-  public void setAttributes(Map<String, AttributeDefinition> attributes) {
-      this.attributes = attributes;
-  }
-
-  @SuppressWarnings("rawtypes")
-  public List<Map<String, RequirementDefinition>> getRequirements() {
-    for (Map<String, RequirementDefinition> requirement : this.requirements) {
-      for (String name : requirement.keySet()) {
-        Object tmp = requirement.get(name);
-        if (tmp instanceof Map) {
-          Map req_value = (Map) tmp;
-          requirement.put(name,  // substitute map with RequirementDefinition
-              new RequirementDefinition(req_value.get("capability"),
-                  req_value.get("node"),
-                  req_value.get("relationship"),
-                  parseOccurrences((List)req_value.get("occurrences"))));
-        }
-      }
-      
-    }
-    return this.requirements;
-  }
-
-  /**
-   * @param list
-   * @return
-   */
-  @SuppressWarnings("rawtypes")
-  private String[] parseOccurrences(List list) {
-    if (list == null || list.isEmpty()) {
-      return RequirementDefinition.UNBOUNDED_OCCURRENCE;
-    }
-    
-    String[] occurrences = new String[list.size()];
-    int i = 0;
-    for (Object object : list) {
-      occurrences[i++] = object.toString();
-    }
-    return occurrences;
-  }
-
-  public void setRequirements(List<Map<String, RequirementDefinition>> requirements) {
-      if (requirements != null) {
-          this.requirements = requirements;
-      }
-  }
-
-  public Map<String, CapabilityDefinition> getCapabilities() {
-      return this.capabilities;
-  }
-
-  public void setCapabilities(Map<String, CapabilityDefinition> capabilities) {
-      if (capabilities != null) {
-          this.capabilities = capabilities;
-      }
-  }
-
-  public Map<String, Map<String, Map<String, String>>> getInterfaces() {
-      return this.interfaces;
-  }
-
-  public void setInterfaces(Map<String, Map<String, Map<String, String>>> interfaces) {
-      if (interfaces != null) {
-          this.interfaces = interfaces;
-      }
-  }
-
-  @Override
-  public boolean equals(Object o) {
-      if (this == o) {
-          return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-          return false;
-      }
-      if (!super.equals(o)) {
-          return false;
-      }
-
-      final NodeType nodeType = (NodeType) o;
-
-      if (!this.artifacts.equals(nodeType.artifacts)) {
-          return false;
-      }
-      if (!this.capabilities.equals(nodeType.capabilities)) {
-          return false;
-      }
-      if (!this.derived_from.equals(nodeType.derived_from)) {
-          return false;
-      }
-      if (!this.interfaces.equals(nodeType.interfaces)) {
-          return false;
-      }
-      if (!this.properties.equals(nodeType.properties)) {
-          return false;
-      }
-      if (!this.attributes.equals(nodeType.attributes)) {
-          return false;
-      }
-      if (!this.requirements.equals(nodeType.requirements)) {
-          return false;
-      }
-
-      return true;
-  }
-
-  @Override
-  public int hashCode() {
-      int result = super.hashCode();
-      result = 31 * result + this.derived_from.hashCode();
-      result = 31 * result + this.properties.hashCode();
-      result = 31 * result + this.attributes.hashCode();
-      result = 31 * result + this.requirements.hashCode();
-      result = 31 * result + this.capabilities.hashCode();
-      result = 31 * result + this.interfaces.hashCode();
-      result = 31 * result + this.artifacts.hashCode();
-      return result;
-  }
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/NodeType.java
@@ -1,0 +1,172 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NodeType extends YAMLElement {
+
+  private String derived_from = "";
+  private Map<String, PropertyDefinition> properties = new HashMap<>();
+  private Map<String, AttributeDefinition> attributes = new HashMap<>();
+  private List<Map<String, RequirementDefinition>> requirements = new ArrayList<>();
+  private Map<String, CapabilityDefinition> capabilities = new HashMap<>();
+  private Map<String, Map<String, Map<String, String>>> interfaces = new HashMap<>();
+  private Map<String, ArtifactDefinition> artifacts = new HashMap<>();
+  
+  public Map<String, ArtifactDefinition> getArtifacts() {
+    return artifacts;
+  }
+
+  public void setArtifacts(Map<String, ArtifactDefinition> artifacts) {
+    this.artifacts = artifacts;
+  }
+
+  public String getDerived_from() {
+    return this.derived_from;
+  }
+
+  public void setDerived_from(String derived_from) {
+      if (derived_from != null) {
+          this.derived_from = derived_from;
+      }
+  }
+
+  public Map<String, PropertyDefinition> getProperties() {
+      return this.properties;
+  }
+
+  public void setProperties(Map<String, PropertyDefinition> properties) {
+      if (properties != null) {
+          this.properties = properties;
+      }
+  }
+
+  public Map<String, AttributeDefinition> getAttributes() {
+      return attributes;
+  }
+
+  public void setAttributes(Map<String, AttributeDefinition> attributes) {
+      this.attributes = attributes;
+  }
+
+  @SuppressWarnings("rawtypes")
+  public List<Map<String, RequirementDefinition>> getRequirements() {
+    for (Map<String, RequirementDefinition> requirement : this.requirements) {
+      for (String name : requirement.keySet()) {
+        Object tmp = requirement.get(name);
+        if (tmp instanceof Map) {
+          Map req_value = (Map) tmp;
+          requirement.put(name,  // substitute map with RequirementDefinition
+              new RequirementDefinition(req_value.get("capability"),
+                  req_value.get("node"),
+                  req_value.get("relationship"),
+                  parseOccurrences((List)req_value.get("occurrences"))));
+        }
+      }
+      
+    }
+    return this.requirements;
+  }
+
+  /**
+   * @param list
+   * @return
+   */
+  @SuppressWarnings("rawtypes")
+  private String[] parseOccurrences(List list) {
+    if (list == null || list.isEmpty()) {
+      return RequirementDefinition.UNBOUNDED_OCCURRENCE;
+    }
+    
+    String[] occurrences = new String[list.size()];
+    int i = 0;
+    for (Object object : list) {
+      occurrences[i++] = object.toString();
+    }
+    return occurrences;
+  }
+
+  public void setRequirements(List<Map<String, RequirementDefinition>> requirements) {
+      if (requirements != null) {
+          this.requirements = requirements;
+      }
+  }
+
+  public Map<String, CapabilityDefinition> getCapabilities() {
+      return this.capabilities;
+  }
+
+  public void setCapabilities(Map<String, CapabilityDefinition> capabilities) {
+      if (capabilities != null) {
+          this.capabilities = capabilities;
+      }
+  }
+
+  public Map<String, Map<String, Map<String, String>>> getInterfaces() {
+      return this.interfaces;
+  }
+
+  public void setInterfaces(Map<String, Map<String, Map<String, String>>> interfaces) {
+      if (interfaces != null) {
+          this.interfaces = interfaces;
+      }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+      if (this == o) {
+          return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+          return false;
+      }
+      if (!super.equals(o)) {
+          return false;
+      }
+
+      final NodeType nodeType = (NodeType) o;
+
+      if (!this.artifacts.equals(nodeType.artifacts)) {
+          return false;
+      }
+      if (!this.capabilities.equals(nodeType.capabilities)) {
+          return false;
+      }
+      if (!this.derived_from.equals(nodeType.derived_from)) {
+          return false;
+      }
+      if (!this.interfaces.equals(nodeType.interfaces)) {
+          return false;
+      }
+      if (!this.properties.equals(nodeType.properties)) {
+          return false;
+      }
+      if (!this.attributes.equals(nodeType.attributes)) {
+          return false;
+      }
+      if (!this.requirements.equals(nodeType.requirements)) {
+          return false;
+      }
+
+      return true;
+  }
+
+  @Override
+  public int hashCode() {
+      int result = super.hashCode();
+      result = 31 * result + this.derived_from.hashCode();
+      result = 31 * result + this.properties.hashCode();
+      result = 31 * result + this.attributes.hashCode();
+      result = 31 * result + this.requirements.hashCode();
+      result = 31 * result + this.capabilities.hashCode();
+      result = 31 * result + this.interfaces.hashCode();
+      result = 31 * result + this.artifacts.hashCode();
+      return result;
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/OperationDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/OperationDefinition.java
@@ -1,40 +1,34 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- * @author Sebi
+ *  
+ * @author Huabing Zhao
+ *
  */
-@Deprecated
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class OperationDefinition {
 
     private String implementation = "";
 
-    public String getImplementation() {
-        return implementation;
-    }
-
-    public void setImplementation(String implementation) {
-        if (implementation != null) {
-            this.implementation = implementation;
-        }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        OperationDefinition that = (OperationDefinition) o;
-
-        if (!implementation.equals(that.implementation)) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return implementation.hashCode();
-    }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/OperationDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/OperationDefinition.java
@@ -1,0 +1,40 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+/**
+ * @author Sebi
+ */
+@Deprecated
+public class OperationDefinition {
+
+    private String implementation = "";
+
+    public String getImplementation() {
+        return implementation;
+    }
+
+    public void setImplementation(String implementation) {
+        if (implementation != null) {
+            this.implementation = implementation;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OperationDefinition that = (OperationDefinition) o;
+
+        if (!implementation.equals(that.implementation)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return implementation.hashCode();
+    }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Output.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Output.java
@@ -1,0 +1,39 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+public class Output extends YAMLElement {
+
+	private Object value;
+
+	public Object getValue() {
+		return value;
+	}
+
+	public void setValue(Object value) {
+		if (value != null) {
+			this.value = value;
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		Output output = (Output) o;
+
+		if (value != null ? !value.equals(output.value) : output.value != null) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (value != null ? value.hashCode() : 0);
+		return result;
+	}
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Output.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Output.java
@@ -1,39 +1,33 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
-public class Output extends YAMLElement {
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Output extends YAMLElement {
 	private Object value;
 
-	public Object getValue() {
-		return value;
-	}
-
-	public void setValue(Object value) {
-		if (value != null) {
-			this.value = value;
-		}
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-		if (!super.equals(o)) return false;
-
-		Output output = (Output) o;
-
-		if (value != null ? !value.equals(output.value) : output.value != null) return false;
-
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		int result = super.hashCode();
-		result = 31 * result + (value != null ? value.hashCode() : 0);
-		return result;
-	}
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Plan.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Plan.java
@@ -14,46 +14,24 @@
  * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
-/**
- * Copyright 2017 ZTE Corporation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class Plan extends YAMLElement {
     private String reference = "";
     private String planLanguage = "";
     private Map<String, Input> inputs = new HashMap<String, Input>();
-    public String getReference() {
-      return reference;
-    }
-    public void setReference(String reference) {
-      this.reference = reference;
-    }
-    public String getPlanLanguage() {
-      return planLanguage;
-    }
-    public void setPlanLanguage(String planLanguage) {
-      this.planLanguage = planLanguage;
-    }
-    public Map<String, Input> getInputs() {
-      return inputs;
-    }
-    public void setInputs(Map<String, Input> inputs) {
-      this.inputs = inputs;
-    }
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Plan.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Plan.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class Plan extends YAMLElement {
+    private String reference = "";
+    private String planLanguage = "";
+    private Map<String, Input> inputs = new HashMap<String, Input>();
+    public String getReference() {
+      return reference;
+    }
+    public void setReference(String reference) {
+      this.reference = reference;
+    }
+    public String getPlanLanguage() {
+      return planLanguage;
+    }
+    public void setPlanLanguage(String planLanguage) {
+      this.planLanguage = planLanguage;
+    }
+    public Map<String, Input> getInputs() {
+      return inputs;
+    }
+    public void setInputs(Map<String, Input> inputs) {
+      this.inputs = inputs;
+    }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Policy.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Policy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,46 +18,21 @@ package org.eclipse.winery.model.tosca.yaml;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class Policy extends YAMLElement {
   private String type = "";
   private String description = "";
   private Map<String, Object> properties = new HashMap<String, Object>();
   private String[] targets = new String[0];
-  
-  public String getType() {
-    return type;
-  }
-  
-  public void setType(String type) {
-    if (type != null) {
-      this.type = type;
-    }
-  }
-  
-  public String getDescription() {
-    return description;
-  }
-  
-  public void setDescription(String description) {
-    if (description != null) {
-      this.description = description;
-    }
-  }
-  
-  public Map<String, Object> getProperties() {
-    return properties;
-  }
-  
-  public void setProperties(Map<String, Object> properties) {
-    this.properties = properties;
-  }
-  
-  public String[] getTargets() {
-    return targets;
-  }
-  
-  public void setTargets(String[] targets) {
-    this.targets = targets;
-  }
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Policy.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Policy.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Policy extends YAMLElement {
+  private String type = "";
+  private String description = "";
+  private Map<String, Object> properties = new HashMap<String, Object>();
+  private String[] targets = new String[0];
+  
+  public String getType() {
+    return type;
+  }
+  
+  public void setType(String type) {
+    if (type != null) {
+      this.type = type;
+    }
+  }
+  
+  public String getDescription() {
+    return description;
+  }
+  
+  public void setDescription(String description) {
+    if (description != null) {
+      this.description = description;
+    }
+  }
+  
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
+  
+  public void setProperties(Map<String, Object> properties) {
+    this.properties = properties;
+  }
+  
+  public String[] getTargets() {
+    return targets;
+  }
+  
+  public void setTargets(String[] targets) {
+    this.targets = targets;
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PolicyType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PolicyType.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PolicyType extends YAMLElement {
+
+    private String derived_from = "";
+    private String version = "";
+    private String description = "";
+    private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
+    private String[] targets = new String[0];
+    
+    public String getVesion() {
+        return version;
+    }
+    public void setVersion(String version) {
+        this.version = version;
+    }
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    public String getDerived_from() {
+        return derived_from;
+    }
+    public void setDerived_from(String derived_from) {
+        this.derived_from = derived_from;
+    }
+    public Map<String, PropertyDefinition> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, PropertyDefinition> properties) {
+        this.properties = properties;
+    }
+    public String[] getTargets() {
+        return targets;
+    }
+    public void setTargets(String[] targets) {
+        this.targets = targets;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final PolicyType policyType = (PolicyType) o;
+
+        if (!this.derived_from.equals(policyType.derived_from)) {
+            return false;
+        }
+        if (!this.version.equals(policyType.version)) {
+            return false;
+        }
+        if (!this.description.equals(policyType.description)) {
+            return false;
+        }
+        if (!this.properties.equals(policyType.properties)) {
+            return false;
+        }
+        if (!this.targets.equals(policyType.targets)) {
+            return false;
+        }
+
+        return true;
+    }
+    
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + this.derived_from.hashCode();
+        result = 31 * result + this.version.hashCode();
+        result = 31 * result + this.description.hashCode();
+        result = 31 * result + this.properties.hashCode();
+        result = 31 * result + this.targets.hashCode();
+        return result;
+    }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PolicyType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PolicyType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,86 +18,23 @@ package org.eclipse.winery.model.tosca.yaml;
 import java.util.HashMap;
 import java.util.Map;
 
-public class PolicyType extends YAMLElement {
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PolicyType extends YAMLElement {
     private String derived_from = "";
     private String version = "";
     private String description = "";
     private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
     private String[] targets = new String[0];
-    
-    public String getVesion() {
-        return version;
-    }
-    public void setVersion(String version) {
-        this.version = version;
-    }
-    public String getDescription() {
-        return description;
-    }
-    public void setDescription(String description) {
-        this.description = description;
-    }
-    public String getDerived_from() {
-        return derived_from;
-    }
-    public void setDerived_from(String derived_from) {
-        this.derived_from = derived_from;
-    }
-    public Map<String, PropertyDefinition> getProperties() {
-        return properties;
-    }
-    public void setProperties(Map<String, PropertyDefinition> properties) {
-        this.properties = properties;
-    }
-    public String[] getTargets() {
-        return targets;
-    }
-    public void setTargets(String[] targets) {
-        this.targets = targets;
-    }
-    
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-
-        final PolicyType policyType = (PolicyType) o;
-
-        if (!this.derived_from.equals(policyType.derived_from)) {
-            return false;
-        }
-        if (!this.version.equals(policyType.version)) {
-            return false;
-        }
-        if (!this.description.equals(policyType.description)) {
-            return false;
-        }
-        if (!this.properties.equals(policyType.properties)) {
-            return false;
-        }
-        if (!this.targets.equals(policyType.targets)) {
-            return false;
-        }
-
-        return true;
-    }
-    
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + this.derived_from.hashCode();
-        result = 31 * result + this.version.hashCode();
-        result = 31 * result + this.description.hashCode();
-        result = 31 * result + this.properties.hashCode();
-        result = 31 * result + this.targets.hashCode();
-        return result;
-    }
+  
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertiesFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertiesFilter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PropertiesFilter {
+  private List<PropertyFilter> properties = new ArrayList<>();
+
+  public void setProperties(List<PropertyFilter> properties) {
+    if (properties != null) {
+      this.properties = properties;
+    }
+  }
+
+  public List<PropertyFilter> getProperties() {
+    return this.properties;
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertiesFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertiesFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,19 @@ package org.eclipse.winery.model.tosca.yaml;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class PropertiesFilter {
   private List<PropertyFilter> properties = new ArrayList<>();
-
-  public void setProperties(List<PropertyFilter> properties) {
-    if (properties != null) {
-      this.properties = properties;
-    }
-  }
-
-  public List<PropertyFilter> getProperties() {
-    return this.properties;
-  }
 
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyDefinition.java
@@ -1,5 +1,17 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
@@ -9,9 +21,18 @@ import java.util.Map;
 
 import com.google.gson.annotations.SerializedName;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- * @author Sebi
+ *  
+ * @author Huabing Zhao
+ *
  */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class PropertyDefinition extends YAMLElement {
 
   private String type = "";
@@ -22,100 +43,4 @@ public class PropertyDefinition extends YAMLElement {
   private List<Map<String, Object>> constraints = new ArrayList<>();
   private EntrySchema entry_schema;
 
-  public String getType() {
-    return this.type;
-  }
-
-  public void setType(String type) {
-    if (type != null) {
-      this.type = type;
-    }
-  }
-
-  public Object getDefault() {
-    return this.defaultValue;
-  }
-
-  public void setDefault(Object defaultValue) {
-    if (defaultValue != null) {
-      this.defaultValue = defaultValue;
-    }
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public boolean isRequired() {
-    return this.required;
-  }
-
-  public void setRequired(boolean required) {
-    this.required = required;
-  }
-
-  public List<Map<String, Object>> getConstraints() {
-    return this.constraints;
-  }
-
-  public void setConstraints(List<Map<String, Object>> constraints) {
-    if (constraints != null) {
-      this.constraints = constraints;
-    }
-  }
-
-  public EntrySchema getEntry_schema() {
-    return entry_schema;
-  }
-
-  public void setEntry_schema(EntrySchema entry_schema) {
-    if (entry_schema == null) {
-      return;
-    }
-    this.entry_schema = entry_schema;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    if (!super.equals(o)) {
-      return false;
-    }
-
-    final PropertyDefinition that = (PropertyDefinition) o;
-
-    if (this.required != that.required) {
-      return false;
-    }
-    if (!this.constraints.equals(that.constraints)) {
-      return false;
-    }
-    if (!this.defaultValue.equals(that.defaultValue)) {
-      return false;
-    }
-    if (!this.type.equals(that.type)) {
-      return false;
-    }
-
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + this.type.hashCode();
-    result = 31 * result + this.defaultValue.hashCode();
-    result = 31 * result + (this.required ? 1 : 0);
-    result = 31 * result + this.constraints.hashCode();
-    return result;
-  }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyDefinition.java
@@ -1,0 +1,121 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * @author Sebi
+ */
+public class PropertyDefinition extends YAMLElement {
+
+  private String type = "";
+  @SerializedName("default")
+  private Object defaultValue = "";
+  private String status;
+  private boolean required = true;
+  private List<Map<String, Object>> constraints = new ArrayList<>();
+  private EntrySchema entry_schema;
+
+  public String getType() {
+    return this.type;
+  }
+
+  public void setType(String type) {
+    if (type != null) {
+      this.type = type;
+    }
+  }
+
+  public Object getDefault() {
+    return this.defaultValue;
+  }
+
+  public void setDefault(Object defaultValue) {
+    if (defaultValue != null) {
+      this.defaultValue = defaultValue;
+    }
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public boolean isRequired() {
+    return this.required;
+  }
+
+  public void setRequired(boolean required) {
+    this.required = required;
+  }
+
+  public List<Map<String, Object>> getConstraints() {
+    return this.constraints;
+  }
+
+  public void setConstraints(List<Map<String, Object>> constraints) {
+    if (constraints != null) {
+      this.constraints = constraints;
+    }
+  }
+
+  public EntrySchema getEntry_schema() {
+    return entry_schema;
+  }
+
+  public void setEntry_schema(EntrySchema entry_schema) {
+    if (entry_schema == null) {
+      return;
+    }
+    this.entry_schema = entry_schema;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    final PropertyDefinition that = (PropertyDefinition) o;
+
+    if (this.required != that.required) {
+      return false;
+    }
+    if (!this.constraints.equals(that.constraints)) {
+      return false;
+    }
+    if (!this.defaultValue.equals(that.defaultValue)) {
+      return false;
+    }
+    if (!this.type.equals(that.type)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + this.type.hashCode();
+    result = 31 * result + this.defaultValue.hashCode();
+    result = 31 * result + (this.required ? 1 : 0);
+    result = 31 * result + this.constraints.hashCode();
+    return result;
+  }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyFilter.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+
+public class PropertyFilter extends HashMap<String, ConstraintClause>{
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 1L;
+
+  public PropertyFilter(String propertyName, ConstraintClause constraintClause) {
+    super();
+    this.put(propertyName, constraintClause);
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyFilter.java
@@ -27,7 +27,6 @@ import lombok.NoArgsConstructor;
  *
  */
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class PropertyFilter extends HashMap<String, ConstraintClause>{
 

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyFilter.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/PropertyFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,19 @@ package org.eclipse.winery.model.tosca.yaml;
 
 import java.util.HashMap;
 
-public class PropertyFilter extends HashMap<String, ConstraintClause>{
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-  /**
-   * 
-   */
-  private static final long serialVersionUID = 1L;
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PropertyFilter extends HashMap<String, ConstraintClause>{
 
   public PropertyFilter(String propertyName, ConstraintClause constraintClause) {
     super();

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RelationshipType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RelationshipType.java
@@ -1,0 +1,64 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RelationshipType extends YAMLElement {
+  private String derived_from = "";
+  private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
+  private Map<String, AttributeDefinition> attributes = new HashMap<>();
+  private Map<String, Map<String, Map<String, String>>> interfaces =
+      new HashMap<String, Map<String, Map<String, String>>>();
+  private String[] valid_target_types;
+
+  public String getDerived_from() {
+    return this.derived_from;
+  }
+
+  public void setDerived_from(String derived_from) {
+    if (derived_from != null) {
+      this.derived_from = derived_from;
+    }
+  }
+
+  public Map<String, PropertyDefinition> getProperties() {
+    return this.properties;
+  }
+
+  public void setProperties(Map<String, PropertyDefinition> properties) {
+    if (properties != null) {
+      this.properties = properties;
+    }
+  }
+
+  public Map<String, AttributeDefinition> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, AttributeDefinition> attributes) {
+    if (attributes != null) {
+      this.attributes = attributes;
+    }
+  }
+
+  public Map<String, Map<String, Map<String, String>>> getInterfaces() {
+    return this.interfaces;
+  }
+
+  public void setInterfaces(Map<String, Map<String, Map<String, String>>> interfaces) {
+    if (interfaces != null) {
+      this.interfaces = interfaces;
+    }
+  }
+
+  public String[] getValid_target_types() {
+    return this.valid_target_types;
+  }
+
+  public void setValid_target_types(String[] valid_target_types) {
+    this.valid_target_types = valid_target_types;
+  }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RelationshipType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RelationshipType.java
@@ -1,11 +1,35 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class RelationshipType extends YAMLElement {
   private String derived_from = "";
   private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
@@ -14,51 +38,4 @@ public class RelationshipType extends YAMLElement {
       new HashMap<String, Map<String, Map<String, String>>>();
   private String[] valid_target_types;
 
-  public String getDerived_from() {
-    return this.derived_from;
-  }
-
-  public void setDerived_from(String derived_from) {
-    if (derived_from != null) {
-      this.derived_from = derived_from;
-    }
-  }
-
-  public Map<String, PropertyDefinition> getProperties() {
-    return this.properties;
-  }
-
-  public void setProperties(Map<String, PropertyDefinition> properties) {
-    if (properties != null) {
-      this.properties = properties;
-    }
-  }
-
-  public Map<String, AttributeDefinition> getAttributes() {
-    return attributes;
-  }
-
-  public void setAttributes(Map<String, AttributeDefinition> attributes) {
-    if (attributes != null) {
-      this.attributes = attributes;
-    }
-  }
-
-  public Map<String, Map<String, Map<String, String>>> getInterfaces() {
-    return this.interfaces;
-  }
-
-  public void setInterfaces(Map<String, Map<String, Map<String, String>>> interfaces) {
-    if (interfaces != null) {
-      this.interfaces = interfaces;
-    }
-  }
-
-  public String[] getValid_target_types() {
-    return this.valid_target_types;
-  }
-
-  public void setValid_target_types(String[] valid_target_types) {
-    this.valid_target_types = valid_target_types;
-  }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Requirement.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Requirement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,74 +15,22 @@
  */
 package org.eclipse.winery.model.tosca.yaml;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class Requirement {
   private String node = "";
   private RequirementRelationship relationship;
   private String capability = "";
   private NodeFilter node_filter;
   private int[] occurrences;
-
-  public Requirement() {
-    super();
-  }
-
-  public Requirement(NodeFilter node_filter) {
-    super();
-    this.node_filter = node_filter;
-  }
-
-  public Requirement(String node) {
-    super();
-    this.node = node;
-  }
-
-  public String getNode() {
-    return node;
-  }
-
-  public void setNode(String node) {
-    if (node != null) {
-      this.node = node;
-    }
-  }
-
-  public RequirementRelationship getRelationship() {
-    return relationship;
-  }
-
-  public void setRelationship(RequirementRelationship relationship) {
-    this.relationship = relationship;
-  }
-
-  public String getCapability() {
-    return capability;
-  }
-
-  public void setCapability(String capability) {
-    if (capability != null) {
-      this.capability = capability;
-    }
-  }
-
-  public NodeFilter getNode_filter() {
-    return node_filter;
-  }
-
-  public void setNode_filter(NodeFilter node_filter) {
-    if (node_filter != null) {
-      this.node_filter = node_filter;
-    }
-  }
-
-  public int[] getOccurrences() {
-    return occurrences;
-  }
-
-  public void setOccurrences(int[] occurrences) {
-    if (occurrences != null && occurrences.length == 2) {
-      this.occurrences = occurrences;
-    }
-  }
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Requirement.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/Requirement.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+
+public class Requirement {
+  private String node = "";
+  private RequirementRelationship relationship;
+  private String capability = "";
+  private NodeFilter node_filter;
+  private int[] occurrences;
+
+  public Requirement() {
+    super();
+  }
+
+  public Requirement(NodeFilter node_filter) {
+    super();
+    this.node_filter = node_filter;
+  }
+
+  public Requirement(String node) {
+    super();
+    this.node = node;
+  }
+
+  public String getNode() {
+    return node;
+  }
+
+  public void setNode(String node) {
+    if (node != null) {
+      this.node = node;
+    }
+  }
+
+  public RequirementRelationship getRelationship() {
+    return relationship;
+  }
+
+  public void setRelationship(RequirementRelationship relationship) {
+    this.relationship = relationship;
+  }
+
+  public String getCapability() {
+    return capability;
+  }
+
+  public void setCapability(String capability) {
+    if (capability != null) {
+      this.capability = capability;
+    }
+  }
+
+  public NodeFilter getNode_filter() {
+    return node_filter;
+  }
+
+  public void setNode_filter(NodeFilter node_filter) {
+    if (node_filter != null) {
+      this.node_filter = node_filter;
+    }
+  }
+
+  public int[] getOccurrences() {
+    return occurrences;
+  }
+
+  public void setOccurrences(int[] occurrences) {
+    if (occurrences != null && occurrences.length == 2) {
+      this.occurrences = occurrences;
+    }
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RequirementDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RequirementDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,18 @@
  */
 package org.eclipse.winery.model.tosca.yaml;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class RequirementDefinition {
   public static final String[] UNBOUNDED_OCCURRENCE = new String [] {"0", "UNBOUNDED"};
   
@@ -23,73 +34,4 @@ public class RequirementDefinition {
   private String node = "";
   private String relationship = "";
   private String[] occurrences;
-
-  public RequirementDefinition() {
-    super();
-  }
-
-  /**
-   * @param node
-   * @param relationship
-   * @param capability
-   * @param parseOccurrences
-   */
-  public RequirementDefinition(Object capability, Object node, Object relationship, String[] occurrences) {
-    super();
-    if (capability != null) {
-      this.capability = capability.toString();
-    }
-    if (node != null) {
-      this.node = node.toString();
-    }
-    if (relationship != null) {
-      this.relationship = relationship.toString();
-    }
-    this.setOccurrences(occurrences);
-//    if (occurrences != null && occurrences.length == 2) {
-//      this.occurrences = occurrences;
-//    } else {
-//      this.occurrences = UNBOUNDED_OCCURRENCE;
-//    }
-  }
-
-  public String getNode() {
-      return node;
-  }
-
-  public void setNode(String node) {
-      if (node != null) {
-          this.node = node;
-      }
-  }
-
-  public String getRelationship() {
-      return relationship;
-  }
-
-  public void setRelationship(String relationship) {
-      if (relationship != null) {
-          this.relationship = relationship;
-      }
-  }
-
-  public String getCapability() {
-      return capability;
-  }
-
-  public void setCapability(String capability) {
-      if (capability != null) {
-          this.capability = capability;
-      }
-  }
-
-  public String[] getOccurrences() {
-      return occurrences;
-  }
-
-  public void setOccurrences(String[] occurrences) {
-      if (occurrences != null && occurrences.length == 2) {
-          this.occurrences = occurrences;
-      }
-  }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RequirementDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RequirementDefinition.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+
+public class RequirementDefinition {
+  public static final String[] UNBOUNDED_OCCURRENCE = new String [] {"0", "UNBOUNDED"};
+  
+  private String capability = "";
+  private String node = "";
+  private String relationship = "";
+  private String[] occurrences;
+
+  public RequirementDefinition() {
+    super();
+  }
+
+  /**
+   * @param node
+   * @param relationship
+   * @param capability
+   * @param parseOccurrences
+   */
+  public RequirementDefinition(Object capability, Object node, Object relationship, String[] occurrences) {
+    super();
+    if (capability != null) {
+      this.capability = capability.toString();
+    }
+    if (node != null) {
+      this.node = node.toString();
+    }
+    if (relationship != null) {
+      this.relationship = relationship.toString();
+    }
+    this.setOccurrences(occurrences);
+//    if (occurrences != null && occurrences.length == 2) {
+//      this.occurrences = occurrences;
+//    } else {
+//      this.occurrences = UNBOUNDED_OCCURRENCE;
+//    }
+  }
+
+  public String getNode() {
+      return node;
+  }
+
+  public void setNode(String node) {
+      if (node != null) {
+          this.node = node;
+      }
+  }
+
+  public String getRelationship() {
+      return relationship;
+  }
+
+  public void setRelationship(String relationship) {
+      if (relationship != null) {
+          this.relationship = relationship;
+      }
+  }
+
+  public String getCapability() {
+      return capability;
+  }
+
+  public void setCapability(String capability) {
+      if (capability != null) {
+          this.capability = capability;
+      }
+  }
+
+  public String[] getOccurrences() {
+      return occurrences;
+  }
+
+  public void setOccurrences(String[] occurrences) {
+      if (occurrences != null && occurrences.length == 2) {
+          this.occurrences = occurrences;
+      }
+  }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RequirementRelationship.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RequirementRelationship.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RequirementRelationship {
+  private String type = "";
+  private Map<String, Object> properties = new HashMap<String, Object>();
+
+  public RequirementRelationship() {
+    super();
+  }
+  
+  public RequirementRelationship(String type) {
+    super();
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Map<String, Object> properties) {
+    if (properties != null) {
+      this.properties = properties;
+    }
+  }
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RequirementRelationship.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/RequirementRelationship.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,35 +18,19 @@ package org.eclipse.winery.model.tosca.yaml;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class RequirementRelationship {
   private String type = "";
   private Map<String, Object> properties = new HashMap<String, Object>();
-
-  public RequirementRelationship() {
-    super();
-  }
-  
-  public RequirementRelationship(String type) {
-    super();
-    this.type = type;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public Map<String, Object> getProperties() {
-    return properties;
-  }
-
-  public void setProperties(Map<String, Object> properties) {
-    if (properties != null) {
-      this.properties = properties;
-    }
-  }
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ServiceTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ServiceTemplate.java
@@ -1,0 +1,198 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ServiceTemplate extends YAMLElement {
+  private String tosca_definitions_version = "";
+  private Map<String, String> metadata = new HashMap<>();
+  private Map<String, Object> dsl_definitions = new HashMap<>();
+  private List<String> imports = new ArrayList<String>();
+  private Map<String, ArtifactType> artifact_types = new HashMap<String, ArtifactType>();
+  private Map<String, DataType> data_types = new HashMap<>();
+  private Map<String, CapabilityType> capability_types = new HashMap<String, CapabilityType>();
+  private Map<String, Object> interface_types = new HashMap<>();
+  private Map<String, RelationshipType> relationship_types = new HashMap<String, RelationshipType>();
+  private Map<String, NodeType> node_types = new HashMap<String, NodeType>();
+  private Map<String, Object> group_types = new HashMap<>();
+  private Map<String, PolicyType> policy_types = new HashMap<>();
+
+  private TopologyTemplate topology_template;
+  private Map<String, Plan> plans = new HashMap<>();
+
+//  private String tosca_default_namespace = "";
+  private String template_name = "";
+  private String template_author = "";
+  private String template_version = "";
+
+  public Map<String, String> getMetadata() {
+      return metadata;
+  }
+
+  public void setMetadata(Map<String, String> metadata) {
+      this.metadata = metadata;
+  }
+
+  public Map<String, Object> getDsl_definitions() {
+      return dsl_definitions;
+  }
+
+  public void setDsl_definitions(Map<String, Object> dsl_definitions) {
+      this.dsl_definitions = dsl_definitions;
+  }
+
+  public Map<String, DataType> getData_types() {
+      return data_types;
+  }
+
+  public void setData_types(Map<String, DataType> data_types) {
+      this.data_types = data_types;
+  }
+
+  public Map<String, Object> getInterface_types() {
+      return interface_types;
+  }
+
+  public void setInterface_types(Map<String, Object> interface_types) {
+      this.interface_types = interface_types;
+  }
+
+  public Map<String, Object> getGroup_types() {
+      return group_types;
+  }
+
+  public void setGroup_types(Map<String, Object> group_types) {
+      this.group_types = group_types;
+  }
+
+  public Map<String, PolicyType> getPolicy_types() {
+      return policy_types;
+  }
+
+  public void setPolicy_types(Map<String, PolicyType> policy_types) {
+      this.policy_types = policy_types;
+  }
+  
+  public TopologyTemplate getTopology_template() {
+      return topology_template;
+  }
+
+public void setTopology_template(TopologyTemplate topology_template) {
+  this.topology_template = topology_template;
+}
+
+public Map<String, Plan> getPlans() {
+  return plans;
+}
+
+public void setPlans(Map<String, Plan> plans) {
+  if (plans != null) {
+    this.plans = plans;
+  }
+  }
+
+  public void setTosca_definitions_version(String tosca_definitions_version) {
+      if (tosca_definitions_version != null) {
+          this.tosca_definitions_version = tosca_definitions_version;
+      }
+  }
+
+  public String getTosca_definitions_version() {
+      return this.tosca_definitions_version;
+  }
+
+//  public void setTosca_default_namespace(String tosca_default_namespace) {
+//      if (tosca_default_namespace != null) {
+//          this.tosca_default_namespace = tosca_default_namespace;
+//      }
+//  }
+//
+//  public String getTosca_default_namespace() {
+//      return this.tosca_default_namespace;
+//  }
+
+  public void setTemplate_name(String template_name) {
+      if (template_name != null) {
+          this.template_name = template_name;
+      }
+  }
+
+  public String getTemplate_name() {
+      return this.template_name;
+  }
+
+  public void setTemplate_author(String template_author) {
+      if (template_author != null) {
+          this.template_author = template_author;
+      }
+  }
+
+  public String getTemplate_author() {
+      return this.template_author;
+  }
+
+  public void setTemplate_version(String template_version) {
+      if (template_version != null) {
+          this.template_version = template_version;
+      }
+  }
+
+  public String getTemplate_version() {
+      return this.template_version;
+  }
+
+  public void setImports(List<String> imports) {
+      if (imports != null) {
+          this.imports = imports;
+      }
+  }
+
+  public List<String> getImports() {
+      return this.imports;
+  }
+
+  public void setNode_types(Map<String, NodeType> node_types) {
+      if (node_types != null) {
+          this.node_types = node_types;
+      }
+  }
+
+  public Map<String, NodeType> getNode_types() {
+      return this.node_types;
+  }
+
+  public void setCapability_types(Map<String, CapabilityType> capability_types) {
+      if (capability_types != null) {
+          this.capability_types = capability_types;
+      }
+  }
+
+  public Map<String, CapabilityType> getCapability_types() {
+      return this.capability_types;
+  }
+
+  public void setRelationship_types(Map<String, RelationshipType> relationship_types) {
+      if (relationship_types != null) {
+          this.relationship_types = relationship_types;
+      }
+  }
+
+  public Map<String, RelationshipType> getRelationship_types() {
+      return this.relationship_types;
+  }
+
+  public void setArtifact_types(Map<String, ArtifactType> artifact_types) {
+      if (artifact_types != null) {
+          this.artifact_types = artifact_types;
+      }
+  }
+
+  public Map<String, ArtifactType> getArtifact_types() {
+      return this.artifact_types;
+  }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ServiceTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/ServiceTemplate.java
@@ -1,5 +1,17 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
@@ -8,6 +20,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ServiceTemplate extends YAMLElement {
   private String tosca_definitions_version = "";
   private Map<String, String> metadata = new HashMap<>();
@@ -29,170 +53,4 @@ public class ServiceTemplate extends YAMLElement {
   private String template_name = "";
   private String template_author = "";
   private String template_version = "";
-
-  public Map<String, String> getMetadata() {
-      return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-      this.metadata = metadata;
-  }
-
-  public Map<String, Object> getDsl_definitions() {
-      return dsl_definitions;
-  }
-
-  public void setDsl_definitions(Map<String, Object> dsl_definitions) {
-      this.dsl_definitions = dsl_definitions;
-  }
-
-  public Map<String, DataType> getData_types() {
-      return data_types;
-  }
-
-  public void setData_types(Map<String, DataType> data_types) {
-      this.data_types = data_types;
-  }
-
-  public Map<String, Object> getInterface_types() {
-      return interface_types;
-  }
-
-  public void setInterface_types(Map<String, Object> interface_types) {
-      this.interface_types = interface_types;
-  }
-
-  public Map<String, Object> getGroup_types() {
-      return group_types;
-  }
-
-  public void setGroup_types(Map<String, Object> group_types) {
-      this.group_types = group_types;
-  }
-
-  public Map<String, PolicyType> getPolicy_types() {
-      return policy_types;
-  }
-
-  public void setPolicy_types(Map<String, PolicyType> policy_types) {
-      this.policy_types = policy_types;
-  }
-  
-  public TopologyTemplate getTopology_template() {
-      return topology_template;
-  }
-
-public void setTopology_template(TopologyTemplate topology_template) {
-  this.topology_template = topology_template;
-}
-
-public Map<String, Plan> getPlans() {
-  return plans;
-}
-
-public void setPlans(Map<String, Plan> plans) {
-  if (plans != null) {
-    this.plans = plans;
-  }
-  }
-
-  public void setTosca_definitions_version(String tosca_definitions_version) {
-      if (tosca_definitions_version != null) {
-          this.tosca_definitions_version = tosca_definitions_version;
-      }
-  }
-
-  public String getTosca_definitions_version() {
-      return this.tosca_definitions_version;
-  }
-
-//  public void setTosca_default_namespace(String tosca_default_namespace) {
-//      if (tosca_default_namespace != null) {
-//          this.tosca_default_namespace = tosca_default_namespace;
-//      }
-//  }
-//
-//  public String getTosca_default_namespace() {
-//      return this.tosca_default_namespace;
-//  }
-
-  public void setTemplate_name(String template_name) {
-      if (template_name != null) {
-          this.template_name = template_name;
-      }
-  }
-
-  public String getTemplate_name() {
-      return this.template_name;
-  }
-
-  public void setTemplate_author(String template_author) {
-      if (template_author != null) {
-          this.template_author = template_author;
-      }
-  }
-
-  public String getTemplate_author() {
-      return this.template_author;
-  }
-
-  public void setTemplate_version(String template_version) {
-      if (template_version != null) {
-          this.template_version = template_version;
-      }
-  }
-
-  public String getTemplate_version() {
-      return this.template_version;
-  }
-
-  public void setImports(List<String> imports) {
-      if (imports != null) {
-          this.imports = imports;
-      }
-  }
-
-  public List<String> getImports() {
-      return this.imports;
-  }
-
-  public void setNode_types(Map<String, NodeType> node_types) {
-      if (node_types != null) {
-          this.node_types = node_types;
-      }
-  }
-
-  public Map<String, NodeType> getNode_types() {
-      return this.node_types;
-  }
-
-  public void setCapability_types(Map<String, CapabilityType> capability_types) {
-      if (capability_types != null) {
-          this.capability_types = capability_types;
-      }
-  }
-
-  public Map<String, CapabilityType> getCapability_types() {
-      return this.capability_types;
-  }
-
-  public void setRelationship_types(Map<String, RelationshipType> relationship_types) {
-      if (relationship_types != null) {
-          this.relationship_types = relationship_types;
-      }
-  }
-
-  public Map<String, RelationshipType> getRelationship_types() {
-      return this.relationship_types;
-  }
-
-  public void setArtifact_types(Map<String, ArtifactType> artifact_types) {
-      if (artifact_types != null) {
-          this.artifact_types = artifact_types;
-      }
-  }
-
-  public Map<String, ArtifactType> getArtifact_types() {
-      return this.artifact_types;
-  }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/SubstitutionMapping.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/SubstitutionMapping.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author 10090474
+ *
+ */
+
+public class SubstitutionMapping {
+  private String node_type;
+  private Map<String, String[]> requirements = new HashMap<>();
+  private Map<String, String[]> capabilities = new HashMap<>();
+  
+  public String getNode_type() {
+    return node_type;
+  }
+  
+  public void setNode_type(String node_type) {
+    this.node_type = node_type;
+  }
+  
+  public Map<String, String[]> getRequirements() {
+    return requirements;
+  }
+  
+  public void setRequirements(Map<String, String[]> requirements) {
+    if (requirements != null && requirements.isEmpty()) {
+      return;
+    }
+    this.requirements = requirements;
+  }
+  
+  public Map<String, String[]> getCapabilities() {
+    return capabilities;
+  }
+  
+  public void setCapabilities(Map<String, String[]> capabilities) {
+    if (capabilities != null && capabilities.isEmpty()) {
+      return;
+    }
+    this.capabilities = capabilities;
+  }
+
+
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/SubstitutionMapping.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/SubstitutionMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,45 +18,20 @@ package org.eclipse.winery.model.tosca.yaml;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- * @author 10090474
+ *  
+ * @author Huabing Zhao
  *
  */
-
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class SubstitutionMapping {
   private String node_type;
   private Map<String, String[]> requirements = new HashMap<>();
   private Map<String, String[]> capabilities = new HashMap<>();
-  
-  public String getNode_type() {
-    return node_type;
-  }
-  
-  public void setNode_type(String node_type) {
-    this.node_type = node_type;
-  }
-  
-  public Map<String, String[]> getRequirements() {
-    return requirements;
-  }
-  
-  public void setRequirements(Map<String, String[]> requirements) {
-    if (requirements != null && requirements.isEmpty()) {
-      return;
-    }
-    this.requirements = requirements;
-  }
-  
-  public Map<String, String[]> getCapabilities() {
-    return capabilities;
-  }
-  
-  public void setCapabilities(Map<String, String[]> capabilities) {
-    if (capabilities != null && capabilities.isEmpty()) {
-      return;
-    }
-    this.capabilities = capabilities;
-  }
-
-
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TopologyTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TopologyTemplate.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TopologyTemplate extends YAMLElement {
+    private Map<String, Input> inputs = new HashMap<String, Input>();
+    private Map<String, NodeTemplate> node_templates = new HashMap<String, NodeTemplate>();
+    private Map<String, Object> relationship_templates = new HashMap<>();
+    private Map<String, Group> groups = new HashMap<String, Group>();
+    private List<Map<String, Policy>> policies = new ArrayList<>();
+    private Map<String, Output> outputs = new HashMap<String, Output>();
+    private SubstitutionMapping substitution_mappings;
+
+
+    public void setInputs(Map<String, Input> inputs) {
+        if (inputs != null) {
+            this.inputs = inputs;
+        }
+    }
+
+    public Map<String, Input> getInputs() {
+        return this.inputs;
+    }
+
+    public void setNode_templates(Map<String, NodeTemplate> node_templates) {
+        if (node_templates != null) {
+            this.node_templates = node_templates;
+        }
+    }
+
+    public Map<String, NodeTemplate> getNode_templates() {
+        return this.node_templates;
+    }
+
+    public Map<String, Object> getRelationship_templates() {
+        return relationship_templates;
+    }
+
+    public void setRelationship_templates(
+            Map<String, Object> relationship_templates) {
+        this.relationship_templates = relationship_templates;
+    }
+
+    public void setGroups(Map<String, Group> groups) {
+        if (groups != null) {
+            this.groups = groups;
+        }
+    }
+
+    public Map<String, Group> getGroups() {
+        return this.groups;
+    }
+
+    public List<Map<String, Policy>> getPolicies() {
+      return policies;
+    }
+
+    public void setPolicies(List<Map<String, Policy>> policies) {
+      this.policies = policies;
+    }
+
+    public void setOutputs(Map<String, Output> outputs) {
+        if (outputs != null) {
+            this.outputs = outputs;
+        }
+    }
+
+    public Map<String, Output> getOutputs() {
+        return this.outputs;
+    }
+
+    public SubstitutionMapping getSubstitution_mappings() {
+      return substitution_mappings;
+    }
+
+    public void setSubstitution_mappings(SubstitutionMapping substitution_mappings) {
+      this.substitution_mappings = substitution_mappings;
+    }
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TopologyTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TopologyTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 ZTE Corporation.
+ * Copyright 2016 ZTE Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class TopologyTemplate extends YAMLElement {
     private Map<String, Input> inputs = new HashMap<String, Input>();
     private Map<String, NodeTemplate> node_templates = new HashMap<String, NodeTemplate>();
@@ -28,70 +40,4 @@ public class TopologyTemplate extends YAMLElement {
     private List<Map<String, Policy>> policies = new ArrayList<>();
     private Map<String, Output> outputs = new HashMap<String, Output>();
     private SubstitutionMapping substitution_mappings;
-
-
-    public void setInputs(Map<String, Input> inputs) {
-        if (inputs != null) {
-            this.inputs = inputs;
-        }
-    }
-
-    public Map<String, Input> getInputs() {
-        return this.inputs;
-    }
-
-    public void setNode_templates(Map<String, NodeTemplate> node_templates) {
-        if (node_templates != null) {
-            this.node_templates = node_templates;
-        }
-    }
-
-    public Map<String, NodeTemplate> getNode_templates() {
-        return this.node_templates;
-    }
-
-    public Map<String, Object> getRelationship_templates() {
-        return relationship_templates;
-    }
-
-    public void setRelationship_templates(
-            Map<String, Object> relationship_templates) {
-        this.relationship_templates = relationship_templates;
-    }
-
-    public void setGroups(Map<String, Group> groups) {
-        if (groups != null) {
-            this.groups = groups;
-        }
-    }
-
-    public Map<String, Group> getGroups() {
-        return this.groups;
-    }
-
-    public List<Map<String, Policy>> getPolicies() {
-      return policies;
-    }
-
-    public void setPolicies(List<Map<String, Policy>> policies) {
-      this.policies = policies;
-    }
-
-    public void setOutputs(Map<String, Output> outputs) {
-        if (outputs != null) {
-            this.outputs = outputs;
-        }
-    }
-
-    public Map<String, Output> getOutputs() {
-        return this.outputs;
-    }
-
-    public SubstitutionMapping getSubstitution_mappings() {
-      return substitution_mappings;
-    }
-
-    public void setSubstitution_mappings(SubstitutionMapping substitution_mappings) {
-      this.substitution_mappings = substitution_mappings;
-    }
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/YAMLElement.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/YAMLElement.java
@@ -1,36 +1,32 @@
 /**
- * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ * Copyright 2016 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.eclipse.winery.model.tosca.yaml;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *  
+ * @author Huabing Zhao
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public abstract class YAMLElement {
-
 	private String description = "";
-
-	public void setDescription(String description) {
-		if (description != null) {
-			this.description = description;
-		}
-	}
-
-	public String getDescription() {
-		return this.description;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-
-		YAMLElement element = (YAMLElement) o;
-
-		if (!description.equals(element.description)) return false;
-
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		return description.hashCode();
-	}
 }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/YAMLElement.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/YAMLElement.java
@@ -1,0 +1,36 @@
+/**
+ * This file is fork from https://github.com/CloudCycle2/YAML_Transformer,which is licensed under Apache 2.0
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+public abstract class YAMLElement {
+
+	private String description = "";
+
+	public void setDescription(String description) {
+		if (description != null) {
+			this.description = description;
+		}
+	}
+
+	public String getDescription() {
+		return this.description;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		YAMLElement element = (YAMLElement) o;
+
+		if (!description.equals(element.description)) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return description.hashCode();
+	}
+}

--- a/org.eclipse.winery.model.tosca.yaml/src/test/java/org/eclipse/winery/model/tosca/yaml/ArtifactDefinitionTest.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/test/java/org/eclipse/winery/model/tosca/yaml/ArtifactDefinitionTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 ZTE Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.winery.model.tosca.yaml;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author Huabing Zhao
+ *
+ */
+public class ArtifactDefinitionTest {
+
+  @Test
+  public void testArtifactDefinition() {
+    final String deploy_path = "test_deploy_path";
+    final String description = "test_description";
+    final String file = "test_file";
+    final String repository = "test_repository";
+    final String type = "test_type";
+    
+    ArtifactDefinition artifactDefinition = new ArtifactDefinition();
+    artifactDefinition.setDeploy_path(deploy_path);
+    assertEquals(artifactDefinition.getDeploy_path(), "test_deploy_path");
+    
+    artifactDefinition.setDescription(description);
+    assertEquals(artifactDefinition.getDescription(), "test_description");
+    
+    artifactDefinition.setFile(file);
+    assertEquals(artifactDefinition.getFile(), "test_file");
+    
+    artifactDefinition.setRepository(repository);
+    assertEquals(artifactDefinition.getRepository(), "test_repository");
+    
+    artifactDefinition.setType(type);
+    assertEquals(artifactDefinition.getType(), "test_type");
+    
+    assertEquals(artifactDefinition, artifactDefinition);
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 		<module>org.eclipse.winery.model.csar.toscametafile</module>
 		<module>org.eclipse.winery.model.selfservice</module>
 		<module>org.eclipse.winery.model.tosca</module>
+		<module>org.eclipse.winery.model.tosca.yaml</module>
 	</modules>
 	<build>
 		<plugins>


### PR DESCRIPTION
Signed-off-by: HuabingZhao <zhao.huabing@zte.com.cn>

<!-- describe the changes you have made here: what, why, ... -->
What: add a YAML model to support service template in TOSCA simple YAML
Why:  TOSCA simple profile for YAML is widely adopted and supported, and OASIS TOSCA TC mainly works on simple YAML profile rather than XML currently, so it's time to consider YAML support in Winery.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
