### PR TITLE
Git4toscaimprovements

### DIFF
--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/RepositoryFileReference.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/RepositoryFileReference.java
@@ -79,6 +79,6 @@ public class RepositoryFileReference implements Comparable<RepositoryFileReferen
 
 	@Override
 	public String toString() {
-		return this.getParent().toString() + "/" + this.getFileName();
+		return this.getParent().toString() + " / " + this.getFileName();
 	}
 }

--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ids/GenericId.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ids/GenericId.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.winery.common.ids;
 
+import org.eclipse.winery.common.Util;
+
 /**
  * Superclass for all IDs appearing in Winery. These are:
  * <ul>
@@ -51,6 +53,7 @@ public abstract class GenericId implements Comparable<GenericId> {
 
 	@Override
 	public String toString() {
-		return this.getClass().toString() + " / " + this.getXmlId().toString();
+		String idName = Util.getEverythingBetweenTheLastDotAndBeforeId(this.getClass());
+		return idName + " / " + this.getXmlId().toString();
 	}
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
@@ -12,7 +12,11 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
-import org.eclipse.jgit.api.*;
+import org.eclipse.jgit.api.AddCommand;
+import org.eclipse.jgit.api.CleanCommand;
+import org.eclipse.jgit.api.CommitCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.ResetCommand.ResetType;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.NoWorkTreeException;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
@@ -89,11 +89,13 @@ public class GitBasedRepository extends FilebasedRepository {
 	 */
 	public void addCommit(RepositoryFileReference ref) throws GitAPIException {
 		synchronized (COMMIT_LOCK) {
-			String message = "Files changed externally.";
-			if (ref != null) {
-				message = ref.toString() + " was updated";
-			}
-			addCommit(message);
+			String message;
+            if (ref == null) {
+                message = "Files changed externally.";
+            } else {
+                message = ref.toString() + " was updated";
+            }
+            addCommit(message);
 		}
 	}
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/admin/RepositoryAdminResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/admin/RepositoryAdminResource.java
@@ -67,7 +67,7 @@ public class RepositoryAdminResource {
 			return Response.noContent().build();
 		} else if (commit != null) {
 			try {
-				((GitBasedRepository) Prefs.INSTANCE.getRepository()).addCommit(null);
+				((GitBasedRepository) Prefs.INSTANCE.getRepository()).addCommit("Files changed externally");
 			} catch (Exception e) {
 				Response res;
 				res = Response.serverError().entity(e.getMessage()).build();

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/admin/RepositoryAdminResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/admin/RepositoryAdminResource.java
@@ -67,7 +67,7 @@ public class RepositoryAdminResource {
 			return Response.noContent().build();
 		} else if (commit != null) {
 			try {
-				((GitBasedRepository) Prefs.INSTANCE.getRepository()).addCommit();
+				((GitBasedRepository) Prefs.INSTANCE.getRepository()).addCommit(null);
 			} catch (Exception e) {
 				Response res;
 				res = Response.serverError().entity(e.getMessage()).build();


### PR DESCRIPTION
Contains the same changes as #39 but without the first commit, which was previously merged.

Because of this weird behavior we decided to reopen the pull request with a new branch.

Copy from old PR:
``Changed commit message for GitBasedRepository. File name and type of the file (servicetemplate, artifacttemplate, etc). Furthermore, the format of GenericId.toString() was changed, for better readability.``