### PR TITLE
Remove select2 and fix issues at visualappearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@ We refer to [GitHub issues](https://github.com/eclipse/winery/issues) by using `
 
 ### Fixed
 * Bounary definitions can be browsed for exported operations again
+* Relationship Type -> Visual Appearance  "Arrow" tab can opened again
+* Boundary definitions -> interfaces
+	*	interfaces selection is properly reloaded if new interface is added
+	*	operations selection is properly reloaded if new operation is added
+

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/entitytypes/relationshiptypes/visualappearance.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/entitytypes/relationshiptypes/visualappearance.jsp
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2012-2016 University of Stuttgart.
+ * Copyright (c) 2012-2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -22,7 +22,7 @@
 <ul class="nav nav-tabs" id="myTab">
 	<li class="active"><a href="#icon">Icon</a></li>
 	<li><a href="#colors">Colors</a></li>
-	<li><a href="#arrow">Arrow</a></li>
+	<li><a href="#arrowDiv">Arrow</a></li>
 </ul>
 
 <div class="tab-content">

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/servicetemplates/boundarydefinitions/boundarydefinitions.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/servicetemplates/boundarydefinitions/boundarydefinitions.jsp
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2016 University of Stuttgart.
+ * Copyright (c) 2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -337,14 +337,14 @@
 			<div class="form-group">
 				<label for="interface" class="col-sm-1 control-label">Interface</label>
 				<div class="col-sm-8">
-					<input id="interface" class="form-control" placeholder="NCName or URI">
+					<input id="interface" autocomplete="off" class="form-control" placeholder="NCName or URI">
 				</div>
 				<button type="button" class="btn btn-danger btn-sm col-sm-1" onclick="deleteCurrentlySelectedInterface();">Delete</button>
 			</div>
 			<div class="form-group">
 				<label for="operation" class="col-sm-1 control-label">Operation</label>
 				<div class="col-sm-8">
-					<input id="operation" class="form-control" placeholder="NCName">
+					<input id="operation" autocomplete="off" class="form-control" placeholder="NCName">
 				</div>
 				<button type="button" class="btn btn-danger btn-sm col-sm-1" onclick="deleteCurrentlySelectedOperation();">Delete</button>
 			</div>
@@ -435,13 +435,22 @@
 	require(["winery-support-common"], function(wsc) {
 		wsc.fetchSelect2DataAndInitSelect2("interface", "boundarydefinitions/interfaces/?select2", function() {
 			$("#interface").on("change", function() {
+				$("#operation").val("");
 				updateOperationsField();
 			});
 			if ($("#interface").val()!= "") {
+				$("#operation").val("");
 				updateOperationsField();
 			}
 		}, true);
 	});
+
+	function updateInterfaces(){
+		require(["winery-support-common"], function(wsc) {
+		    //pass null as callback since event handler for interfaces are alredy set above, therefore no callback required
+			wsc.fetchSelect2DataAndInitSelect2("interface", "boundarydefinitions/interfaces/?select2", null, true);
+		});
+	}
 
 	function getInterfacesAndInterfaceURLs() {
 		var iface = $("#interface").val();
@@ -490,6 +499,7 @@
 						contentType: "application/json"
 					}).done(function (result) {
 						vShowSuccess("Sucessfully created interface");
+						updateInterfaces();
 					}).fail(function(jqXHR, textStatus, errorThrown) {
 						vShowAJAXError("Could not create interface", jqXHR, errorThrown);
 					});
@@ -523,6 +533,7 @@
 						contentType: "application/json"
 					}).done(function (result) {
 						vShowSuccess("Sucessfully created operation");
+						updateOperationsField();
 					}).fail(function(jqXHR, textStatus, errorThrown) {
 						vShowAJAXError("Could not create interface", jqXHR, errorThrown);
 					});

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
@@ -1,6 +1,6 @@
 <%--
 /*******************************************************************************
- * Copyright (c) 2012-2016 University of Stuttgart.
+ * Copyright (c) 2012-2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -34,12 +34,13 @@
 <!-- createArtifactTemplate class is required for artifactcreationdialog -->
 <div class="form-group createArtifactTemplate">
 	<label for="${idOfInput}" class="control-label">Namespace</label>
-	<input type="hidden" class="form-control" name="${nameOfInput}" id="${idOfInput}"></input>
+	<input type="text" class="form-control" name="${nameOfInput}" id="${idOfInput}"></input>
 </div>
 
 <script>
 	// we have to use data as select2 does not allow "createSearchChoice" when using <select> as underlying html element
-require("bootstrap3-typeahead", function(){
+	require(["bootstrap3-typeahead"], function () {
+
 	$("#${idOfInput}").typeahead({
 
 		source:[

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/index.jsp
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/index.jsp
@@ -1521,7 +1521,7 @@ function onDoneRegisterConnectionTypesAndConnectNodeTemplates() {
 			</div>
 			<div class="modal-footer">
 				<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-				<button type="button" id="importButon" class="btn btn-primary" data-loading="Adding..."  onclick="require(['winery-topologymodeler-AMD'], function(wt) {wt.importTopology('<%=repositoryURL%>/servicetemplates/', $('#serviceTemplate').select2('data').id);})">Add</button>
+				<button type="button" id="importButon" class="btn btn-primary" data-loading="Adding..."  onclick="require(['winery-topologymodeler-AMD'], function(wt) {wt.importTopology('<%=repositoryURL%>/servicetemplates/', $('#serviceTemplate').val());})">Add</button>
 			</div>
 		</div>
 	</div>

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-support-common.js
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-support-common.js
@@ -183,7 +183,8 @@ define([], function() {
 				}
 				// console.log("params", params);
 				// init select2 and select first item
-				require(["bootstrap3-typeahead"], function(){
+				require(["bootstrap3-typeahead"], function() {
+					$("#" + fieldId).typeahead('destroy');
 					$("#" + fieldId).typeahead(params);
 					if (result.length === 0) {
 						$("#" + fieldId).val("");


### PR DESCRIPTION
Removes the select2 library from the winery UI. Fixes bugs at Relationship Types -> Visual Appearance
The select2 library is replaced by bootstrap3-typeahead and standard HTML select elements.
Further fixes selection of Arrow tab at Relationship Types->Visual Appearance.

Signed-off-by: Niko Stadelmaier <nstadelmaier.dev@gmail.com>

<!-- describe the changes you have made here: what, why, ... -->
- [x] Remove select2 from UI (Repository and Topologymodeler)
- [x] Operations selection at Boundary Definitions -> Interfaces is reloaded after creating a new operation
- [x] Arrow tab at visual appearance can be selected again 
- [x] Change in CHANGELOG.md described
- [x] Tests created for changes (UI compared with master and tested with winery quickstart guide and additional manual tests)

