### PR TITLE
Add test for empty list of node type implementations

### DIFF
--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/AbstractResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/AbstractResourceTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractResourceTest {
 				.ifValidationFails();
 	}
 
-	private String callURL(String restURL) {
+	protected String callURL(String restURL) {
 		return PREFIX + Util.URLdecode(restURL);
 	}
 

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
@@ -61,4 +61,13 @@ public class NodeTypeResourceTest extends AbstractResourceTest {
 		this.assertGetSize("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/implementations", 0);
 	}
 
+	@Test
+	public void baboabHasNoImage() throws Exception {
+		this.setRevisionTo("5b5ad1106a3a428020b6bc5d2f154841acb5f779");
+		start()
+				.get(callURL("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/visualappearance/50x50"))
+				.then()
+				.statusCode(404);
+	}
+
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
@@ -55,4 +55,10 @@ public class NodeTypeResourceTest extends AbstractResourceTest {
 		this.assertNotFound("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/");
 	}
 
+	@Test
+	public void baboabHasNoImplementations() throws Exception {
+		this.setRevisionTo("5b5ad1106a3a428020b6bc5d2f154841acb5f779");
+		this.assertGetSize("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/implementations", 0);
+	}
+
 }


### PR DESCRIPTION
Add one more test. This should trigger CodeCov.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=514157#c1 for a discussion of CodeCov enablement.