### PR TITLE
Add TOSCA Namespace Alias value

### DIFF
--- a/org.eclipse.winery.repository/src/test/resources/yaml/artifact_types.yaml
+++ b/org.eclipse.winery.repository/src/test/resources/yaml/artifact_types.yaml
@@ -9,9 +9,15 @@
 #
 
 ##########################################################################
+# TOSCA Namespacing keyword specifies the TOSCA Namespace Alias value which 
+# all TOSCA Service Templates MUST always have.
+##########################################################################
+tosca_definitions_version: tosca_simple_yaml_1_1
+
+##########################################################################
 # TOSCA Artifacts Types represent the types of packages and files used by 
 # the orchestrator when deploying  TOSCA Node or Relationship Types or 
-# nvoking their interfaces. 
+# invoking their interfaces. 
 ##########################################################################    
 artifact_types:
 

--- a/org.eclipse.winery.repository/src/test/resources/yaml/capability_types.yaml
+++ b/org.eclipse.winery.repository/src/test/resources/yaml/capability_types.yaml
@@ -8,6 +8,12 @@
 # and http://www.apache.org/licenses/LICENSE-2.0
 #
 
+##########################################################################
+# TOSCA Namespacing keyword specifies the TOSCA Namespace Alias value which 
+# all TOSCA Service Templates MUST always have.
+##########################################################################
+tosca_definitions_version: tosca_simple_yaml_1_1
+
 capability_types:
 
   ##########################################################################

--- a/org.eclipse.winery.repository/src/test/resources/yaml/data_types.yaml
+++ b/org.eclipse.winery.repository/src/test/resources/yaml/data_types.yaml
@@ -8,6 +8,12 @@
 # and http://www.apache.org/licenses/LICENSE-2.0
 #
 
+##########################################################################
+# TOSCA Namespacing keyword specifies the TOSCA Namespace Alias value which 
+# all TOSCA Service Templates MUST always have.
+##########################################################################
+tosca_definitions_version: tosca_simple_yaml_1_1
+
 data_types:
 
   ##########################################################################

--- a/org.eclipse.winery.repository/src/test/resources/yaml/group_types.yaml
+++ b/org.eclipse.winery.repository/src/test/resources/yaml/group_types.yaml
@@ -9,6 +9,12 @@
 #
 
 ##########################################################################
+# TOSCA Namespacing keyword specifies the TOSCA Namespace Alias value which 
+# all TOSCA Service Templates MUST always have.
+##########################################################################
+tosca_definitions_version: tosca_simple_yaml_1_1
+
+##########################################################################
 # TOSCA Group Types represent logical groupings of TOSCA nodes that have an 
 # implied membership relationship and may need to be orchestrated or managed 
 # together to achieve some result.  Some use cases being developed by the 

--- a/org.eclipse.winery.repository/src/test/resources/yaml/interface_types.yaml
+++ b/org.eclipse.winery.repository/src/test/resources/yaml/interface_types.yaml
@@ -9,6 +9,12 @@
 #
 
 ##########################################################################
+# TOSCA Namespacing keyword specifies the TOSCA Namespace Alias value which 
+# all TOSCA Service Templates MUST always have.
+##########################################################################
+tosca_definitions_version: tosca_simple_yaml_1_1
+
+##########################################################################
 # Interfaces are reusable entities that define a set of operations that that 
 # can be included as part of a Node type or Relationship Type definition. 
 # Each named operations may have code or scripts associated with them that 

--- a/org.eclipse.winery.repository/src/test/resources/yaml/node_types.yaml
+++ b/org.eclipse.winery.repository/src/test/resources/yaml/node_types.yaml
@@ -8,6 +8,12 @@
 # and http://www.apache.org/licenses/LICENSE-2.0
 #
 
+##########################################################################
+# TOSCA Namespacing keyword specifies the TOSCA Namespace Alias value which 
+# all TOSCA Service Templates MUST always have.
+##########################################################################
+tosca_definitions_version: tosca_simple_yaml_1_1
+
 node_types:
 
   ##########################################################################

--- a/org.eclipse.winery.repository/src/test/resources/yaml/policy_types.yaml
+++ b/org.eclipse.winery.repository/src/test/resources/yaml/policy_types.yaml
@@ -9,6 +9,12 @@
 #
 
 ##########################################################################
+# TOSCA Namespacing keyword specifies the TOSCA Namespace Alias value which 
+# all TOSCA Service Templates MUST always have.
+##########################################################################
+tosca_definitions_version: tosca_simple_yaml_1_1
+
+##########################################################################
 # TOSCA Policy Types represent logical grouping of TOSCA nodes that have an 
 # implied relationship and need to be orchestrated or managed together to 
 # achieve some result.  Some use cases being developed by the TOSCA TC use 

--- a/org.eclipse.winery.repository/src/test/resources/yaml/relationship_types.yaml
+++ b/org.eclipse.winery.repository/src/test/resources/yaml/relationship_types.yaml
@@ -8,6 +8,12 @@
 # and http://www.apache.org/licenses/LICENSE-2.0
 #
 
+##########################################################################
+# TOSCA Namespacing keyword specifies the TOSCA Namespace Alias value which 
+# all TOSCA Service Templates MUST always have.
+##########################################################################
+tosca_definitions_version: tosca_simple_yaml_1_1
+
 relationship_types:
 
   ##########################################################################

--- a/org.eclipse.winery.repository/src/test/resources/yaml/tosca-simple-profile-1.0.yaml
+++ b/org.eclipse.winery.repository/src/test/resources/yaml/tosca-simple-profile-1.0.yaml
@@ -8,6 +8,12 @@
 # and http://www.apache.org/licenses/LICENSE-2.0
 #
 
+##########################################################################
+# TOSCA Namespacing keyword specifies the TOSCA Namespace Alias value which 
+# all TOSCA Service Templates MUST always have.
+##########################################################################
+tosca_definitions_version: tosca_simple_yaml_1_1
+
 imports:
   - artifact_types.yaml
   - capability_types.yaml


### PR DESCRIPTION
Signed-off-by: Christoph Kleine <kleinech.github@gmail.com>

<!-- describe the changes you have made here: what, why, ... -->
All TOSCA Simple Profile in YAML Service Templates MUST always have 
the keyword "tosca_definitions_version" 
with an associated TOSCA Namespace Alias value.

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
