### PR TITLE
Added backend support for Git in Artifacts

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/GitInfo.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/GitInfo.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2013 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v10.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors:
+ *     Armin Hüneburg - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.winery.repository;
+
+/**
+ * Class for handling information of Git repositories.
+ */
+public class GitInfo {
+	/**
+	 * The URL of the git repository
+	 */
+	public final String URL;
+	/**
+	 * The branch or tag that should be pulled from the repository
+	 */
+	public final String BRANCH;
+
+	/**
+	 * Constructs a new pair of values.
+	 * @param url The URL of the git repository
+	 * @param branch The branch or tag that should be pulled from the repository
+	 */
+	GitInfo(String url, String branch) {
+		this.URL = url;
+		this.BRANCH = branch;
+	}
+}

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Utils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Utils.java
@@ -980,10 +980,9 @@ public class Utils {
 			Unmarshaller u = JAXBSupport.createUnmarshaller();
 			Definitions defs = ((Definitions) u.unmarshal(is));
 			for (TExtensibleElements elem : defs.getServiceTemplateOrNodeTypeOrNodeTypeImplementation()) {
-				if (!(elem instanceof TArtifactTemplate)) {
-					continue;
+				if (elem instanceof TArtifactTemplate) {
+					return (TArtifactTemplate) elem;
 				}
-				return (TArtifactTemplate) elem;
 			}
 		} catch (IOException e) {
 			Utils.LOGGER.error("Error reading definitions of " + directoryId.getParent() + " at " + ref.getFileName(), e);

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Utils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Utils.java
@@ -11,75 +11,6 @@
  *******************************************************************************/
 package org.eclipse.winery.repository;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.Response.Status.Family;
-import javax.ws.rs.core.StreamingOutput;
-import javax.ws.rs.core.UriInfo;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.namespace.QName;
-
-import org.eclipse.winery.common.RepositoryFileReference;
-import org.eclipse.winery.common.Util;
-import org.eclipse.winery.common.constants.MimeTypes;
-import org.eclipse.winery.common.ids.GenericId;
-import org.eclipse.winery.common.ids.Namespace;
-import org.eclipse.winery.common.ids.XMLId;
-import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
-import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
-import org.eclipse.winery.common.ids.definitions.TOSCAComponentId;
-import org.eclipse.winery.common.ids.definitions.imports.XSDImportId;
-import org.eclipse.winery.model.tosca.Definitions;
-import org.eclipse.winery.model.tosca.TArtifactType;
-import org.eclipse.winery.model.tosca.TConstraint;
-import org.eclipse.winery.model.tosca.TEntityTemplate;
-import org.eclipse.winery.model.tosca.TEntityType;
-import org.eclipse.winery.model.tosca.TExtensibleElements;
-import org.eclipse.winery.model.tosca.TNodeTemplate;
-import org.eclipse.winery.model.tosca.TNodeType;
-import org.eclipse.winery.model.tosca.TPolicyType;
-import org.eclipse.winery.model.tosca.TRelationshipType;
-import org.eclipse.winery.model.tosca.TServiceTemplate;
-import org.eclipse.winery.model.tosca.TTag;
-import org.eclipse.winery.repository.backend.BackendUtils;
-import org.eclipse.winery.repository.backend.Repository;
-import org.eclipse.winery.repository.datatypes.ids.admin.AdminId;
-import org.eclipse.winery.repository.export.CSARExporter;
-import org.eclipse.winery.repository.export.TOSCAExportUtil;
-import org.eclipse.winery.repository.resources.AbstractComponentInstanceResource;
-import org.eclipse.winery.repository.resources.AbstractComponentsResource;
-import org.eclipse.winery.repository.resources.entitytemplates.artifacttemplates.ArtifactTemplateResource;
-import org.eclipse.winery.repository.resources.entitytemplates.artifacttemplates.ArtifactTemplatesResource;
-import org.eclipse.winery.repository.resources.entitytypes.nodetypes.NodeTypeResource;
-import org.eclipse.winery.repository.resources.entitytypes.nodetypes.NodeTypesResource;
-import org.eclipse.winery.repository.resources.entitytypes.relationshiptypes.RelationshipTypeResource;
-import org.eclipse.winery.repository.resources.entitytypes.relationshiptypes.RelationshipTypesResource;
-import org.eclipse.winery.repository.resources.imports.xsdimports.XSDImportResource;
-import org.eclipse.winery.repository.resources.servicetemplates.ServiceTemplateResource;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -94,9 +25,83 @@ import org.apache.tika.detect.Detector;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.xerces.xs.XSConstants;
+import org.eclipse.winery.common.RepositoryFileReference;
+import org.eclipse.winery.common.Util;
+import org.eclipse.winery.common.constants.MimeTypes;
+import org.eclipse.winery.common.constants.Namespaces;
+import org.eclipse.winery.common.ids.GenericId;
+import org.eclipse.winery.common.ids.Namespace;
+import org.eclipse.winery.common.ids.XMLId;
+import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
+import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
+import org.eclipse.winery.common.ids.definitions.TOSCAComponentId;
+import org.eclipse.winery.common.ids.definitions.imports.XSDImportId;
+import org.eclipse.winery.model.tosca.Definitions;
+import org.eclipse.winery.model.tosca.TArtifactTemplate;
+import org.eclipse.winery.model.tosca.TArtifactType;
+import org.eclipse.winery.model.tosca.TConstraint;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TEntityType;
+import org.eclipse.winery.model.tosca.TExtensibleElements;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TPolicyType;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.model.tosca.TTag;
+import org.eclipse.winery.repository.backend.BackendUtils;
+import org.eclipse.winery.repository.backend.Repository;
+import org.eclipse.winery.repository.datatypes.ids.admin.AdminId;
+import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateDirectoryId;
+import org.eclipse.winery.repository.export.CSARExporter;
+import org.eclipse.winery.repository.export.TOSCAExportUtil;
+import org.eclipse.winery.repository.resources.AbstractComponentInstanceResource;
+import org.eclipse.winery.repository.resources.AbstractComponentsResource;
+import org.eclipse.winery.repository.resources.entitytemplates.artifacttemplates.ArtifactTemplateResource;
+import org.eclipse.winery.repository.resources.entitytemplates.artifacttemplates.ArtifactTemplatesResource;
+import org.eclipse.winery.repository.resources.entitytypes.nodetypes.NodeTypeResource;
+import org.eclipse.winery.repository.resources.entitytypes.nodetypes.NodeTypesResource;
+import org.eclipse.winery.repository.resources.entitytypes.relationshiptypes.RelationshipTypeResource;
+import org.eclipse.winery.repository.resources.entitytypes.relationshiptypes.RelationshipTypesResource;
+import org.eclipse.winery.repository.resources.imports.xsdimports.XSDImportResource;
+import org.eclipse.winery.repository.resources.servicetemplates.ServiceTemplateResource;
 import org.slf4j.ext.XLogger;
 import org.slf4j.ext.XLoggerFactory;
 import org.w3c.dom.Element;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.Response.Status.Family;
+import javax.ws.rs.core.StreamingOutput;
+import javax.ws.rs.core.UriInfo;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Contains utility functionality concerning with everything that is
@@ -787,6 +792,38 @@ public class Utils {
 		return res;
 	}
 
+	/**
+	 *
+	 * @param directoryId ArtifactTemplateDirectoryId of the ArtifactTemplate that should contain a reference to a git repository.
+	 * @return The URL and the branch/tag that contains the files for the ArtifactTemplate. null if no git information is given.
+	 */
+	public static GitInfo getGitInformation(ArtifactTemplateDirectoryId directoryId) {
+		if (!(directoryId.getParent() instanceof ArtifactTemplateId)) {
+			return null;
+		}
+		RepositoryFileReference ref = BackendUtils.getRefOfDefinitions((ArtifactTemplateId)directoryId.getParent());
+		try (InputStream is = Repository.INSTANCE.newInputStream(ref)) {
+			Unmarshaller u = JAXBSupport.createUnmarshaller();
+			Definitions defs = ((Definitions) u.unmarshal(is));
+			Map<QName, String> atts = defs.getOtherAttributes();
+			String src = atts.get(new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "gitsrc"));
+			String branch = atts.get(new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "gitbranch"));
+			// ^ is the XOR operator
+			if (src == null ^ branch == null) {
+				Utils.LOGGER.error("Git information not complete, URL or branch missing");
+				return null;
+			} else if (src == null && branch == null) {
+				return null;
+			}
+			return new GitInfo(src, branch);
+		} catch (IOException e) {
+			Utils.LOGGER.error("Error reading definitions of " + directoryId.getParent() + " at " + ref.getFileName(), e);
+		} catch (JAXBException e) {
+			Utils.LOGGER.error("Error in XML in " + ref.getFileName(), e);
+		}
+		return null;
+	}
+
 	public static Set<String> clean(Set<String> set) {
 		Set<String> newSet = new HashSet<String>();
 
@@ -930,6 +967,62 @@ public class Utils {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 *
+	 * @param directoryId DirectoryID of the TArtifactTemplate that should be returned.
+	 * @return The TArtifactTemplate corresponding to the directoryId.
+	 */
+	public static TArtifactTemplate getTArtifactTemplate(ArtifactTemplateDirectoryId directoryId) {
+		RepositoryFileReference ref = BackendUtils.getRefOfDefinitions((ArtifactTemplateId)directoryId.getParent());
+		try (InputStream is = Repository.INSTANCE.newInputStream(ref)) {
+			Unmarshaller u = JAXBSupport.createUnmarshaller();
+			Definitions defs = ((Definitions) u.unmarshal(is));
+			for (TExtensibleElements elem : defs.getServiceTemplateOrNodeTypeOrNodeTypeImplementation()) {
+				if (!(elem instanceof TArtifactTemplate)) {
+					continue;
+				}
+				return (TArtifactTemplate) elem;
+			}
+		} catch (IOException e) {
+			Utils.LOGGER.error("Error reading definitions of " + directoryId.getParent() + " at " + ref.getFileName(), e);
+		} catch (JAXBException e) {
+			Utils.LOGGER.error("Error in XML in " + ref.getFileName(), e);
+		}
+		return null;
+	}
+
+	/**
+	 * Tests if a path matches a glob pattern. {@see <a href="https://en.wikipedia.org/wiki/Glob_(programming)">Wikipedia</a>}
+	 * @param glob Glob pattern to test the path against.
+	 * @param path Path that should match the glob pattern.
+	 * @return Whether the glob and the path result in a match.
+	 */
+	public static boolean isGlobMatch(String glob, Path path) {
+		PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + glob);
+		return matcher.matches(path);
+	}
+
+	public static class GitInfo {
+		/**
+		 * The URL of the git repository
+		 */
+		public final String URL;
+		/**
+		 * The branch or tag that should be pulled from the repository
+		 */
+		public final String BRANCH;
+
+		/**
+		 * Constructs a new pair of values.
+		 * @param url The URL of the git repository
+		 * @param branch The branch or tag that should be pulled from the repository
+		 */
+		GitInfo(String url, String branch) {
+			this.URL = url;
+			this.BRANCH = branch;
+		}
 	}
 
 	public static boolean injectArtifactTemplateIntoDeploymentArtifact(ServiceTemplateId serviceTemplate, String nodeTemplateId, String deploymentArtifactId, ArtifactTemplateId artifactTemplate) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
@@ -12,6 +12,14 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.winery.common.RepositoryFileReference;
+
 import org.eclipse.jgit.api.AddCommand;
 import org.eclipse.jgit.api.CleanCommand;
 import org.eclipse.jgit.api.CommitCommand;
@@ -22,14 +30,9 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.NoWorkTreeException;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-import org.eclipse.winery.common.RepositoryFileReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.MediaType;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * Allows to reset repository to a certain commit id

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/CSARExporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/CSARExporter.java
@@ -13,25 +13,16 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.export;
 
-import java.io.*;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.winery.common.RepositoryFileReference;
@@ -55,20 +46,32 @@ import org.eclipse.winery.repository.datatypes.ids.elements.SelfServiceMetaDataI
 import org.eclipse.winery.repository.resources.admin.NamespacesResource;
 import org.eclipse.winery.repository.resources.servicetemplates.ServiceTemplateResource;
 import org.eclipse.winery.repository.resources.servicetemplates.selfserviceportal.SelfServicePortalResource;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.compress.archivers.ArchiveEntry;
-import org.apache.commons.compress.archivers.ArchiveException;
-import org.apache.commons.compress.archivers.ArchiveOutputStream;
-import org.apache.commons.compress.archivers.ArchiveStreamFactory;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class exports a CSAR crawling from the the given GenericId<br/>


### PR DESCRIPTION
ImplementationArtifacts can now have an associated Git repo that provides the files.
The repo is cloned and traversed.
The URL and branch are specified with the namespace "http://www.opentosca.org/winery/extensions/tosca/2013/02/12" and the properties "gitsrc" and "gitbranch".
gitbranch can also be a tag or release.
The current version does not include any form of authentication towards the Git server.
ArtifactReferences can be used to include or exclude files.
If no include statement is found, everything is included by default, except explicitly excluded.
If a file is included as well as excluded, it will be excluded.