### PR TITLE
Move IntelliJ docu to IntelliJ README.md

### DIFF
--- a/docs/dev/ToolChain.md
+++ b/docs/dev/ToolChain.md
@@ -13,25 +13,11 @@
 
 <!-- tocstop -->
 
-## IntelliJ
+This presents the tool chain used for creating and updating a pull request on GitHub.
 
-* Install Plugins
-  1. JRebel
-    - JRebel enables a better debugging - changes can be immediately loaded without building the whole project again
-    - Download https://zeroturnaround.com/software/jrebel/
-    - File --> Settings --> Plugins --> Search for JRebel
-    - If JRebel is not available press "Browse repositories" --> Search -->Install
-  2. Checkstyle
-    - httpa://eclipse.github.io/winery/ --> IntelliJ Ultimate Setup
-    - Follow the steps and apply it in IntelliJ
-* Shortcuts
-  - 2x Shift / Str + Shift + F / Str + F: Differrent forms of search
-  - Str + Alt + O: check style
-  - Str + X: if nothing is marked - delete line and free space
-  
-## Git and GitHub
+For setup the IDE, please go to the [DevGuide](./).
 
-### GitHub - Start
+## GitHub - Start
 
 * To contribute to the winery you need a github account and access to https://github.com/opentosca/winery
 * First steps:
@@ -48,13 +34,13 @@
   5. Commit. Don't forget to sign the commit (Ctrl+S in Git Gui)
   6. Push the changes to origin: git push
 
-### GitHub - Preparation First Pull Request
+## GitHub - Preparation First Pull Request
 
 * Check winery/CONTRIBUTING.md and carefully read the instruction
 * http://wiki.eclipse.org/Development_Resources/Contributing_via_Git --> Create an account WITH THE SAME EMAIL THEN USED FOR THE COMMITS (can also be checked in Gitk)
 * Sign the Contributor Agreement electronically
 
