### PR TITLE
Small improvements of the splitting functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ We refer to [GitHub issues](https://github.com/eclipse/winery/issues) by using `
 
 ### Fixed
 * Bounary definitions can be browsed for exported operations again
+* 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,3 @@ We refer to [GitHub issues](https://github.com/eclipse/winery/issues) by using `
 
 ### Fixed
 * Bounary definitions can be browsed for exported operations again
-* 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
@@ -727,6 +727,10 @@ public class BackendUtils {
 		nodeTemplateClone.setProperties(nodeTemplate.getProperties());
 		nodeTemplateClone.setPropertyConstraints(nodeTemplate.getPropertyConstraints());
 
+		if (ModelUtilities.getTargetLabel(nodeTemplate).isPresent()) {
+			ModelUtilities.setTargetLabel(nodeTemplateClone, ModelUtilities.getTargetLabel(nodeTemplate).get());
+		}
+
 		return nodeTemplateClone;
 	}
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplateResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplateResource.java
@@ -228,7 +228,6 @@ public class ServiceTemplateResource extends AbstractComponentInstanceWithRefere
 			}
 		}
 		TTopologyTemplate tTopologyTemplate = splitting.injectNodeTemplates(this.getServiceTemplate().getTopologyTemplate(), injectorReplaceData.injections);
-		this.getServiceTemplate().setTopologyTemplate(null);
 		this.getServiceTemplate().setTopologyTemplate(tTopologyTemplate);
 		LOGGER.debug("Persisting...");
 		this.persist();
@@ -237,7 +236,7 @@ public class ServiceTemplateResource extends AbstractComponentInstanceWithRefere
 		//No renaming of the Service Template allowed because of the plans
 
 		URI url = uriInfo.getBaseUri().resolve(Utils.getAbsoluteURL(id));
-		LOGGER.debug("URI of the old and new ServiceTemplate: " + url.toString());
+		LOGGER.debug("URI of the old and new service template {}", url.toString());
 		return Response.created(url).build();
 	}
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/ProviderRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/ProviderRepository.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
 
+import org.eclipse.winery.common.ModelUtilities;
 import org.eclipse.winery.common.ids.definitions.RequirementTypeId;
 import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
