### PR TITLE
Add matching functionality

### DIFF
--- a/docs/user/Splitting.md
+++ b/docs/user/Splitting.md
@@ -1,4 +1,6 @@
-# Splitting Functionality
+# Splitting and Matching
+
+## Splitting Functionality
 
 In the topologymodeler target labels can be shown/hidden by "Target Locations" - The Target Location assigned
  to a Node Template determines the service templates serving as cloud provider repositories, which should be searched
@@ -23,3 +25,32 @@ The split as well as the matched topology are persistently stored with an attach
 the Service Template Id.
 
 ![splitting](graphics/splitting.png)
+
+## Matching Functionality
+
+Additional and based on the split function a match function is added to the winery.
+A topology is inspected if open requirements are contained. A open requirement is a requirement for which no relationship 
+to a node template exists which has the matching capability assigned.
+In case open requirements are found, the provider repositories are searched for suitable matching candidates.
+A matching candidate can be a single node, but also a whole topology fragment.
+The matching can be done to new hosts, but also to dat resources, etc.
+That means, based on the matching capabilities matching candidates are found and based on the requirements and capabilities
+and their inheritance hierarchies the correct relationship types are determined.
+
+To use this functionality a strict type and inheritance system is important.
+These are the rules:
+  - Each capability type with the semantic, that it acts as host/container has to be derived from the capability "Container"
+  - Each capability type with the semantic, that it acts as a endpoint has to be derived from the capability "Endpoint"
+  - The two default relationship types "hostedOn" and "connectsTo" should ne available and requires as valid target the 
+    capability "Container" oder "Endpoint"
+
+By using this function a vertical as well as horizontal matching is possible.
+
+## License
+
+Copyright (c) 2013-2017 University of Stuttgart.
+
+All rights reserved. Made available under the terms of the [Eclipse Public License v1.0] and the [Apache License v2.0] which both accompany this distribution.
+
+ [Apache License v2.0]: http://www.apache.org/licenses/LICENSE-2.0.html
+ [Eclipse Public License v1.0]: http://www.eclipse.org/legal/epl-v10.html

--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ModelUtilities.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ModelUtilities.java
@@ -685,17 +685,43 @@ public class ModelUtilities {
 		otherAttributes.put(QNAME_LOCATION, targetLabel);
 	}
 