-### GitHub - Prepare Pull Request
+## GitHub - Prepare Pull Request
 
 * Check [CONTRIBUTING.MD](https://github.com/eclipse/winery/blob/master/CONTRIBUTING.md)
 * Steps to prepare Pull Request:
@@ -69,7 +55,7 @@
   9. Sign the Commit Message (<kbd>Ctrl</kbd>+<kbd>S</kbd>)
   10. Commit & Push with "force overwrite" since you changed the branch: `git push -f`
 
-### GitHub - Create Pull Request
+## GitHub - Create Pull Request
 
 Attention: Commits on the same branch done after the Pull Request is sent are still part of the Pull Request (!)
 
@@ -79,8 +65,7 @@ Attention: Commits on the same branch done after the Pull Request is sent are st
 * Add `[x]` to the items listed in the write field
 * Check the description in the Preview and send the Pull Request
 
-
-### GitHub - Change Pull Request
+## GitHub - Change Pull Request
 
 * There are automatic checks in place
 
@@ -96,6 +81,6 @@ Attention: Commits on the same branch done after the Pull Request is sent are st
   - Commit
   - Push
 
-### Excursus: Git
+## Excursus: Git
 
 ![ExcursusGit](graphics/ExcursusGit.png)

--- a/docs/dev/ToolChain.md
+++ b/docs/dev/ToolChain.md
@@ -2,14 +2,12 @@
 
 <!-- toc -->
 
-- [IntelliJ](#intellij)
-- [Git and GitHub](#git-and-github)
-  * [GitHub - Start](#github---start)
-  * [GitHub - Preparation First Pull Request](#github---preparation-first-pull-request)
-  * [GitHub - Prepare Pull Request](#github---prepare-pull-request)
-  * [GitHub - Create Pull Request](#github---create-pull-request)
-  * [GitHub - Change Pull Request](#github---change-pull-request)
-  * [Excursus: Git](#excursus-git)
+- [GitHub - Start](#github---start)
+- [GitHub - Preparation First Pull Request](#github---preparation-first-pull-request)
+- [GitHub - Prepare Pull Request](#github---prepare-pull-request)
+- [GitHub - Create Pull Request](#github---create-pull-request)
+- [GitHub - Change Pull Request](#github---change-pull-request)
+- [Excursus: Git](#excursus-git)
 
 <!-- tocstop -->
 
@@ -25,14 +23,14 @@ For setup the IDE, please go to the [DevGuide](./).
   2. git remote add upstream [https://github.com/eclipse/winery.git]
 * Steps for working on a topic
   1. Create a new branch for each topic (fix a bug, add functionality) and name it accordingly.
-  2. Sync with latest upstream/master: git fech upstream
-  3. Create branch based on upstream/master and make it known publicly:  
-     git checkout upstream/master  
-	 git checkout -b [name]  
-	 git push --set-upstream origin [name]
+  2. Sync with latest upstream/master: `git fetch upstream`
+  3. Create branch based on `upstream/master` and make it known publicly:
+     - `git checkout upstream/master`
+	 - `git checkout -b [name]`
+	 - `git push --set-upstream origin [name]`
   4. Work on the branch with the specific name
-  5. Commit. Don't forget to sign the commit (Ctrl+S in Git Gui)
-  6. Push the changes to origin: git push
+  5. Commit. Don't forget to sign the commit (<kbd>Ctrl</kbd>+<kbd>S</kbd> in Git Gui)
+  6. Push the changes to origin: `git push`
 
 ## GitHub - Preparation First Pull Request
 
@@ -61,7 +59,7 @@ Attention: Commits on the same branch done after the Pull Request is sent are st
 
 * Go to eclipse/winery --> Pull Request
 * Fill in the title of the Pull Request and give a more detailed description of the changes or added functionality
-* In case of UI changes: Add Screenshots
+* In case of UI changes: Add screenshots
 * Add `[x]` to the items listed in the write field
 * Check the description in the Preview and send the Pull Request
 

--- a/docs/dev/config/IntelliJ IDEA/README.md
+++ b/docs/dev/config/IntelliJ IDEA/README.md
@@ -2,8 +2,20 @@
 ---
 # IntelliJ Configuration
 
-1. First of all, generate a war to have all dependencies fetched by maven.
-2. Open IntelliJ
+Preparation: Generate a war to have all dependencies fetched by maven: `mvn package`
+
+1. Install JRebel plugin
+    - JRebel enables a better debugging - changes can be immediately loaded without building the whole project again
+    - Download https://zeroturnaround.com/software/jrebel/
+    - Get a JRebel license from <https://my.rebel.com>.
+      It is for free if JRebel may post to your Twitter account.
+    - File --> Settings --> Plugins --> Search for JRebel
+    - If JRebel is not available press "Browse repositories" --> Search -->Install
+2. Enable checkstyle: Follow the shown steps and apply them in IntelliJ
+  ![Enable CheckStyle in IntelliJ](activate-checkstyle.gif)
+  - Install the [IntelliJ Checkstyle Plugin](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea).
+  - Open Settings > Other Settings > CheckStyle.
+  - Click on the green plus and add `checkstyle.xml` from the root of the Winery code repository.
 3. Open `pom.xml` in the main directory
 4. Configure the code style
     1. Press <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>S</kbd>
@@ -16,15 +28,12 @@
     7. Press "OK"
     8. Press "Close"
     9. Press "OK"
-5. Enable checkstyle:
-  ![Enable CheckStyle in IntelliJ](activate-checkstyle.gif)
 6. Setup tomcat as usual.
-7. Recommended: Get a JRebel license from <https://my.rebel.com>.
-   It is for free if JRebel may post to your Twitter account.
 
 ## Further Remarks
 
 * Please let `.editorconfig` override the settings of IntelliJ
-* Install the [IntelliJ Checkstyle Plugin](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea).
-  Open Settings > Other Settings > CheckStyle.
-  Click on the green plus and add `checkstyle.xml` from the root of the Winery code repository.
+* Shortcuts
+  - 2x <kbd>Shift</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> / <kbd>Ctrl</kbd>+<kbd>F</kbd>: Differrent forms of search
+  - <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd>: Organize imports (fixes checkstyle)
+  - <kbd>Ctrl</kbd>+<kbd>X</kbd>: if nothing is marked: delete line and free space


### PR DESCRIPTION
The documentation about IntelliJ is moved from ToolChain.md to a separate README.md. Reason: ToolChain is shared more often to external committers who have their IDE configured properly.