### PR TITLE
Avoid duplicate Ids for split & merge

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
@@ -1080,10 +1080,7 @@ public class BackendUtils {
 	}
 
 	/**
-	 * Check the id's for new nodes, avoid repeating of target labels
-	 * @param duplicatedNode
-	 * @param tNodeTemplate
-	 * @param targetLabel
+	 * Check the ids for new nodes, avoid repeating of target labels
 	 */
 	public static TNodeTemplate checkId(TNodeTemplate duplicatedNode, TNodeTemplate tNodeTemplate, String targetLabel) {
 		if (tNodeTemplate.getId().contains(targetLabel)) {
@@ -1099,13 +1096,12 @@ public class BackendUtils {
 	}
 
 	/**
-	 * Fix the Ids to avoid duplicate Ids in capabilities
-	 * @param nodeTemplate
-	 * @return fixedCapabilities with fixed Ids
+	 * Fix the ids to avoid duplicate ids in capabilities
+	 * @return fixedCapabilities with fixed ids or null if the nodeTemplate has no capabilities
 	 */
 	public static TNodeTemplate.Capabilities cloneCapabilities(TNodeTemplate nodeTemplate) {
 		if (nodeTemplate.getCapabilities() == null) {
-			LOGGER.info("Capabilites are null, not cloned any capabilities for " +  nodeTemplate.getId());
+			LOGGER.debug("Capabilites are null, not cloned any capabilities for " +  nodeTemplate.getId());
 			return null;
 		}
 			TNodeTemplate.Capabilities fixedCapabilities = new TNodeTemplate.Capabilities();
@@ -1118,20 +1114,20 @@ public class BackendUtils {
 				tempCapability.setPropertyConstraints(nodeTemplate.getCapabilities().getCapability().get(i).getPropertyConstraints());
 				tempCapability.setType(nodeTemplate.getCapabilities().getCapability().get(i).getType());
 				fixedCapabilities.getCapability().add(tempCapability);
-				LOGGER.info("Cloned requirements for " + nodeTemplate.getId());
+				LOGGER.debug("Cloned requirements for " + nodeTemplate.getId());
 				idCounterCapabilities++;
 			}
 			return fixedCapabilities;
 	}
 
 	/**
-	 * Fix the Ids to avoid duplicate Ids in requirements
+	 * Fix the ids to avoid duplicate ids in requirements
 	 * @param nodeTemplate
-	 * @return fixedRequirements with fixed Ids
+	 * @return fixedRequirements with fixed ids or null if the nodeTemplate has no requirements
 	 */
 	public static TNodeTemplate.Requirements cloneRequirements(TNodeTemplate nodeTemplate) {
 		if (nodeTemplate.getRequirements() == null) {
-			LOGGER.info("Requirements are null, not cloned any requirements for " + nodeTemplate.getId());
+			LOGGER.debug("Requirements are null, not cloned any requirements for " + nodeTemplate.getId());
 			return null;
 		}
 		TNodeTemplate.Requirements fixedRequirements = new TNodeTemplate.Requirements();
@@ -1144,7 +1140,7 @@ public class BackendUtils {
 			tempRequirement.setPropertyConstraints(nodeTemplate.getRequirements().getRequirement().get(i).getPropertyConstraints());
 			tempRequirement.setType(nodeTemplate.getRequirements().getRequirement().get(i).getType());
 			fixedRequirements.getRequirement().add(tempRequirement);
-			LOGGER.info("Cloned requirements for " + nodeTemplate.getId());
+			LOGGER.debug("Cloned requirements for " + nodeTemplate.getId());
 			idCounterRequirements++;
 		}
 		return fixedRequirements;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
@@ -11,6 +11,7 @@
  *     Tino Stadelmaier, Philipp Meyer - rename for id/namespace
  *     Lukas Harzenetter, Nicole Keppler - forceDelete for Namespaces
  *     Karoline Saatkamp - clone of TTopologyTemplates, TNodeTemplate, and TRelationshipTemplates
+ *     Marvin Wohlfarth - implementation for detection of duplicate ids
  *******************************************************************************/
 package org.eclipse.winery.repository.backend;
 
@@ -65,6 +66,7 @@ import org.eclipse.winery.common.propertydefinitionkv.PropertyDefinitionKVList;
 import org.eclipse.winery.common.propertydefinitionkv.WinerysPropertiesDefinition;
 import org.eclipse.winery.model.tosca.Definitions;
 import org.eclipse.winery.model.tosca.ObjectFactory;
+import org.eclipse.winery.model.tosca.TCapability;
 import org.eclipse.winery.model.tosca.TDeploymentArtifact;
 import org.eclipse.winery.model.tosca.TDeploymentArtifacts;
 import org.eclipse.winery.model.tosca.TEntityTemplate;
@@ -75,6 +77,7 @@ import org.eclipse.winery.model.tosca.TImplementationArtifacts;
 import org.eclipse.winery.model.tosca.TImplementationArtifacts.ImplementationArtifact;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRequirement;
 import org.eclipse.winery.model.tosca.TServiceTemplate;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.repository.Constants;
@@ -120,6 +123,8 @@ import org.w3c.dom.ls.LSInput;
 public class BackendUtils {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(BackendUtils.class);
+	private static int idCounterRequirements = 0;
+	private static int idCounterCapabilities = 0;
 
 	/**
 	 * Deletes the whole namespace in the component
@@ -722,8 +727,8 @@ public class BackendUtils {
 		nodeTemplateClone.setMinInstances(nodeTemplate.getMinInstances());
 		nodeTemplateClone.setName(nodeTemplate.getName());
 		nodeTemplateClone.setPolicies(nodeTemplate.getPolicies());
-		nodeTemplateClone.setRequirements(nodeTemplate.getRequirements());
-		nodeTemplateClone.setCapabilities(nodeTemplate.getCapabilities());
+		nodeTemplateClone.setCapabilities(cloneCapabilities(nodeTemplate));
+		nodeTemplateClone.setRequirements(cloneRequirements(nodeTemplate));
 		nodeTemplateClone.setProperties(nodeTemplate.getProperties());
 		nodeTemplateClone.setPropertyConstraints(nodeTemplate.getPropertyConstraints());
 
@@ -1072,5 +1077,76 @@ public class BackendUtils {
 			res.add(id.getQName());
 		}
 		return res;
+	}
+
+	/**
+	 * Check the id's for new nodes, avoid repeating of target labels
+	 * @param duplicatedNode
+	 * @param tNodeTemplate
+	 * @param targetLabel
+	 */
+	public static TNodeTemplate checkId(TNodeTemplate duplicatedNode, TNodeTemplate tNodeTemplate, String targetLabel) {
+		if (tNodeTemplate.getId().contains(targetLabel)) {
+			duplicatedNode.setId(Util.makeNCName(tNodeTemplate.getId() + idCounterRequirements));
+			duplicatedNode.setName(Util.makeNCName(tNodeTemplate.getName() + idCounterRequirements));
+			idCounterRequirements++;
+			return duplicatedNode;
+		} else {
+			duplicatedNode.setId(Util.makeNCName(tNodeTemplate.getId() + "-" + targetLabel));
+			duplicatedNode.setName(Util.makeNCName(tNodeTemplate.getName() + "-" + targetLabel));
+			return duplicatedNode;
+		}
+	}
+
+	/**
+	 * Fix the Ids to avoid duplicate Ids in capabilities
+	 * @param nodeTemplate
+	 * @return fixedCapabilities with fixed Ids
+	 */
+	public static TNodeTemplate.Capabilities cloneCapabilities(TNodeTemplate nodeTemplate) {
+		if (nodeTemplate.getCapabilities() == null) {
+			LOGGER.info("Capabilites are null, not cloned any capabilities for " +  nodeTemplate.getId());
+			return null;
+		}
+			TNodeTemplate.Capabilities fixedCapabilities = new TNodeTemplate.Capabilities();
+			for (int i = 0; i < nodeTemplate.getCapabilities().getCapability().size(); i++) {
+				TCapability tempCapability = new TCapability();
+				String id = nodeTemplate.getCapabilities().getCapability().get(i).getId() + "_" + idCounterCapabilities;
+				tempCapability.setId(id);
+				tempCapability.setName(nodeTemplate.getCapabilities().getCapability().get(i).getName());
+				tempCapability.setProperties(nodeTemplate.getCapabilities().getCapability().get(i).getProperties());
+				tempCapability.setPropertyConstraints(nodeTemplate.getCapabilities().getCapability().get(i).getPropertyConstraints());
+				tempCapability.setType(nodeTemplate.getCapabilities().getCapability().get(i).getType());
+				fixedCapabilities.getCapability().add(tempCapability);
+				LOGGER.info("Cloned requirements for " + nodeTemplate.getId());
+				idCounterCapabilities++;
+			}
+			return fixedCapabilities;
+	}
+
+	/**
+	 * Fix the Ids to avoid duplicate Ids in requirements
+	 * @param nodeTemplate
+	 * @return fixedRequirements with fixed Ids
+	 */
+	public static TNodeTemplate.Requirements cloneRequirements(TNodeTemplate nodeTemplate) {
+		if (nodeTemplate.getRequirements() == null) {
+			LOGGER.info("Requirements are null, not cloned any requirements for " + nodeTemplate.getId());
+			return null;
+		}
+		TNodeTemplate.Requirements fixedRequirements = new TNodeTemplate.Requirements();
+		for (int i = 0; i < nodeTemplate.getRequirements().getRequirement().size(); i++) {
+			TRequirement tempRequirement = new TRequirement();
+			String id = nodeTemplate.getRequirements().getRequirement().get(i).getId() + "_" + idCounterRequirements;
+			tempRequirement.setId(id);
+			tempRequirement.setName(nodeTemplate.getRequirements().getRequirement().get(i).getName());
+			tempRequirement.setProperties(nodeTemplate.getRequirements().getRequirement().get(i).getProperties());
+			tempRequirement.setPropertyConstraints(nodeTemplate.getRequirements().getRequirement().get(i).getPropertyConstraints());
+			tempRequirement.setType(nodeTemplate.getRequirements().getRequirement().get(i).getType());
+			fixedRequirements.getRequirement().add(tempRequirement);
+			LOGGER.info("Cloned requirements for " + nodeTemplate.getId());
+			idCounterRequirements++;
+		}
+		return fixedRequirements;
 	}
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.eclipse.winery.common.ModelUtilities;
@@ -42,6 +41,7 @@ public class Splitting {
 
 	private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(Splitting.class);
 
+	// counter for relationships starts at 100 because all TRelationshipTemplate should have a 3 digit number in their id
 	private static int newRelationshipIdCounter = 100;
 	private static int nodeTemplateIdCounter = 1;
 
@@ -190,8 +190,6 @@ public class Splitting {
 					for (String targetLabel: predecessorsTargetLabel) {
 						TNodeTemplate duplicatedNode = BackendUtils.clone(currentNode);
 						duplicatedNode = BackendUtils.checkId(duplicatedNode, currentNode, targetLabel);
-						//duplicatedNode.setId(Util.makeNCName(currentNode.getId() + "-" + targetLabel));
-						//duplicatedNode.setName(Util.makeNCName(currentNode.getName() + "-" + targetLabel));
 						topologyTemplate.getNodeTemplateOrRelationshipTemplate().add(duplicatedNode);
 						topologyTemplateCopy.getNodeTemplateOrRelationshipTemplate().add(duplicatedNode);
 						ModelUtilities.setTargetLabel(duplicatedNode, targetLabel);
@@ -405,7 +403,7 @@ public class Splitting {
 	 * @return modified topology with the replaced Node Templates
 	 */
 	public TTopologyTemplate injectNodeTemplates (TTopologyTemplate topologyTemplate, Map<String, TNodeTemplate> injectNodes) {
-		String id = UUID.randomUUID().toString();
+		String id;
 
 		// Matching contains all cloud provider nodes matched to the topology
 		List<TNodeTemplate> matching = new ArrayList<>();
@@ -461,6 +459,8 @@ public class Splitting {
 					while (ids.contains(newRelationshipIdCounter)) {
 						newRelationshipIdCounter++;
 					}
+					id = "con_" + newRelationshipIdCounter + "-" + ModelUtilities.getTargetLabel(predecessorOfNewHost).get();
+					newRelationshipIdCounter++;
 				}
 				newHostedOnRelationship.setId(id);
 				newHostedOnRelationship.setName(id);

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
@@ -760,7 +760,7 @@ public class Splitting {
 
 			//check if id only contains 2 digits, if yes -> reduce array
 			String check = String.valueOf(idNumbers[2]);
-			if (check.equals("-")) {
+			if ("-".equals(check)) {
 				char tempOne = idNumbers[0];
 				char tempTwo = idNumbers[1];
 				idNumbers = new char[2];


### PR DESCRIPTION
Improve the splitting functionality by avoiding the occurrence of duplicate ids.
Avoid multiple appending of Targetlabel to the id & name of
a cloned NodeTemplate.

Signed-off-by: Marvin Wohlfarth <st112462@stud.uni-stuttgart.de>

<!-- describe the changes you have made here: what, why, ... -->

- [x ] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