+	public static TNodeTemplate getSourceNodeTemplateOfRelationshipTemplate (TTopologyTemplate topologyTemplate, TRelationshipTemplate relationshipTemplate) {
+		if (relationshipTemplate.getSourceElement().getRef() instanceof TRequirement) {
+			TRequirement requirement = (TRequirement) relationshipTemplate.getSourceElement().getRef();
+			return topologyTemplate.getNodeTemplates().stream()
+					.filter(nt -> nt.getRequirements().getRequirement() != null)
+					.filter(nt -> nt.getRequirements().getRequirement().contains(requirement))
+					.findAny().get();
+		} else {
+			TNodeTemplate sourceNodeTemplate = (TNodeTemplate) relationshipTemplate.getSourceElement().getRef();
+			return sourceNodeTemplate;
+		}
+	}
+
+	public static TNodeTemplate getTargetNodeTemplateOfRelationshipTemplate (TTopologyTemplate topologyTemplate, TRelationshipTemplate relationshipTemplate) {
+		if (relationshipTemplate.getTargetElement().getRef() instanceof TCapability) {
+			TCapability capability = (TCapability) relationshipTemplate.getTargetElement().getRef();
+			return topologyTemplate.getNodeTemplates().stream()
+					.filter(nt -> nt.getRequirements().getRequirement() != null)
+					.filter(nt -> nt.getRequirements().getRequirement().contains(capability))
+					.findAny().get();
+		} else {
+			return (TNodeTemplate) relationshipTemplate.getTargetElement().getRef();
+		}
+	}
+
 	/**
 	 * @return incoming relation ship templates <em>pointing to node templates</em>
 	 */
 	public static List<TRelationshipTemplate> getIncomingRelationshipTemplates(TTopologyTemplate topologyTemplate, TNodeTemplate nodeTemplate) {
 		Objects.requireNonNull(topologyTemplate);
 		Objects.requireNonNull(nodeTemplate);
-
-		return getAllRelationshipTemplates(topologyTemplate)
+		List<TRelationshipTemplate> incomingRelationshipTemplates = topologyTemplate.getRelationshipTemplates()
 				.stream()
-				.filter(rt -> rt.getTargetElement().getRef().equals(nodeTemplate))
+				.filter(rt -> getTargetNodeTemplateOfRelationshipTemplate(topologyTemplate, rt).equals(nodeTemplate))
 				.collect(Collectors.toList());
+
+		return incomingRelationshipTemplates;
 	}
 
 	/**
@@ -704,11 +730,13 @@ public class ModelUtilities {
 	public static List<TRelationshipTemplate> getOutgoingRelationshipTemplates(TTopologyTemplate topologyTemplate, TNodeTemplate nodeTemplate) {
 		Objects.requireNonNull(topologyTemplate);
 		Objects.requireNonNull(nodeTemplate);
-
-		return getAllRelationshipTemplates(topologyTemplate)
+		List<TRelationshipTemplate> outgoingRelationshipTemplates = topologyTemplate.getRelationshipTemplates()
 				.stream()
-				.filter(rt -> rt.getSourceElement().getRef().equals(nodeTemplate))
+				.filter(rt -> getSourceNodeTemplateOfRelationshipTemplate(topologyTemplate, rt).equals(nodeTemplate))
 				.collect(Collectors.toList());
+
+		return outgoingRelationshipTemplates;
+
 	}
 
 	/**

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/Injection.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/Injection.java
@@ -15,21 +15,21 @@ package org.eclipse.winery.repository.resources._support.dataadapter;
 import javax.xml.bind.annotation.XmlElement;
 
 import org.eclipse.winery.common.constants.Namespaces;
-import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 
 //@XmlType
 public class Injection {
-	@XmlElement(name = "hostedNodeID")
-	protected String hostedNodeID;
-	@XmlElement(namespace = Namespaces.TOSCA_NAMESPACE, name = "NodeTemplate")
-	protected TNodeTemplate hostNodeTemplate;
+	@XmlElement(name = "NodeID")
+	protected String nodeID;
+	@XmlElement(namespace = Namespaces.TOSCA_NAMESPACE, name = "TopologyTemplate")
+	protected TTopologyTemplate injectedTopologyFragment;
 
 	public Injection() {
 	}
 
-	public Injection(String hostedNodeID, TNodeTemplate hostNodeTemplate) {
-		this.hostedNodeID = hostedNodeID;
-		this.hostNodeTemplate = hostNodeTemplate;
+	public Injection(String hostedNodeID, TTopologyTemplate injectedTopologyFragment) {
+		this.nodeID = hostedNodeID;
+		this.injectedTopologyFragment = injectedTopologyFragment;
 	}
 
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectionDataMapAdapter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectionDataMapAdapter.java
@@ -17,23 +17,23 @@ import java.util.Map;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 
-public class InjectionDataMapAdapter extends XmlAdapter<Injections, Map<String, TNodeTemplate>> {
+public class InjectionDataMapAdapter extends XmlAdapter<Injections, Map<String, TTopologyTemplate>> {
 
 	@Override
-	public Map<String, TNodeTemplate> unmarshal(Injections injections) throws Exception {
-		Map<String, TNodeTemplate> mapInjections = new HashMap<>();
+	public Map<String, TTopologyTemplate> unmarshal(Injections injections) throws Exception {
+		Map<String, TTopologyTemplate> mapInjections = new HashMap<>();
 		for (Injection injection : injections.getInjections()) {
-			mapInjections.put(injection.hostedNodeID, injection.hostNodeTemplate);
+			mapInjections.put(injection.nodeID, injection.injectedTopologyFragment);
 		}
 		return mapInjections;
 	}
 
 	@Override
-	public Injections marshal(Map<String, TNodeTemplate> mapInjections) throws Exception {
+	public Injections marshal(Map<String, TTopologyTemplate> mapInjections) throws Exception {
 		Injections injections = new Injections();
-		for (Map.Entry<String, TNodeTemplate> entry : mapInjections.entrySet()) {
+		for (Map.Entry<String, TTopologyTemplate> entry : mapInjections.entrySet()) {
 			injections.addInjection(new Injection(entry.getKey(), entry.getValue()));
 		}
 		return injections;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectionOption.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectionOption.java
@@ -18,21 +18,21 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 
 import org.eclipse.winery.common.constants.Namespaces;
-import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 
 public class InjectionOption {
-	@XmlElement(name = "hostedNodeID")
-	protected String hostedNodeID;
+	@XmlElement(name = "NodeID")
+	protected String nodeID;
 
-	@XmlElementWrapper (name = "hostOptions")
-	@XmlElement(namespace = Namespaces.TOSCA_NAMESPACE, name = "NodeTemplate")
-	protected List<TNodeTemplate> hostNodeTemplateOptions;
+	@XmlElementWrapper (name = "InjectionOptions")
+	@XmlElement(namespace = Namespaces.TOSCA_NAMESPACE, name = "TopologyTemplate")
+	protected List<TTopologyTemplate> injectionOptions;
 
 	public InjectionOption() {
 	}
 
-	public InjectionOption(String hostedNodeID, List<TNodeTemplate> hostNodeTemplateOptions) {
-		this.hostedNodeID = hostedNodeID;
-		this.hostNodeTemplateOptions = hostNodeTemplateOptions;
+	public InjectionOption(String nodeID, List<TTopologyTemplate> injectionOptions) {
+		this.nodeID = nodeID;
+		this.injectionOptions = injectionOptions;
 	}
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectionOptionsMapAdapter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectionOptionsMapAdapter.java
@@ -18,23 +18,23 @@ import java.util.Map;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 
-public class InjectionOptionsMapAdapter extends XmlAdapter<InjectionOptions, Map<String, List<TNodeTemplate>>> {
+public class InjectionOptionsMapAdapter extends XmlAdapter<InjectionOptions, Map<String, List<TTopologyTemplate>>> {
 
 	@Override
-	public Map<String, List<TNodeTemplate>> unmarshal(InjectionOptions injectionOptions) throws Exception {
-		Map<String, List<TNodeTemplate>> mapInjections = new HashMap<>();
+	public Map<String, List<TTopologyTemplate>> unmarshal(InjectionOptions injectionOptions) throws Exception {
+		Map<String, List<TTopologyTemplate>> mapInjections = new HashMap<>();
 		for (InjectionOption injection : injectionOptions.getInjectionOption()) {
-			mapInjections.put(injection.hostedNodeID, injection.hostNodeTemplateOptions);
+			mapInjections.put(injection.nodeID, injection.injectionOptions);
 		}
 		return mapInjections;
 	}
 
 	@Override
-	public InjectionOptions marshal(Map<String, List<TNodeTemplate>> mapInjectionOptions) throws Exception {
+	public InjectionOptions marshal(Map<String, List<TTopologyTemplate>> mapInjectionOptions) throws Exception {
 		InjectionOptions injectionOptions = new InjectionOptions();
-		for (Map.Entry<String, List<TNodeTemplate>> entry : mapInjectionOptions.entrySet()) {
+		for (Map.Entry<String, List<TTopologyTemplate>> entry : mapInjectionOptions.entrySet()) {
 			injectionOptions.addInjectionOptions(new InjectionOption(entry.getKey(), entry.getValue()));
 		}
 		return injectionOptions;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectorReplaceData.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectorReplaceData.java
@@ -20,7 +20,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "")
@@ -28,10 +28,17 @@ import org.eclipse.winery.model.tosca.TNodeTemplate;
 public class InjectorReplaceData {
 
 	@XmlJavaTypeAdapter(value = InjectionDataMapAdapter.class)
-    public Map<String, TNodeTemplate> injections;
+    public Map<String, TTopologyTemplate> hostInjections;
 
-	public void setInjections (Map<String, TNodeTemplate> injections) {
-		this.injections = injections;
+	@XmlJavaTypeAdapter(value = InjectionOptionsMapAdapter.class)
+	public Map<String, TTopologyTemplate> connectionInjections;
+
+	public void setHostInjections (Map<String, TTopologyTemplate> hostInjections) {
+		this.hostInjections = hostInjections;
+	}
+
+	public void setConnectionInjections (Map<String, TTopologyTemplate> connectionInjections) {
+		this.connectionInjections = connectionInjections;
 	}
 
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectorReplaceOptions.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/_support/dataadapter/InjectorReplaceOptions.java
@@ -24,7 +24,6 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.eclipse.winery.common.constants.Namespaces;
-import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -36,14 +35,21 @@ public class InjectorReplaceOptions {
 	public TTopologyTemplate topologyTemplate;
 
 	@XmlJavaTypeAdapter(value = InjectionOptionsMapAdapter.class)
-	public Map<String, List<TNodeTemplate>> injections = new HashMap<>();
+	public Map<String, List<TTopologyTemplate>> hostInjections = new HashMap<>();
+
+	@XmlJavaTypeAdapter(value = InjectionOptionsMapAdapter.class)
+	public Map<String, List<TTopologyTemplate>> connectionInjections = new HashMap<>();
 
 	public void setTopologyTemplate (TTopologyTemplate topologyTemplate) {
 		this.topologyTemplate = topologyTemplate;
 	}
 
-	public void setInjectionOptions(Map<String, List<TNodeTemplate>> injectionOptions) {
-		this.injections = injectionOptions;
+	public void setHostInjectionOptions(Map<String, List<TTopologyTemplate>> hostInjectionOptions) {
+		this.hostInjections = hostInjectionOptions;
+	}
+
+	public void setConnectionInjectionOptions(Map<String, List<TTopologyTemplate>> connectionInjectionOptions) {
+		this.connectionInjections = connectionInjectionOptions;
 	}
 
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplateResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplateResource.java
@@ -175,16 +175,41 @@ public class ServiceTemplateResource extends AbstractComponentInstanceWithRefere
 	public Response getInjectorOptions() {
 		Splitting splitting = new Splitting();
 		TTopologyTemplate topologyTemplate = this.getServiceTemplate().getTopologyTemplate();
-		Map<String, List<TNodeTemplate>> matchingOptions;
+		Map<String, List<TTopologyTemplate>> hostMatchingOptions;
+		Map<String, List<TTopologyTemplate>> connectionMatchingOptions;
 		InjectorReplaceOptions injectionReplaceOptions = new InjectorReplaceOptions();
 
 		try {
-			matchingOptions = splitting.getMatchingOptionsWithDefaultLabeling(topologyTemplate);
+
+			Map<TRequirement, String> requirementsAndMatchingBasisCapabilityTypes =
+					splitting.getOpenRequirementsAndMatchingBasisCapabilityTypeNames(this.getServiceTemplate().getTopologyTemplate());
+			// Output check
+			for (TRequirement req : requirementsAndMatchingBasisCapabilityTypes.keySet()) {
+				System.out.println("open Requirement: " + req.getId());
+				System.out.println("matchingBasisType: " + requirementsAndMatchingBasisCapabilityTypes.get(req));
+			}
+
+			if (requirementsAndMatchingBasisCapabilityTypes.containsValue("Container")) {
+				hostMatchingOptions = splitting.getHostingMatchingOptionsWithDefaultLabeling(topologyTemplate);
+			} else {
+				hostMatchingOptions = null;
+			}
+			if (requirementsAndMatchingBasisCapabilityTypes.containsValue("Endpoint")) {
+				connectionMatchingOptions = splitting.getConnectionInjectionOptions(topologyTemplate);
+			} else {
+				connectionMatchingOptions = null;
+			}
+
 			injectionReplaceOptions.setTopologyTemplate(topologyTemplate);
-			injectionReplaceOptions.setInjectionOptions(matchingOptions);
+			injectionReplaceOptions.setHostInjectionOptions(hostMatchingOptions);
+			injectionReplaceOptions.setConnectionInjectionOptions(connectionMatchingOptions);
+
+			if (hostMatchingOptions == null && connectionMatchingOptions == null) {
+				return Response.status(Status.BAD_REQUEST).type(MediaType.TEXT_PLAIN).entity("No need for matching").build();
+			}
 		} catch (SplittingException e) {
-			LOGGER.error("Could not get matching options", e);
-			return Response.serverError().entity("Could not get matching options").build();
+			LOGGER.error("Could not match", e);
+			return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
 		}
 		return Response.ok().entity(injectionReplaceOptions).build();
 	}
@@ -193,14 +218,55 @@ public class ServiceTemplateResource extends AbstractComponentInstanceWithRefere
 	@Path("injector/replace")
 	@Consumes({MediaType.APPLICATION_XML, MediaType.TEXT_XML, MediaType.APPLICATION_JSON})
 	@Produces({MediaType.APPLICATION_XML, MediaType.TEXT_XML, MediaType.APPLICATION_JSON})
-	public Response injectNodeTemplates(InjectorReplaceData injectorReplaceData, @Context UriInfo uriInfo) throws IOException, ParserConfigurationException, SAXException {
-		Collection<TNodeTemplate> injectorNodeTemplates = injectorReplaceData.injections.values();
-		ModelUtilities.patchAnyAttributes(injectorNodeTemplates);
+	public Response injectNodeTemplates(InjectorReplaceData injectorReplaceData, @Context UriInfo uriInfo) throws IOException, ParserConfigurationException, SAXException, SplittingException {
+		Collection<TTopologyTemplate> hostInjectorTopologyTemplates = injectorReplaceData.hostInjections.values();
+		hostInjectorTopologyTemplates.forEach(t -> {
+			try {
+				ModelUtilities.patchAnyAttributes(t.getNodeTemplates());
+			} catch (IOException e) {
+				LOGGER.error("XML was invalid", e);
+			}
+		});
+
+		Collection<TTopologyTemplate> connectionInjectorTopologyTemplates = injectorReplaceData.connectionInjections.values();
+		connectionInjectorTopologyTemplates.forEach(t -> {
+			try {
+				ModelUtilities.patchAnyAttributes(t.getNodeTemplates());
+			} catch (IOException e) {
+				LOGGER.error("XML was invalid", e);
+			}
+		});
 
 		Splitting splitting = new Splitting();
+		TTopologyTemplate matchedHostsTopologyTemplate;
+		TTopologyTemplate matchedConnectedTopologyTemplate;
 
-		TTopologyTemplate tTopologyTemplate = splitting.injectNodeTemplates(this.getServiceTemplate().getTopologyTemplate(), injectorReplaceData.injections);
-		this.getServiceTemplate().setTopologyTemplate(tTopologyTemplate);
+		//Test Method findOpenRequirements
+		Map<TRequirement, String> requirementsAndMatchingBasisCapabilityTypes =
+				splitting.getOpenRequirementsAndMatchingBasisCapabilityTypeNames(this.getServiceTemplate().getTopologyTemplate());
+		// Output check
+		for (TRequirement req : requirementsAndMatchingBasisCapabilityTypes.keySet()) {
+			System.out.println("open Requirement: " + req.getId());
+			System.out.println("matchingbasisType: " + requirementsAndMatchingBasisCapabilityTypes.get(req));
+		}
+		// End Output check
+
+		if (requirementsAndMatchingBasisCapabilityTypes.containsValue("Container")) {
+			matchedHostsTopologyTemplate = splitting.injectNodeTemplates(this.getServiceTemplate().getTopologyTemplate(), injectorReplaceData.hostInjections);
+
+			if (requirementsAndMatchingBasisCapabilityTypes.containsValue("Endpoint")) {
+				matchedConnectedTopologyTemplate = splitting.injectConnectionNodeTemplates(matchedHostsTopologyTemplate, injectorReplaceData.connectionInjections);
+			} else {
+				matchedConnectedTopologyTemplate = matchedHostsTopologyTemplate;
+			}
+		} else if (requirementsAndMatchingBasisCapabilityTypes.containsValue("Endpoint")) {
+			matchedConnectedTopologyTemplate = splitting.injectConnectionNodeTemplates(this.getServiceTemplate().getTopologyTemplate(), injectorReplaceData.connectionInjections);
+		} else {
+			throw new SplittingException("No open Requirements which can be matched");
+		}
+
+		this.getServiceTemplate().setTopologyTemplate(matchedConnectedTopologyTemplate);
+
 		LOGGER.debug("Persisting...");
 		this.persist();
 		LOGGER.debug("Persisted.");
@@ -238,7 +304,7 @@ public class ServiceTemplateResource extends AbstractComponentInstanceWithRefere
 		Map<String, TNodeTemplate> replaceNodes = new HashMap<>();
 		replaceNodes.put("test", nt2);
 		replaceNodes.put("test2", nt3);
-		injectorReplaceData.setInjections(replaceNodes);
+		//injectorReplaceData.setInjections(replaceNodes);
 
 		return Response.ok().entity(injectorReplaceData).build();
 	}

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
@@ -360,8 +360,9 @@ public class TopologyTemplateResource {
 		return Utils.getXML(TTopologyTemplate.class, this.topologyTemplate);
 	}
 
-	@POST
+	@Path("split/")
 	@Produces(MediaType.TEXT_PLAIN)
+	@POST
 	public Response split(@Context UriInfo uriInfo) {
 		Splitting splitting = new Splitting();
 		ServiceTemplateId splitServiceTemplateId;
@@ -371,6 +372,21 @@ public class TopologyTemplateResource {
 			return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Could not split. " + e.getMessage()).build();
 		}
 		URI url = uriInfo.getBaseUri().resolve(Utils.getAbsoluteURL(splitServiceTemplateId));
+		return Response.created(url).build();
+	}
+
+	@Path("match/")
+	@Produces(MediaType.TEXT_PLAIN)
+	@POST
+	public Response match(@Context UriInfo uriInfo) {
+		Splitting splitting = new Splitting();
+		ServiceTemplateId matchedServiceTemplateId;
+		try {
+			matchedServiceTemplateId = splitting.matchTopologyOfServiceTemplate((ServiceTemplateId) this.serviceTemplateRes.getId());
+		} catch (Exception e) {
+			return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Could not match. " + e.getMessage()).build();
+		}
+		URI url = uriInfo.getBaseUri().resolve(Utils.getAbsoluteURL(matchedServiceTemplateId));
 		return Response.created(url).build();
 	}
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/ProviderRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/ProviderRepository.java
@@ -12,7 +12,9 @@
 
 package org.eclipse.winery.repository.splitting;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
@@ -20,8 +22,12 @@ import javax.xml.namespace.QName;
 import org.eclipse.winery.common.ModelUtilities;
 import org.eclipse.winery.common.ids.definitions.RequirementTypeId;
 import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
+import org.eclipse.winery.model.tosca.TDocumentation;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.repository.backend.Repository;
 import org.eclipse.winery.repository.resources.AbstractComponentsResource;
 import org.eclipse.winery.repository.resources.entitytypes.requirementtypes.RequirementTypeResource;
@@ -42,7 +48,32 @@ public class ProviderRepository {
 	 *
 	 * @return All node templates available for the given targetLocation.
 	 */