@@ -55,9 +56,15 @@ public class ProviderRepository {
 				// get all contained node templates
 				.flatMap(id -> {
 					ServiceTemplateResource serviceTemplateResource = (ServiceTemplateResource) AbstractComponentsResource.getComponentInstaceResource(id);
-					return serviceTemplateResource.getServiceTemplate().getTopologyTemplate().getNodeTemplateOrRelationshipTemplate().stream()
+					List<TNodeTemplate> matchedNodeTemplates = serviceTemplateResource.getServiceTemplate().getTopologyTemplate().getNodeTemplateOrRelationshipTemplate().stream()
 							.filter(t -> t instanceof TNodeTemplate)
-							.map(TNodeTemplate.class::cast);
+							.map(TNodeTemplate.class::cast)
+							.collect(Collectors.toList());
+
+					matchedNodeTemplates.stream().forEach(t -> ModelUtilities.setTargetLabel(t, id.getNamespace().getDecoded().replace(NS_NAME_START, "")));
+
+					return matchedNodeTemplates.stream();
+
 				})
 				.collect(Collectors.toList());
 	}

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
@@ -124,7 +124,7 @@ public class Splitting {
 			if (!transitiveAndDirectSuccessors.get(node).isEmpty()) {
 				for (TNodeTemplate successor : transitiveAndDirectSuccessors.get(node)) {
 					if (ModelUtilities.getTargetLabel(successor).isPresent() && ModelUtilities.getTargetLabel(node).isPresent()
-						&& !ModelUtilities.getTargetLabel(node).get().toLowerCase().equals(ModelUtilities.getTargetLabel(successor).get().toLowerCase())) {
+						&& !ModelUtilities.getTargetLabel(node).get().equalsIgnoreCase(ModelUtilities.getTargetLabel(successor).get())) {
 							return false;
 					}
 				}
@@ -200,8 +200,8 @@ public class Splitting {
 							 * The origin relationships are duplicated
 							*/
 							if (sourceElementIncommingRel instanceof TNodeTemplate
-									&& ((ModelUtilities.getTargetLabel((TNodeTemplate) sourceElementIncommingRel).get().toLowerCase()
-									.equals(ModelUtilities.getTargetLabel(duplicatedNode).get().toLowerCase())
+									&& ((ModelUtilities.getTargetLabel((TNodeTemplate) sourceElementIncommingRel).get()
+									.equalsIgnoreCase(ModelUtilities.getTargetLabel(duplicatedNode).get())
 									&& incomingRelationship.getType().getLocalPart().toLowerCase().contains("hostedon"))
 									|| !predecessors.contains(sourceElementIncommingRel))) {
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
@@ -124,7 +124,7 @@ public class Splitting {
 			if (!transitiveAndDirectSuccessors.get(node).isEmpty()) {
 				for (TNodeTemplate successor : transitiveAndDirectSuccessors.get(node)) {
 					if (ModelUtilities.getTargetLabel(successor).isPresent() && ModelUtilities.getTargetLabel(node).isPresent()
-						&& !ModelUtilities.getTargetLabel(node).equals(ModelUtilities.getTargetLabel(successor))) {
+						&& !ModelUtilities.getTargetLabel(node).get().toLowerCase().equals(ModelUtilities.getTargetLabel(successor).get().toLowerCase())) {
 							return false;
 					}
 				}
@@ -169,7 +169,7 @@ public class Splitting {
 					}
 
 					//noinspection OptionalGetWithoutIsPresent
-					predecessorsTargetLabel.add(targetLabel.get());
+					predecessorsTargetLabel.add(targetLabel.get().toLowerCase());
 				}
 				// If all predecessors have the same target label assign this label to the considered node
 				if (predecessorsTargetLabel.size() == 1) {
@@ -200,8 +200,8 @@ public class Splitting {
 							 * The origin relationships are duplicated
 							*/
 							if (sourceElementIncommingRel instanceof TNodeTemplate
-									&& ((ModelUtilities.getTargetLabel((TNodeTemplate) sourceElementIncommingRel)
-									.equals(ModelUtilities.getTargetLabel(duplicatedNode))
+									&& ((ModelUtilities.getTargetLabel((TNodeTemplate) sourceElementIncommingRel).get().toLowerCase()
+									.equals(ModelUtilities.getTargetLabel(duplicatedNode).get().toLowerCase())
 									&& incomingRelationship.getType().getLocalPart().toLowerCase().contains("hostedon"))
 									|| !predecessors.contains(sourceElementIncommingRel))) {
 
@@ -294,7 +294,6 @@ public class Splitting {
 
 				//Add compatible nodes to the injectionOptions to host the considered lowest level node
 				if (!compatibleNodeTemplates.isEmpty()) {
-					compatibleNodeTemplates.stream().forEach(n -> ModelUtilities.setTargetLabel(n,targetLabel));
 					injectionOptions.put(needHostNode.getId(), compatibleNodeTemplates);
 					nodesForWhichHostsFound.add(needHostNode);
 				}
@@ -326,7 +325,6 @@ public class Splitting {
 							.getAllNodeTemplatesForLocationAndOfferingCapability(targetLabel, predecessor.getRequirements().getRequirement());
 					//Add compatible nodes to the injectionOptions to host the considered lowest level node
 					if (!compatibleNodeTemplates.isEmpty()) {
-						compatibleNodeTemplates.stream().forEach(n -> ModelUtilities.setTargetLabel(n, targetLabel));
 						injectionOptions.put(predecessor.getId(), compatibleNodeTemplates);
 						nodesForWhichHostsFound.add(predecessor);
 					}
@@ -419,16 +417,24 @@ public class Splitting {
 			originHostSuccessors.clear();
 			originHostSuccessors = getHostedOnSuccessorsOfNodeTemplate(topologyTemplate, predecessorOfNewHost);
 			TNodeTemplate newMatchingNodeTemplate;
+			TNodeTemplate newHostNodeTemplate = injectNodes.get(predecessorOfNewHostId);
+
+			boolean matchingFound = matching.stream()
+					.anyMatch(nt -> ModelUtilities.getTargetLabel(nt).get().toLowerCase()
+							.equals(ModelUtilities.getTargetLabel(newHostNodeTemplate).get().toLowerCase())
+					&& nt.getId().equals(Util.makeNCName(newHostNodeTemplate.getId() + "-" + ModelUtilities.getTargetLabel(newHostNodeTemplate).get())));
 
 			//Check if the chosen replace node is already in the matching
-			if (!matching.contains(injectNodes.get(predecessorOfNewHostId))) {
+			if (!matchingFound) {
 				newMatchingNodeTemplate = injectNodes.get(predecessorOfNewHostId);
-				newMatchingNodeTemplate.setId(Util.makeNCName(newMatchingNodeTemplate.getId() + "-" + ModelUtilities.getTargetLabel(predecessorOfNewHost).get()));
-				newMatchingNodeTemplate.setName(Util.makeNCName(newMatchingNodeTemplate.getId() + "-" + ModelUtilities.getTargetLabel(predecessorOfNewHost).get()));
+				newMatchingNodeTemplate.setId(Util.makeNCName(newMatchingNodeTemplate.getId() + "-" + ModelUtilities.getTargetLabel(newMatchingNodeTemplate).get()));
+				newMatchingNodeTemplate.setName(Util.makeNCName(newMatchingNodeTemplate.getName() + "-" + ModelUtilities.getTargetLabel(newMatchingNodeTemplate).get()));
 				topologyTemplate.getNodeTemplateOrRelationshipTemplate().add(newMatchingNodeTemplate);
 				matching.add(newMatchingNodeTemplate);
 			} else {
-				newMatchingNodeTemplate = matching.stream().filter(nt -> injectNodes.get(predecessorOfNewHostId).equals(nt)).findAny().get();
+				newMatchingNodeTemplate = matching.stream().filter(nt -> ModelUtilities.getTargetLabel(nt).get().toLowerCase()
+						.equals(ModelUtilities.getTargetLabel(newHostNodeTemplate).get().toLowerCase())
+						&& nt.getId().equals(Util.makeNCName(newHostNodeTemplate.getId() + "-" + ModelUtilities.getTargetLabel(newHostNodeTemplate).get()))).findAny().get();
 			}
 
 			//In case the predecessor was a lowest node a new hostedOn relationship has to be added

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/web.xml
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/web.xml
@@ -27,6 +27,10 @@
 			<param-value>GET,PUT,POST,DELETE,HEAD,OPTIONS</param-value>
 		</init-param>
 		<init-param>
+			<param-name>cors.exposed.headers</param-name>
+			<param-value>Location, Access-Control-Allow-Origin</param-value>
+		</init-param>
+		<init-param>
 			<param-name>cors.preflight.maxage</param-name>
 			<param-value>10</param-value>
 		</init-param>


### PR DESCRIPTION
Improvements are done to fix small bugs and to improve the functionality itself.
The following things were done:
- Fixed that by calling injectNodeTemplates by a http call the injected topology is not renaming because attached plans can't deal with renaming.
- If a Node Template provided by the provider repository is added to a topology for matching the name of the provider repository is added as target label to the Node Template. This improves the tracebility. 
- Removed the case sensitive handling of target labels. Thus, the case does not influence the execution of the algorithms.
- Added the target label to a cloned Node Template if it is present, so that no information added to a Node Template is lost by cloning it.
- improve the communication with clients by exposing headers like Location and Access-Control-Allow-Origin. Thus, the location header can be accessed by the client.


Signed-off-by: Karoline Saatkamp <karoline.saatkamp@iaas.uni-stuttgart.de>




- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for UI changes)
