### PR TITLE
fixes issue with XaaS Packager dialog sending undefined qnames 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We refer to [GitHub issues](https://github.com/eclipse/winery/issues) by using `
 * Enfore `LF` line endings in the repository
 * Add splitting functionality based on target labels
 * BREAKING: in the tosca model `SourceElement` and `TargetElement` are combined into `SourceOrTargetElement` due to serialization issues with JSON
+* Fix: If there are only XaaS packages without an infrastructure node defined the XaasPackager dialog  sends an undefined QName, got fixed by adding a check
 
 ### Fixed
 * Bounary definitions can be browsed for exported operations again

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplatesResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplatesResource.java
@@ -57,7 +57,7 @@ public class ServiceTemplatesResource extends AbstractComponentsResource<Service
 				toRemove.add(serviceTemplate);
 				continue;
 			}
-			if (infrastructureNodeType != null) {
+			if (infrastructureNodeType != null && !infrastructureNodeType.getLocalPart().equals("undefined")) {
 				if (Utils.getTagValue(new ServiceTemplateResource(serviceTemplate).getServiceTemplate(), "xaasPackageInfrastructure") == null) {
 					toRemove.add(serviceTemplate);
 					continue;


### PR DESCRIPTION
Fixes issue with XaaS Packager sending an undefined infrastructure node type when there is no XaaS package available with a defined infrastructure node type set (infrastructure node is optional)

Signed-off-by: Kálmán Képes <kalman.kepes@iaas.uni-stuttgart.de>