-	public List<TNodeTemplate> getAllNodeTemplatesForLocation(String targetLocation) {
+
+	public List<TTopologyTemplate> getAllTopologyFragmentsForLocationAndOfferingCapability(String targetLocation, TRequirement requirement) {
+		QName reqTypeQName = requirement.getType();
+		RequirementTypeId reqTypeId = new RequirementTypeId(reqTypeQName);
+		RequirementTypeResource reqTypeResource = (RequirementTypeResource) AbstractComponentsResource.getComponentInstaceResource(reqTypeId);
+		QName requiredCapabilityType = reqTypeResource.getRequirementType().getRequiredCapabilityType();
+
+		return getAllTopologyFragmentsForLocation(targetLocation).stream()
+				.filter(tf -> {
+					Optional<TNodeTemplate> nodeTemplate = ModelUtilities.getAllNodeTemplates(tf).stream()
+							.filter(nt -> nt.getCapabilities() != null)
+							.filter(nt -> nt.getCapabilities().getCapability().stream()
+									.anyMatch(cap -> cap.getType().equals(requiredCapabilityType))
+							).findAny();
+					if (nodeTemplate.isPresent()) {
+						return true;
+					} else {
+						return false;
+					}
+
+				})
+				.collect(Collectors.toList());
+
+	}
+
+	public List<TTopologyTemplate> getAllTopologyFragmentsForLocation(String targetLocation) {
 		String namespaceStr;
 		if ("*".equals(targetLocation)) {
 			namespaceStr = NS_NAME_START;
@@ -56,33 +87,83 @@ public class ProviderRepository {
 				// get all contained node templates
 				.flatMap(id -> {
 					ServiceTemplateResource serviceTemplateResource = (ServiceTemplateResource) AbstractComponentsResource.getComponentInstaceResource(id);
-					List<TNodeTemplate> matchedNodeTemplates = serviceTemplateResource.getServiceTemplate().getTopologyTemplate().getNodeTemplateOrRelationshipTemplate().stream()
+					TTopologyTemplate topologyTemplate = serviceTemplateResource.getServiceTemplate().getTopologyTemplate();
+					List<TNodeTemplate> matchedNodeTemplates = topologyTemplate.getNodeTemplateOrRelationshipTemplate().stream()
 							.filter(t -> t instanceof TNodeTemplate)
 							.map(TNodeTemplate.class::cast)
 							.collect(Collectors.toList());
 
-					matchedNodeTemplates.stream().forEach(t -> ModelUtilities.setTargetLabel(t, id.getNamespace().getDecoded().replace(NS_NAME_START, "")));
+					matchedNodeTemplates.forEach(t -> ModelUtilities.setTargetLabel(t, id.getNamespace().getDecoded().replace(NS_NAME_START, "")));
 
-					return matchedNodeTemplates.stream();
+					return getAllTopologyFragmentsFromServiceTemplate(topologyTemplate).stream();
 
 				})
 				.collect(Collectors.toList());
 	}
 
-	/**
-	 * @return All node templates available for the given targetLocation
-	 */
-	public List<TNodeTemplate> getAllNodeTemplatesForLocationAndOfferingCapability(String targetLocation, List <TRequirement> requirements) {
-		QName reqTypeQName = requirements.get(0).getType();
-		RequirementTypeId reqTypeId = new RequirementTypeId(reqTypeQName);
-		RequirementTypeResource reqTypeResource = (RequirementTypeResource) AbstractComponentsResource.getComponentInstaceResource(reqTypeId);
-		QName requiredCapabilityType = reqTypeResource.getRequirementType().getRequiredCapabilityType();
+	private List<TTopologyTemplate> getAllTopologyFragmentsFromServiceTemplate (TTopologyTemplate topologyTemplate) {
 
-		return this.getAllNodeTemplatesForLocation(targetLocation).stream()
-				.filter(nt -> nt.getCapabilities() != null)
-				.filter(nt -> nt.getCapabilities().getCapability().stream()
-						.anyMatch(cap -> cap.getType().equals(requiredCapabilityType))
-				).collect(Collectors.toList());
+		List<TTopologyTemplate> topologyFragments = new ArrayList<>();
+
+		Splitting helperFunctions = new Splitting();
+		List<TNodeTemplate> nodeTemplatesWithoutIncomingRelationship = helperFunctions.getNodeTemplatesWithoutIncomingHostedOnRelationships(topologyTemplate);
+		List<TNodeTemplate> visitedNodeTemplates = new ArrayList<>();
+
+		//It can only be one topology fragment contained in the service template
+		if (nodeTemplatesWithoutIncomingRelationship.size() == 1) {
+			TDocumentation documentation = new TDocumentation();
+			Optional<String> targetLabel = ModelUtilities.getTargetLabel(nodeTemplatesWithoutIncomingRelationship.get(0));
+			String label;
+			if (!targetLabel.isPresent()) {
+				label = "unkown";
+			} else {
+				label = targetLabel.get();
+			}
+			documentation.getContent().add("Stack of Node Template " + nodeTemplatesWithoutIncomingRelationship.get(0).getId()
+					+ " from Provider Repository " + label);
+			topologyTemplate.getDocumentation().add(documentation);
+			topologyFragments.add(topologyTemplate);
+		} else {
+			for (TNodeTemplate nodeWithoutIncomingRel: nodeTemplatesWithoutIncomingRelationship) {
+				if (!visitedNodeTemplates.contains(nodeWithoutIncomingRel)) {
+					TTopologyTemplate topologyFragment = new TTopologyTemplate();
+					TDocumentation documentation = new TDocumentation();
+					Optional<String> targetLabel = ModelUtilities.getTargetLabel(nodeWithoutIncomingRel);
+					String label;
+					if (!targetLabel.isPresent()) {
+						label = "unkown";
+					} else {
+						label = targetLabel.get();
+					}
+					documentation.getContent().add("Stack of Node Template " + nodeWithoutIncomingRel.getId()
+							+ " from Provider Repository " + label);
+					topologyFragment.getDocumentation().add(documentation);
+					topologyFragment.getNodeTemplateOrRelationshipTemplate().addAll(breadthFirstSearch(nodeWithoutIncomingRel, topologyTemplate));
+					topologyFragments.add(topologyFragment);
+
+					topologyFragment.getNodeTemplateOrRelationshipTemplate().stream()
+							.filter(et -> et instanceof TNodeTemplate)
+							.map(TNodeTemplate.class::cast)
+							.forEach(nt -> visitedNodeTemplates.add(nt));
+				}
+			}
+		}
+		return topologyFragments;
+	}
+
+	private List<TEntityTemplate> breadthFirstSearch(TNodeTemplate nodeTemplate, TTopologyTemplate topologyTemplate) {
+		List<TEntityTemplate> topologyFragmentElements = new ArrayList<>();
+		topologyFragmentElements.add(nodeTemplate);
+		List<TRelationshipTemplate> outgoingRelationships = ModelUtilities.getOutgoingRelationshipTemplates(topologyTemplate, nodeTemplate);
+
+		for (TRelationshipTemplate outgoingRelationship : outgoingRelationships) {
+			Object successor = outgoingRelationship.getTargetElement().getRef();
+			if (successor instanceof TNodeTemplate) {
+				topologyFragmentElements.add(outgoingRelationship);
+				topologyFragmentElements.addAll(breadthFirstSearch((TNodeTemplate) successor, topologyTemplate));
+			}
+		}
+		return topologyFragmentElements;
 	}
 
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplateResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplateResourceTest.java
@@ -9,6 +9,7 @@
  * Contributors:
  *     Niko Stadelmaier - initial API and implementation
  *     Oliver Kopp - test of create instance
+ *     Karoline Saatkamp - test injector
  *******************************************************************************/
 package org.eclipse.winery.repository.resources.servicetemplates;
 
@@ -20,7 +21,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class ServiceTemplateResourceTest extends AbstractResourceTest {
-
+	
 	@Test
 	@Ignore
 	public void addServicetemplate() throws Exception {
@@ -30,7 +31,20 @@ public class ServiceTemplateResourceTest extends AbstractResourceTest {
 	}
 
 	@Test
+	public void addTopologyTemplate() throws Exception {
+		this.setRevisionTo("84d064a2f7390b3274ca8b3641a5902ba4c822d7");
+		this.assertPut("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Fponyuniverse%252Finjector/FoodandHouseInjectionTest/topologytemplate/", "entitytypes/servicetemplates/straw-stall.json");
+		this.assertGet("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Fponyuniverse%252Finjector/FoodandHouseInjectionTest/topologytemplate/", "entitytypes/servicetemplates/straw-stall.json");
+	}
+
+	@Test
 	public void getServicetemplate() throws Exception {
+		this.setRevisionTo("a5fd2da6845e9599138b7c20c1fd9d727c1df66f");
+		this.assertGet("servicetemplates/","entitytypes/servicetemplates/baobab_inital.json");
+	}
+
+	@Test
+	public void updateTopology() throws Exception {
 		this.setRevisionTo("a5fd2da6845e9599138b7c20c1fd9d727c1df66f");
 		this.assertGet("servicetemplates/","entitytypes/servicetemplates/baobab_inital.json");
 	}
@@ -42,4 +56,25 @@ public class ServiceTemplateResourceTest extends AbstractResourceTest {
 		ServiceTemplateResource serviceTemplateResource = new ServiceTemplateResource(id);
 		Assert.assertNotNull(serviceTemplateResource);
 	}
+
+	@Test
+	public void getInjectorOptions() throws Exception {
+		this.setRevisionTo("84d064a2f7390b3274ca8b3641a5902ba4c822d7");
+		this.assertGet("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Fponyuniverse%252Finjector/FoodandHouseInjectionTest/injector/options", "servicetemplates/ServiceTemplateResource-getInjectionOptions.json");
+	}
+
+	@Test
+	public void getInjectorOptionsWithoutOpenRequirementsBadRequest() throws Exception {
+		this.setRevisionTo("black");
+		//this.assertGetExpectBadRequestResponse("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Ffruits/baobab_serviceTemplate/injector/options", "servicetemplates/pony.json");
+		this.assertGetExpectBadRequestResponse("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Ffruits/baobab_serviceTemplate/injector/options", "servicetemplates/ServiceTemplateResource-getInjectorOptionsWithoutOpenRequirements-badrequest.txt");
+	}
+
+	@Test
+	public void injectNodeTemplates() throws Exception {
+		this.setRevisionTo("d535f69bf50b2c4eda437be46b7ba1f85c4ff3bc");
+		this.assertPost("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Fponyuniverse%252Finjector/FoodandHouseInjectionTest/injector/replace", "servicetemplates/ServiceTemplateResource-injectNodeTemplates-input2.json");
+
+	}
+
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResourceTest.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Oliver Kopp - initial API and implementation
+ *     Karoline Saatkamp - add test
  *******************************************************************************/
 package org.eclipse.winery.repository.resources.servicetemplates.topologytemplates;
 
@@ -66,6 +67,12 @@ public class TopologyTemplateResourceTest  extends AbstractResourceTest {
 	@Test
 	public void farmTopologyTemplateJsonCanBeParsed() throws Exception {
 		final String jsonStr = AbstractResourceTest.readFromClasspath("servicetemplates/farm_topologytemplate.json");
+		final TTopologyTemplate topologyTemplate = Utils.mapper.readValue(jsonStr, TTopologyTemplate.class);
+	}
+
+	@Test
+	public void strawStallTopologyTemplateJsonCanBeParsed() throws Exception {
+		final String jsonStr = AbstractResourceTest.readFromClasspath("entitytypes/servicetemplates/straw-stall.json");
 		final TTopologyTemplate topologyTemplate = Utils.mapper.readValue(jsonStr, TTopologyTemplate.class);
 	}
 

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/splitting/SplittingTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/splitting/SplittingTest.java
@@ -292,7 +292,7 @@ public class SplittingTest {
 		TTopologyTemplate topologyTemplateMatching = resource.getServiceTemplate().getTopologyTemplate();
 
 		List<String> expectedIds = Arrays.asList("PHP-5-WebApplication", "Java7", "MySQL-DB", "PHP-5-Module", "Apache-2.4", "Ubuntu-14.04-VM-OnPremiseIAAS", "OpenStack-Liberty-12-OnPremiseIAAS", "AmazonBeanstalk", "AmazonRDS");
-		List<TNodeTemplate> NodeTemplates = splitting.matchingWithDefaultHostSelection(topologyTemplateMatching).getNodeTemplateOrRelationshipTemplate().stream().filter(t -> t instanceof TNodeTemplate).map(TNodeTemplate.class::cast).collect(Collectors.toList());
+		List<TNodeTemplate> NodeTemplates = splitting.hostMatchingWithDefaultHostSelection(topologyTemplateMatching).getNodeTemplateOrRelationshipTemplate().stream().filter(t -> t instanceof TNodeTemplate).map(TNodeTemplate.class::cast).collect(Collectors.toList());
 
 		List<String> Ids = new ArrayList<>();
 		for (TNodeTemplate nodeTemplate : NodeTemplates) {

--- a/org.eclipse.winery.repository/src/test/resources/.editorconfig
+++ b/org.eclipse.winery.repository/src/test/resources/.editorconfig
@@ -1,0 +1,5 @@
+[*.json]
+insert_final_newline = false
+
+[*.txt]
+insert_final_newline = false

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/servicetemplates/straw-stall.json
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/servicetemplates/straw-stall.json
@@ -1,0 +1,131 @@
+{
+  "documentation": [
+	{
+	  "content": [
+		"Stack of Node Template straw from Provider Repository StallProvider"
+	  ],
+	  "source": null,
+	  "lang": null
+	}
+  ],
+  "any": [
+
+  ],
+  "otherAttributes": {
+
+  },
+  "nodeTemplates": [
+	{
+	  "documentation": [
+
+	  ],
+	  "any": [
+
+	  ],
+	  "otherAttributes": {
+		"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "StallProvider",
+		"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "909",
+		"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "62"
+	  },
+	  "id": "straw",
+	  "type": "{http://winery.opentosca.org/test/ponyuniverse}straw",
+	  "requirements": {
+		"requirement": [
+		  {
+			"documentation": [
+
+			],
+			"any": [
+
+			],
+			"otherAttributes": {
+
+			},
+			"id": "hosting",
+			"type": "{http://winery.opentosca.org/test/ponyuniverse}ReqCanHostStraw",
+			"name": "ReqCanHostStraw"
+		  }
+		]
+	  },
+	  "capabilities": {
+		"capability": [
+		  {
+			"documentation": [
+
+			],
+			"any": [
+
+			],
+			"otherAttributes": {
+
+			},
+			"id": "providesAWarmGround",
+			"type": "{http://winery.opentosca.org/test/ponyuniverse}CapWarmFloor",
+			"name": "CapWarmFloor"
+		  }
+		]
+	  },
+	  "name": "straw",
+	  "minInstances": 1,
+	  "maxInstances": "1"
+	},
+	{
+	  "documentation": [
+
+	  ],
+	  "any": [
+
+	  ],
+	  "otherAttributes": {
+		"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "StallProvider",
+		"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "911",
+		"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "485"
+	  },
+	  "id": "stall",
+	  "type": "{http://winery.opentosca.org/test/ponyuniverse}stall",
+	  "capabilities": {
+		"capability": [
+		  {
+			"documentation": [
+
+			],
+			"any": [
+
+			],
+			"otherAttributes": {
+
+			},
+			"id": "providesAhost",
+			"type": "{http://winery.opentosca.org/test/ponyuniverse}CapCanHostStraw",
+			"name": "CapCanHostStraw"
+		  }
+		]
+	  },
+	  "name": "stall",
+	  "minInstances": 1,
+	  "maxInstances": "1"
+	}
+  ],
+  "relationshipTemplates": [
+	{
+	  "documentation": [
+
+	  ],
+	  "any": [
+
+	  ],
+	  "otherAttributes": {
+
+	  },
+	  "id": "con_19",
+	  "type": "{http://winery.opentosca.org/test/ponyuniverse}hostedOn",
+	  "sourceElement": {
+		"ref": "straw"
+	  },
+	  "targetElement": {
+		"ref": "stall"
+	  },
+	  "name": "con_19"
+	}
+  ]
+}

--- a/org.eclipse.winery.repository/src/test/resources/servicetemplates/ServiceTemplateResource-getInjectionOptions.json
+++ b/org.eclipse.winery.repository/src/test/resources/servicetemplates/ServiceTemplateResource-getInjectionOptions.json
@@ -1,0 +1,323 @@
+{
+  "topologyTemplate": {
+	"documentation": [
+
+	],
+	"any": [
+
+	],
+	"otherAttributes": {
+
+	},
+	"nodeTemplates": [
+	  {
+		"documentation": [
+
+		],
+		"any": [
+
+		],
+		"otherAttributes": {
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "*",
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "695",
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "166"
+		},
+		"id": "shetland_pony",
+		"type": "{http://winery.opentosca.org/test/ponyuniverse}shetland_pony",
+		"requirements": {
+		  "requirement": [
+			{
+			  "documentation": [
+
+			  ],
+			  "any": [
+
+			  ],
+			  "otherAttributes": {
+
+			  },
+			  "id": "requiresWarmFloor",
+			  "type": "{http://winery.opentosca.org/test/ponyuniverse}ReqWarmFloor",
+			  "name": "ReqWarmFloor"
+			},
+			{
+			  "documentation": [
+
+			  ],
+			  "any": [
+
+			  ],
+			  "otherAttributes": {
+
+			  },
+			  "id": "requiresDryFood",
+			  "type": "{http://winery.opentosca.org/test/ponyuniverse}ReqDryFood",
+			  "name": "ReqDryFood"
+			}
+		  ]
+		},
+		"name": "shetland_pony",
+		"minInstances": 1,
+		"maxInstances": "1"
+	  }
+	],
+	"relationshipTemplates": [
+
+	]
+  },
+  "hostInjections": {
+	"shetland_pony": [
+	  {
+		"documentation": [
+		  {
+			"content": [
+			  "Stack of Node Template pasture from Provider Repository PastureProvider"
+			],
+			"source": null,
+			"lang": null
+		  }
+		],
+		"any": [
+
+		],
+		"otherAttributes": {
+
+		},
+		"nodeTemplates": [
+		  {
+			"documentation": [
+
+			],
+			"any": [
+
+			],
+			"otherAttributes": {
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "PastureProvider",
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "841",
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "245"
+			},
+			"id": "pasture",
+			"type": "{http://winery.opentosca.org/test/ponyuniverse}pasture",
+			"capabilities": {
+			  "capability": [
+				{
+				  "documentation": [
+
+				  ],
+				  "any": [
+
+				  ],
+				  "otherAttributes": {
+
+				  },
+				  "id": "placeforaPony",
+				  "type": "{http://winery.opentosca.org/test/ponyuniverse}CapWarmFloor",
+				  "name": "CapWarmFloor"
+				}
+			  ]
+			},
+			"name": "pasture",
+			"minInstances": 1,
+			"maxInstances": "1"
+		  }
+		],
+		"relationshipTemplates": [
+
+		]
+	  },
+	  {
+		"documentation": [
+		  {
+			"content": [
+			  "Stack of Node Template straw from Provider Repository StallProvider"
+			],
+			"source": null,
+			"lang": null
+		  }
+		],
+		"any": [
+
+		],
+		"otherAttributes": {
+
+		},
+		"nodeTemplates": [
+		  {
+			"documentation": [
+
+			],
+			"any": [
+
+			],
+			"otherAttributes": {
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "StallProvider",
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "909",
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "62"
+			},
+			"id": "straw",
+			"type": "{http://winery.opentosca.org/test/ponyuniverse}straw",
+			"requirements": {
+			  "requirement": [
+				{
+				  "documentation": [
+
+				  ],
+				  "any": [
+
+				  ],
+				  "otherAttributes": {
+
+				  },
+				  "id": "hosting",
+				  "type": "{http://winery.opentosca.org/test/ponyuniverse}ReqCanHostStraw",
+				  "name": "ReqCanHostStraw"
+				}
+			  ]
+			},
+			"capabilities": {
+			  "capability": [
+				{
+				  "documentation": [
+
+				  ],
+				  "any": [
+
+				  ],
+				  "otherAttributes": {
+
+				  },
+				  "id": "providesAWarmGround",
+				  "type": "{http://winery.opentosca.org/test/ponyuniverse}CapWarmFloor",
+				  "name": "CapWarmFloor"
+				}
+			  ]
+			},
+			"name": "straw",
+			"minInstances": 1,
+			"maxInstances": "1"
+		  },
+		  {
+			"documentation": [
+
+			],
+			"any": [
+
+			],
+			"otherAttributes": {
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "StallProvider",
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "911",
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "485"
+			},
+			"id": "stall",
+			"type": "{http://winery.opentosca.org/test/ponyuniverse}stall",
+			"capabilities": {
+			  "capability": [
+				{
+				  "documentation": [
+
+				  ],
+				  "any": [
+
+				  ],
+				  "otherAttributes": {
+
+				  },
+				  "id": "providesAhost",
+				  "type": "{http://winery.opentosca.org/test/ponyuniverse}CapCanHostStraw",
+				  "name": "CapCanHostStraw"
+				}
+			  ]
+			},
+			"name": "stall",
+			"minInstances": 1,
+			"maxInstances": "1"
+		  }
+		],
+		"relationshipTemplates": [
+		  {
+			"documentation": [
+
+			],
+			"any": [
+
+			],
+			"otherAttributes": {
+
+			},
+			"id": "con_19",
+			"type": "{http://winery.opentosca.org/test/ponyuniverse}hostedOn",
+			"sourceElement": {
+			  "ref": "straw"
+			},
+			"targetElement": {
+			  "ref": "stall"
+			},
+			"name": "con_19"
+		  }
+		]
+	  }
+	]
+  },
+  "connectionInjections": {
+	"requiresDryFood": [
+	  {
+		"documentation": [
+		  {
+			"content": [
+			  "Stack of Node Template oat from Provider Repository FoodProvider"
+			],
+			"source": null,
+			"lang": null
+		  }
+		],
+		"any": [
+
+		],
+		"otherAttributes": {
+
+		},
+		"nodeTemplates": [
+		  {
+			"id": "oat",
+			"documentation": [
+
+			],
+			"any": [
+
+			],
+			"otherAttributes": {
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "FoodProvider",
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "730",
+			  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "180"
+			},
+			"type": "{http://winery.opentosca.org/test/ponyuniverse}oat",
+			"capabilities": {
+			  "capability": [
+				{
+				  "documentation": [
+
+				  ],
+				  "any": [
+
+				  ],
+				  "otherAttributes": {
+
+				  },
+				  "id": "provideDryFood",
+				  "type": "{http://winery.opentosca.org/test/ponyuniverse}CapDryFood",
+				  "name": "CapDryFood"
+				}
+			  ]
+			},
+			"name": "oat",
+			"minInstances": 1,
+			"maxInstances": "1"
+		  }
+		],
+		"relationshipTemplates": [
+
+		]
+	  }
+	]
+  }
+}

--- a/org.eclipse.winery.repository/src/test/resources/servicetemplates/ServiceTemplateResource-getInjectorOptionsWithoutOpenRequirements-badrequest.txt
+++ b/org.eclipse.winery.repository/src/test/resources/servicetemplates/ServiceTemplateResource-getInjectorOptionsWithoutOpenRequirements-badrequest.txt
@@ -1,0 +1,1 @@
+No need for matching

--- a/org.eclipse.winery.repository/src/test/resources/servicetemplates/ServiceTemplateResource-injectNodeTemplates-input.json
+++ b/org.eclipse.winery.repository/src/test/resources/servicetemplates/ServiceTemplateResource-injectNodeTemplates-input.json
@@ -1,0 +1,275 @@
+{"hostInjections": {
+  "shetland_pony": {
+	"documentation": [
+	  {
+		"content": [
+		  "Stack of Node Template pasture from Provider Repository PastureProvider"
+		],
+		"source": null,
+		"lang": null
+	  }
+	],
+	"any": [
+	],
+	"otherAttributes": {
+	},
+	"relationshipTemplates": [
+	],
+	"nodeTemplates": [
+	  {
+		"documentation": [
+		],
+		"any": [
+		],
+		"otherAttributes": {
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "PastureProvider",
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "841",
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "245"
+		},
+		"id": "pasture",
+		"type": "{http://winery.opentosca.org/test/ponyuniverse}pasture",
+		"capabilities": {
+		  "capability": [
+			{
+			  "documentation": [
+			  ],
+			  "any": [
+			  ],
+			  "otherAttributes": {
+			  },
+			  "id": "placeforaPony",
+			  "type": "{http://winery.opentosca.org/test/ponyuniverse}CapWarmFloor",
+			  "name": "CapWarmFloor"
+			}
+		  ]
+		},
+		"name": "pasture",
+		"minInstances": 1,
+		"maxInstances": "1"
+	  }
+	]
+  }
+},
+  "connectionInjections": {
+	"requiresDryFood":
+	{
+	  "documentation": [
+		{
+		  "content": [
+			"Stack of Node Template oat from Provider Repository FoodProvider"
+		  ],
+		  "source": null,
+		  "lang": null
+		}
+	  ],
+	  "any": [
+
+	  ],
+	  "otherAttributes": {
+
+	  },
+	  "nodeTemplates": [
+		{
+		  "documentation": [
+
+		  ],
+		  "any": [
+
+		  ],
+		  "otherAttributes": {
+			"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "FoodProvider",
+			"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "733",
+			"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "45"
+		  },
+		  "id": "oat",
+		  "type": "{http://winery.opentosca.org/test/ponyuniverse}oat",
+		  "requirements": {
+			"requirement": [
+			  {
+				"documentation": [
+
+				],
+				"any": [
+
+				],
+				"otherAttributes": {
+
+				},
+				"id": "requiredAHostingTrough",
+				"type": "{http://winery.opentosca.org/test/ponyuniverse}ReqCanHostOat",
+				"name": "ReqCanHostOat"
+			  }
+			]
+		  },
+		  "capabilities": {
+			"capability": [
+			  {
+				"documentation": [
+
+				],
+				"any": [
+
+				],
+				"otherAttributes": {
+
+				},
+				"id": "provideDryFood",
+				"type": "{http://winery.opentosca.org/test/ponyuniverse}CapDryFood",
+				"name": "CapDryFood"
+			  }
+			]
+		  },
+		  "name": "oat",
+		  "minInstances": 1,
+		  "maxInstances": "1"
+		},
+		{
+		  "documentation": [
+
+		  ],
+		  "any": [
+
+		  ],
+		  "otherAttributes": {
+			"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "FoodProvider",
+			"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "727",
+			"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "391"
+		  },
+		  "id": "trough",
+		  "type": "{http://winery.opentosca.org/test/ponyuniverse}trough",
+		  "capabilities": {
+			"capability": [
+			  {
+				"documentation": [
+
+				],
+				"any": [
+
+				],
+				"otherAttributes": {
+
+				},
+				"id": "CanHostOat",
+				"type": "{http://winery.opentosca.org/test/ponyuniverse}CapCanHostOat",
+				"name": "CapCanHostOat"
+			  }
+			]
+		  },
+		  "name": "trough",
+		  "minInstances": 1,
+		  "maxInstances": "1"
+		}
+	  ],
+	  "relationshipTemplates": [
+		{
+		  "documentation": [
+
+		  ],
+		  "any": [
+
+		  ],
+		  "otherAttributes": {
+
+		  },
+		  "id": "con_19",
+		  "type": "{http://winery.opentosca.org/test/ponyuniverse}hostedOn",
+		  "sourceElement": {
+			"ref": {
+			  "documentation": [
+
+			  ],
+			  "any": [
+
+			  ],
+			  "otherAttributes": {
+				"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "FoodProvider",
+				"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "733",
+				"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "45"
+			  },
+			  "id": "oat",
+			  "type": "{http://winery.opentosca.org/test/ponyuniverse}oat",
+			  "requirements": {
+				"requirement": [
+				  {
+					"documentation": [
+
+					],
+					"any": [
+
+					],
+					"otherAttributes": {
+
+					},
+					"id": "requiredAHostingTrough",
+					"type": "{http://winery.opentosca.org/test/ponyuniverse}ReqCanHostOat",
+					"name": "ReqCanHostOat"
+				  }
+				]
+			  },
+			  "capabilities": {
+				"capability": [
+				  {
+					"documentation": [
+
+					],
+					"any": [
+
+					],
+					"otherAttributes": {
+
+					},
+					"id": "provideDryFood",
+					"type": "{http://winery.opentosca.org/test/ponyuniverse}CapDryFood",
+					"name": "CapDryFood"
+				  }
+				]
+			  },
+			  "name": "oat",
+			  "minInstances": 1,
+			  "maxInstances": "1"
+			}
+		  },
+		  "targetElement": {
+			"ref": {
+			  "documentation": [
+
+			  ],
+			  "any": [
+
+			  ],
+			  "otherAttributes": {
+				"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "FoodProvider",
+				"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "727",
+				"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "391"
+			  },
+			  "id": "trough",
+			  "type": "{http://winery.opentosca.org/test/ponyuniverse}trough",
+			  "capabilities": {
+				"capability": [
+				  {
+					"documentation": [
+
+					],
+					"any": [
+
+					],
+					"otherAttributes": {
+
+					},
+					"id": "CanHostOat",
+					"type": "{http://winery.opentosca.org/test/ponyuniverse}CapCanHostOat",
+					"name": "CapCanHostOat"
+				  }
+				]
+			  },
+			  "name": "trough",
+			  "minInstances": 1,
+			  "maxInstances": "1"
+			}
+		  },
+		  "name": "con_19"
+		}
+	  ]
+	}
+  }
+}

--- a/org.eclipse.winery.repository/src/test/resources/servicetemplates/ServiceTemplateResource-injectNodeTemplates-input2.json
+++ b/org.eclipse.winery.repository/src/test/resources/servicetemplates/ServiceTemplateResource-injectNodeTemplates-input2.json
@@ -1,0 +1,196 @@
+{ "hostInjections": {
+  "shetland_pony":
+  {
+	"documentation": [
+	  {
+		"content": [
+		  "Stack of Node Template straw from Provider Repository StallProvider"
+		],
+		"source": null,
+		"lang": null
+	  }
+	],
+	"any": [
+
+	],
+	"otherAttributes": {
+
+	},
+	"nodeTemplates": [
+	  {
+		"documentation": [
+
+		],
+		"any": [
+
+		],
+		"otherAttributes": {
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "StallProvider",
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "909",
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "62"
+		},
+		"id": "straw",
+		"type": "{http://winery.opentosca.org/test/ponyuniverse}straw",
+		"requirements": {
+		  "requirement": [
+			{
+			  "documentation": [
+
+			  ],
+			  "any": [
+
+			  ],
+			  "otherAttributes": {
+
+			  },
+			  "id": "hosting",
+			  "type": "{http://winery.opentosca.org/test/ponyuniverse}ReqCanHostStraw",
+			  "name": "ReqCanHostStraw"
+			}
+		  ]
+		},
+		"capabilities": {
+		  "capability": [
+			{
+			  "documentation": [
+
+			  ],
+			  "any": [
+
+			  ],
+			  "otherAttributes": {
+
+			  },
+			  "id": "providesAWarmGround",
+			  "type": "{http://winery.opentosca.org/test/ponyuniverse}CapWarmFloor",
+			  "name": "CapWarmFloor"
+			}
+		  ]
+		},
+		"name": "straw",
+		"minInstances": 1,
+		"maxInstances": "1"
+	  },
+	  {
+		"documentation": [
+
+		],
+		"any": [
+
+		],
+		"otherAttributes": {
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "StallProvider",
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "911",
+		  "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "485"
+		},
+		"id": "stall",
+		"type": "{http://winery.opentosca.org/test/ponyuniverse}stall",
+		"capabilities": {
+		  "capability": [
+			{
+			  "documentation": [
+
+			  ],
+			  "any": [
+
+			  ],
+			  "otherAttributes": {
+
+			  },
+			  "id": "providesAhost",
+			  "type": "{http://winery.opentosca.org/test/ponyuniverse}CapCanHostStraw",
+			  "name": "CapCanHostStraw"
+			}
+		  ]
+		},
+		"name": "stall",
+		"minInstances": 1,
+		"maxInstances": "1"
+	  }
+	],
+	"relationshipTemplates": [
+	  {
+		"documentation": [
+
+		],
+		"any": [
+
+		],
+		"otherAttributes": {
+
+		},
+		"id": "con_19",
+		"type": "{http://winery.opentosca.org/test/ponyuniverse}hostedOn",
+		"sourceElement": {
+		  "ref": "straw"
+		},
+		"targetElement": {
+		  "ref": "stall"
+		},
+		"name": "con_19"
+	  }
+	]
+  }
+},
+  "connectionInjections": {
+	"requiresDryFood":
+	{
+	  "documentation": [
+		{
+		  "content": [
+			"Stack of Node Template oat from Provider Repository FoodProvider"
+		  ],
+		  "source": null,
+		  "lang": null
+		}
+	  ],
+	  "any": [
+
+	  ],
+	  "otherAttributes": {
+
+	  },
+	  "nodeTemplates": [
+		{
+		  "id": "oat",
+		  "documentation": [
+
+		  ],
+		  "any": [
+
+		  ],
+		  "otherAttributes": {
+			"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}location": "FoodProvider",
+			"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}x": "730",
+			"{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}y": "180"
+		  },
+		  "type": "{http://winery.opentosca.org/test/ponyuniverse}oat",
+		  "capabilities": {
+			"capability": [
+			  {
+				"documentation": [
+
+				],
+				"any": [
+
+				],
+				"otherAttributes": {
+
+				},
+				"id": "provideDryFood",
+				"type": "{http://winery.opentosca.org/test/ponyuniverse}CapDryFood",
+				"name": "CapDryFood"
+			  }
+			]
+		  },
+		  "name": "oat",
+		  "minInstances": 1,
+		  "maxInstances": "1"
+		}
+	  ],
+	  "relationshipTemplates": [
+
+	  ]
+	}
+  }
+}

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/index.jsp
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/index.jsp
@@ -14,7 +14,7 @@
  *    Niko Stadelmaier - removal of select2 library
  *    Philipp Meyer - removal of select2 library
  *    Lukas Balzer, Nicole Keppler - switch to bootstrap-touchspin
- *    Karoline Saatkamp - maintenance
+ *    Karoline Saatkamp - add matching and maintenance
  *******************************************************************************/
 --%>
 
@@ -447,6 +447,8 @@ Collection<QNameWithName> artifactTemplateList = client.getListOfAllInstances(Ar
 
 		<button class="btn btn-default" onclick="winery.events.fire(winery.events.name.command.SPLIT);" id="splitBtn" data-loading-text="Splitting...">Split</button>
 
+		<button class="btn btn-default" onclick="winery.events.fire(winery.events.name.command.MATCH);" id="matchBtn" data-loading-text="Matching...">Match</button>
+
 		<button class="btn btn-default topbutton" onclick="winery.events.fire(winery.events.name.command.IMPORT_TOPOLOGY);" id="importBtn">Import Topology</button>
 
 		<div class="btn-group">
@@ -650,6 +652,7 @@ Collection<QNameWithName> artifactTemplateList = client.getListOfAllInstances(Ar
 		winery.events.register(winery.events.name.command.IMPORT_TOPOLOGY, wt.openChooseTopologyToImportDiag);
 		winery.events.register(winery.events.name.command.SAVE, wt.save);
 		winery.events.register(winery.events.name.command.SPLIT, wt.split);
+		winery.events.register(winery.events.name.command.MATCH, wt.match);
 		wt.setTopologyTemplateURL("<%=topologyTemplateURL%>");
 	});
 </script>

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-topologymodeler-AMD.js
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-topologymodeler-AMD.js
@@ -29,6 +29,7 @@ define(
 			importTopology: importTopology,
 			save: save,
 			split: split,
+			match: match,
 			setTopologyTemplateURL: function (url) {
 				topologyTemplateURL = url;
 			},
@@ -116,7 +117,7 @@ define(
 			$("#splitBtn").button("loading");
 
 			$.ajax({
-				url: topologyTemplateURL,
+				url: topologyTemplateURL + 'split',
 				type: "POST",
 				success: function(data, textStatus, jqXHR) {
 					$("#splitBtn").button("reset");
@@ -126,6 +127,27 @@ define(
 				error: function(jqXHR, textStatus, errorThrown) {
 					$("#splitBtn").button("reset");
 					vShowAJAXError("Could not split", jqXHR, errorThrown);
+				}
+			});
+		}
+
+		/**
+		 * "doMatch"
+		 */
+		function match() {
+			$("#matchBtn").button("loading");
+
+			$.ajax({
+				url: topologyTemplateURL + 'match',
+				type: "POST",
+				success: function(data, textStatus, jqXHR) {
+					$("#matchBtn").button("reset");
+					var location = jqXHR.getResponseHeader("Location");
+					vShowSuccess("Successfully matched. <a target=\"_blank\" href=\"" + location + "\">Open matched service template</a>");
+				},
+				error: function(jqXHR, textStatus, errorThrown) {
+					$("#matchBtn").button("reset");
+					vShowAJAXError("Could not match", jqXHR, errorThrown);
 				}
 			});
 		}

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-topologymodeler.js
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-topologymodeler.js
@@ -315,3 +315,4 @@ winery.events.name.command.MOVE_RIGHT = "moveRight";
 
 winery.events.name.command.SAVE = "save";
 winery.events.name.command.SPLIT = "split";
+winery.events.name.command.MATCH = "match";


### PR DESCRIPTION
For each open requirement found in a topology a suitable candidate with the
matching capability is searched in the provider repositories.
Furthermore, the matching relationship between the requirement and capability is searched.
Not only single nodes but also topolgoy fragments can be injected.

Furthermore, the matching of hosts used for the splitting function is replaced by this
advanced matching function.

Modify the API to enable the injection of the topology fragments.

To use this functionality a strict type and inheritance system is important.
These are the rules:
	- Each capability type with the semantic, that it acts as host/container has to be derived from the capability "Container"
	- Each capability type with the semantic, that it acts as a endpoint has to be derived from the capability "Endpoint"
	- The two default relationship types "hostedOn" and "connectsTo" should ne available and requires as valid target the 
	capability "Container" oder "Endpoint"

Signed-off-by: Karoline Saatkamp <karoline.saatkamp@iaas.uni-stuttgart.de>

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for UI changes)
