### PR TITLE
URLs fragments are now single encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ We refer to [GitHub issues](https://github.com/eclipse/winery/issues) by using `
 
 ## [unreleased]
 
+### Changed
+
+* **BREAKING** URL fragments are now single encoded only. The double encoding is not necessary, as each hosting component (Tomcat, ...) can be configured to let `%2F` pass through.
+
 ### Removed
+
 * `csarname` is empty at all CSAR exports
 * `data.json` is not exported any more
 

--- a/docs/dev/config/IntelliJ IDEA/README.md
+++ b/docs/dev/config/IntelliJ IDEA/README.md
@@ -28,7 +28,7 @@ Preparation: Generate a war to have all dependencies fetched by maven: `mvn pack
     7. Press "OK"
     8. Press "Close"
     9. Press "OK"
-6. Setup tomcat as usual.
+6. Setup tomcat as usual and additionally add this to `VM Options`: `-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true`
 
 ## Further Remarks
 

--- a/docs/user/HostingConfiguration.md
+++ b/docs/user/HostingConfiguration.md
@@ -1,0 +1,16 @@
+# Hosting Configuration
+
+We use `%2F` in URLs which is not allowed by default in many systems.
+This document lists how to configure each one of them.
+
+## Apache Tomcat
+
+Pass `-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true` as argument.
+See also <https://stackoverflow.com/a/15949229/873282>.
+
+It is not possible to set this in Winery during execution:
+It has to be configured outside.
+
+## Apache Web Server
+
+Use [AllowEncodedSlashes](http://httpd.apache.org/docs/2.2/mod/core.html#allowencodedslashes)

--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/Util.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/Util.java
@@ -98,19 +98,15 @@ public class Util {
         }
     }
 
-    public static String DoubleURLencode(String s) {
-        return Util.URLencode(Util.URLencode(s));
-    }
-
     /**
      * Encodes the namespace and the localname of the given qname, separated by
      * "/"
      *
-     * @return <double encoded namespace>"/"<double encoded localname>
+     * @return <encoded namespace>"/"<encoded localname>
      */
-    public static String DoubleURLencode(QName qname) {
-        String ns = Util.DoubleURLencode(qname.getNamespaceURI());
-        String localName = Util.DoubleURLencode(qname.getLocalPart());
+    public static String URLencode(QName qname) {
+        String ns = Util.URLencode(qname.getNamespaceURI());
+        String localName = Util.URLencode(qname.getLocalPart());
         return ns + "/" + localName;
     }
 
@@ -224,7 +220,7 @@ public class Util {
             return "(none)";
         }
 
-        String absoluteURL = repositoryUrl + "/" + Util.getURLpathFragmentForCollection(element) + "/" + Util.DoubleURLencode(qname.getNamespaceURI()) + "/" + Util.DoubleURLencode(qname.getLocalPart());
+        String absoluteURL = repositoryUrl + "/" + Util.getURLpathFragmentForCollection(element) + "/" + Util.URLencode(qname);
 
         if (name == null) {
             // fallback if no name is given

--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ids/IdUtil.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ids/IdUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 University of Stuttgart.
+ * Copyright (c) 2013-2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and the Apache License 2.0 which both accompany this distribution,
@@ -26,7 +26,7 @@ public class IdUtil {
      * parent has to be asked for its namespace. The parent, in turn, if it is
      * no TOSCAComponentId has to ask his parent.
      *
-     * @param id the id refering to an element, where the namespace has to be
+     * @param id the id referencing to an element, where the namespace has to be
      *            checked for
      * @return the namespace of the element denoted by id
      */
@@ -35,41 +35,6 @@ public class IdUtil {
             return ((TOSCAComponentId) id).getNamespace();
         } else {
             return IdUtil.getNamespace(id.getParent());
-        }
-    }
-
-    /**
-     * Executes the real conversion to a path fragment
-     *
-     * @param id the id to transform to a path
-     * @param doubleEncode true if each sub fragment should be double encoded,
-     *            false if it should be encoded only once
-     */
-    private static String getPathFragment(final GenericId id, final boolean doubleEncode) {
-        String toInsert;
-        if (id instanceof TOSCAComponentId) {
-            // @return "[ComponentName]s/{namespace}/{id}/"
-            TOSCAComponentId tId = (TOSCAComponentId) id;
-            String res = Util.getRootPathFragment(tId.getClass());
-            toInsert = tId.getNamespace().getEncoded();
-            if (doubleEncode) {
-                toInsert = Util.URLencode(toInsert);
-            }
-            res = res + toInsert + "/";
-            toInsert = tId.getXmlId().getEncoded();
-            if (doubleEncode) {
-                toInsert = Util.URLencode(toInsert);
-            }
-            res = res + toInsert + "/";
-            return res;
-        } else if (id instanceof TOSCAElementId) {
-            toInsert = id.getXmlId().getEncoded();
-            if (doubleEncode) {
-                toInsert = Util.URLencode(toInsert);
-            }
-            return IdUtil.getPathFragment(id.getParent()) + toInsert + "/";
-        } else {
-            throw new IllegalStateException("Unknown subclass of GenericId " + id.getClass());
         }
     }
 
@@ -84,20 +49,22 @@ public class IdUtil {
      *         inside a URL
      */
     public static String getPathFragment(GenericId id) {
-        return IdUtil.getPathFragment(id, false);
-    }
-
-    /**
-     * Returns the fragment of the URL path belonging to the id
-     *
-     * For instance, an Id of type ServiceTemplateId has
-     * <code>servicetemplates/{double encoded ns}/{double encoded name}/</encode>
-     *
-     * @param id the element to return the path fragment for
-     * @return the path fragment to be used inside an URL
-     */
-    public static String getURLPathFragment(GenericId id) {
-        return IdUtil.getPathFragment(id, true);
+        String toInsert;
+        if (id instanceof TOSCAComponentId) {
+            // @return "[ComponentName]s/{namespace}/{id}/"
+            TOSCAComponentId tId = (TOSCAComponentId) id;
+            String res = Util.getRootPathFragment(tId.getClass());
+            toInsert = tId.getNamespace().getEncoded();
+            res = res + toInsert + "/";
+            toInsert = tId.getXmlId().getEncoded();
+            res = res + toInsert + "/";
+            return res;
+        } else if (id instanceof TOSCAElementId) {
+            toInsert = id.getXmlId().getEncoded();
+            return IdUtil.getPathFragment(id.getParent()) + toInsert + "/";
+        } else {
+            throw new IllegalStateException("Unknown subclass of GenericId " + id.getClass());
+        }
     }
 
 }

--- a/org.eclipse.winery.repository.client/src/main/java/org/eclipse/winery/repository/client/WineryRepositoryClient.java
+++ b/org.eclipse.winery.repository.client/src/main/java/org/eclipse/winery/repository/client/WineryRepositoryClient.java
@@ -357,7 +357,7 @@ public final class WineryRepositoryClient implements IWineryRepositoryClient {
 
         String name = null;
         for (WebResource wr : this.repositoryResources) {
-            String pathFragment = IdUtil.getURLPathFragment(id);
+            String pathFragment = IdUtil.getPathFragment(id);
             WebResource resource = wr.path(pathFragment).path("name");
             ClientResponse response = resource.accept(MediaType.TEXT_PLAIN_TYPE).get(ClientResponse.class);
             if (response.getClientResponseStatus() == ClientResponse.Status.OK) {
@@ -480,8 +480,8 @@ public final class WineryRepositoryClient implements IWineryRepositoryClient {
     }
 
     private static WebResource getTopologyTemplateWebResource(WebResource base, QName serviceTemplate) {
-        String nsEncoded = Util.DoubleURLencode(serviceTemplate.getNamespaceURI());
-        String idEncoded = Util.DoubleURLencode(serviceTemplate.getLocalPart());
+        String nsEncoded = Util.URLencode(serviceTemplate.getNamespaceURI());
+        String idEncoded = Util.URLencode(serviceTemplate.getLocalPart());
         WebResource res = base.path("servicetemplates").path(nsEncoded).path(idEncoded).path("topologytemplate");
         return res;
     }
@@ -570,8 +570,8 @@ public final class WineryRepositoryClient implements IWineryRepositoryClient {
      */
     private static TDefinitions getDefinitions(WebResource componentListResource, String ns, String localPart) {
         // we need double encoding as the client decodes the URL once
-        String nsEncoded = Util.DoubleURLencode(ns);
-        String idEncoded = Util.DoubleURLencode(localPart);
+        String nsEncoded = Util.URLencode(ns);
+        String idEncoded = Util.URLencode(localPart);
 
         WebResource instanceResource = componentListResource.path(nsEncoded).path(idEncoded);
 
@@ -728,7 +728,7 @@ public final class WineryRepositoryClient implements IWineryRepositoryClient {
 
     @Override
     public void forceDelete(GenericId id) throws IOException {
-        String pathFragment = IdUtil.getURLPathFragment(id);
+        String pathFragment = IdUtil.getPathFragment(id);
         for (WebResource wr : this.repositoryResources) {
             ClientResponse response = wr.path(pathFragment).delete(ClientResponse.class);
             if ((response.getClientResponseStatus() != ClientResponse.Status.NO_CONTENT) || (response.getClientResponseStatus() != ClientResponse.Status.NOT_FOUND)) {
@@ -748,7 +748,7 @@ public final class WineryRepositoryClient implements IWineryRepositoryClient {
      */
     @Override
     public void rename(TOSCAComponentId oldId, TOSCAComponentId newId) throws IOException {
-        String pathFragment = IdUtil.getURLPathFragment(oldId);
+        String pathFragment = IdUtil.getPathFragment(oldId);
         NamespaceAndIdAsString namespaceAndIdAsString = new NamespaceAndIdAsString();
         namespaceAndIdAsString.namespace = newId.getNamespace().getDecoded();
         namespaceAndIdAsString.id = newId.getXmlId().getDecoded();

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Utils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Utils.java
@@ -358,7 +358,7 @@ public class Utils {
      * @return the absolute path for the given id
      */
     public static String getAbsoluteURL(GenericId id) {
-        return Prefs.INSTANCE.getResourcePath() + "/" + Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(id));
+        return Prefs.INSTANCE.getResourcePath() + "/" + (BackendUtils.getPathInsideRepo(id));
     }
 
     /**
@@ -368,7 +368,7 @@ public class Utils {
      * @return the relative path for the given id
      */
     public static String getRelativeURL(URI baseURI, GenericId id) {
-        String absolutePath = Prefs.INSTANCE.getResourcePath() + "/" + Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(id));
+        String absolutePath = Prefs.INSTANCE.getResourcePath() + "/" + (BackendUtils.getPathInsideRepo(id));
         return baseURI.relativize(URI.create(absolutePath)).toString();
     }
 
@@ -376,7 +376,7 @@ public class Utils {
      * @return the absolute path for the given id
      */
     public static String getAbsoluteURL(RepositoryFileReference ref) {
-        return Prefs.INSTANCE.getResourcePath() + "/" + Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(ref));
+        return Prefs.INSTANCE.getResourcePath() + "/" + (BackendUtils.getPathInsideRepo(ref));
     }
 
     public static URI getAbsoluteURI(GenericId id) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
@@ -204,7 +204,7 @@ public class BackendUtils {
                 // relative to the caller
                 // Does not work: String path = Prefs.INSTANCE.getResourcePath()
                 // + "/" +
-                // Utils.getURLforPathInsideRepo(id.getPathInsideRepo());
+                // (id.getPathInsideRepo());
                 // We distinguish between two cases: TOSCAcomponentId and
                 // TOSCAelementId
                 // @formatter:on
@@ -222,7 +222,6 @@ public class BackendUtils {
                     path = id.getXmlId().getEncoded() + "/";
                 }
                 // we have to encode it twice to get correct URIs
-                path = Utils.getURLforPathInsideRepo(path);
                 URI uri = Utils.createURI(path);
                 res.setUri(uri);
                 res.setId(id);
@@ -820,7 +819,6 @@ public class BackendUtils {
     public static String getImportLocationForWinerysPropertiesDefinitionXSD(EntityTypeId tcId, URI uri, String wrapperElementLocalName) {
         String loc = BackendUtils.getPathInsideRepo(tcId);
         loc = loc + "propertiesdefinition/";
-        loc = Utils.getURLforPathInsideRepo(loc);
         if (uri == null) {
             loc = loc + wrapperElementLocalName + ".xsd";
             // for the import later, we need "../" in front

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/TOSCAExportUtil.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/TOSCAExportUtil.java
@@ -80,7 +80,6 @@ import org.eclipse.winery.model.tosca.TRelationshipType.ValidTarget;
 import org.eclipse.winery.model.tosca.TRequirement;
 import org.eclipse.winery.model.tosca.TRequirementDefinition;
 import org.eclipse.winery.repository.JAXBSupport;
-import org.eclipse.winery.repository.Utils;
 import org.eclipse.winery.repository.backend.BackendUtils;
 import org.eclipse.winery.repository.backend.Repository;
 import org.eclipse.winery.repository.backend.constants.Filename;
@@ -426,10 +425,11 @@ public class TOSCAExportUtil {
             // all Definitions are contained in "Definitions" directory, therefore, we provide the filename only
             // references are resolved relatively from a definitions element (COS01, line 425)
             String fn = CSARExporter.getDefinitionsFileName(id);
+            // URL fragments should be decoded when interpreting (https://tools.ietf.org/html/rfc3986#section-2.4), thus, we encode each fragment
             fn = Util.URLencode(fn);
             imp.setLocation(fn);
         } else {
-            String path = Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(id));
+            String path = (BackendUtils.getPathInsideRepo(id));
             path = path + "?definitions";
             URI absoluteURI = uri.resolve(path);
             imp.setLocation(absoluteURI.toString());

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CSARImporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CSARImporter.java
@@ -551,7 +551,7 @@ public class CSARImporter {
                     // add import to definitions
 
                     // adapt path - similar to importOtherImport
-                    String newLoc = "../" + Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(fileRef));
+                    String newLoc = "../" + (BackendUtils.getPathInsideRepo(fileRef));
                     imp.setLocation(newLoc);
                     defs.getImport().add(imp);
                 } else {
@@ -694,7 +694,7 @@ public class CSARImporter {
 
                         // file is imported
                         // Adjust the reference
-                        refContainer.setReference("../" + Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(fref)));
+                        refContainer.setReference("../" + (BackendUtils.getPathInsideRepo(fref)));
                     }
                 }
             }
@@ -1089,7 +1089,7 @@ public class CSARImporter {
         // location is relative to Definitions/
         // even if the import already exists, we have to adapt the path
         // URIs are encoded
-        String newLoc = "../" + Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(fileRef));
+        String newLoc = "../" + (BackendUtils.getPathInsideRepo(fileRef));
         imp.setLocation(newLoc);
 
         if (!importDataExistsInRepo || overwrite) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/AbstractComponentsResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/AbstractComponentsResource.java
@@ -179,7 +179,7 @@ public abstract class AbstractComponentsResource<R extends AbstractComponentInst
      */
     @Path("{namespace}/{id}/")
     public R getComponentInstaceResource(@PathParam("namespace") String namespace, @PathParam("id") String id) {
-        return this.getComponentInstaceResource(namespace, id, true);
+        return this.getComponentInstaceResource(namespace, id, false);
     }
 
     /**

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/GenericVisualAppearanceResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/GenericVisualAppearanceResource.java
@@ -74,7 +74,7 @@ public abstract class GenericVisualAppearanceResource {
     //@JsonIgnore
     public URI getAbsoluteURL() {
         String URI = Prefs.INSTANCE.getResourcePath();
-        URI = URI + "/" + Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(this.id));
+        URI = URI + "/" + (BackendUtils.getPathInsideRepo(this.id));
         return Utils.createURI(URI);
     }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/entitytemplates/artifacttemplates/ArtifactTemplateResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/entitytemplates/artifacttemplates/ArtifactTemplateResource.java
@@ -44,7 +44,6 @@ import org.eclipse.winery.model.tosca.TImplementationArtifact;
 import org.eclipse.winery.model.tosca.TImplementationArtifacts;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
-import org.eclipse.winery.repository.Utils;
 import org.eclipse.winery.repository.backend.BackendUtils;
 import org.eclipse.winery.repository.backend.Repository;
 import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateDirectoryId;
@@ -141,7 +140,7 @@ public class ArtifactTemplateResource extends AbstractComponentInstanceWithRefer
             for (RepositoryFileReference ref : files) {
                 // determine path
                 // path relative from the root of the CSAR is ok (COS01, line 2663)
-                String path = Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(ref));
+                String path = (BackendUtils.getPathInsideRepo(ref));
 
                 // put path into data structure
                 // we do not use Inlude/Exclude as we directly reference a concrete file

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplateResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/ServiceTemplateResource.java
@@ -338,7 +338,7 @@ public class ServiceTemplateResource extends AbstractComponentInstanceWithRefere
             plan.setPlanLanguage(org.eclipse.winery.common.constants.Namespaces.URI_BPEL20_EXECUTABLE);
 
             // create a PlanModelReferenceElement pointing to that file
-            String path = Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(ref));
+            String path = (BackendUtils.getPathInsideRepo(ref));
             // path is relative from the definitions element
             path = "../" + path;
             PlanModelReference pref = new PlanModelReference();

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/plans/PlansResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/servicetemplates/plans/PlansResource.java
@@ -190,7 +190,7 @@ public class PlansResource extends EntityWithIdCollectionResource<PlanResource, 
     static void setPlanModelReference(TPlan plan, PlanId planId, String fileName) {
         PlanModelReference pref = new PlanModelReference();
         // Set path relative to Definitions/ path inside CSAR.
-        pref.setReference("../" + Utils.getURLforPathInsideRepo(BackendUtils.getPathInsideRepo(planId)) + fileName);
+        pref.setReference("../" + (BackendUtils.getPathInsideRepo(planId)) + fileName);
         plan.setPlanModelReference(pref);
     }
 

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/functions.tld
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/functions.tld
@@ -30,9 +30,9 @@
         <function-signature>java.lang.String URLencode(java.lang.String)</function-signature>
     </function>
     <function>
-        <name>DoubleURLencode</name>
+        <name>URLencodeQName</name>
         <function-class>org.eclipse.winery.common.Util</function-class>
-        <function-signature>java.lang.String DoubleURLencode(javax.xml.namespace.QName)</function-signature>
+        <function-signature>java.lang.String URLencode(javax.xml.namespace.QName)</function-signature>
     </function>
     <function>
         <name>absoluteURL</name>

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/namespaceandname.tag
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/namespaceandname.tag
@@ -23,7 +23,7 @@
         <c:when test="${it.namespace != null}">
             <c:choose>
                 <c:when test="${it.namespace == t.namespace}">
-                    <c:set var="uri" value="./${v:URLencode(t.xmlId.encoded)}"></c:set>
+                    <c:set var="uri" value="./${t.xmlId.encoded}"></c:set>
                 </c:when>
                 <c:otherwise>
                     <c:set var="uri" value="null"></c:set>
@@ -31,7 +31,7 @@
             </c:choose>
         </c:when>
         <c:otherwise>
-            <c:set var="uri" value="./${v:URLencode(t.namespace.encoded)}/${v:URLencode(t.xmlId.encoded)}"></c:set>
+            <c:set var="uri" value="./${t.namespace.encoded}/${t.xmlId.encoded}"></c:set>
         </c:otherwise>
     </c:choose>
 

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/namespaceonly.tag
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/namespaceonly.tag
@@ -22,10 +22,10 @@
 <%@taglib prefix="t"  tagdir="/WEB-INF/tags" %>
 
 <c:forEach var="d" items="${w:countOfInstancesInEachNamespace(it.TOSCAComponentId)}">
-    <div class="entityContainer ${it.CSSclass}" id="${v:URLencode(d.namespace.encoded)}">
+    <div class="entityContainer ${it.CSSclass}" id="${d.namespace.encoded}">
         <div class="left">
             <c:if test="${it.type eq 'NodeType'}">
-                <a href="./${v:URLencode(d.namespace.encoded)}/"></a>
+                <a href="./${d.namespace.encoded}/"></a>
             </c:if>
         </div>
         <div class="center">
@@ -41,8 +41,7 @@
                 </div>
 
             <div class="buttonContainer" >
-                    <%-- we need double encoding of the URL as the passing to javascript: decodes the given string once --%>
-                <a type="button" class="deleteButton" onclick="deleteNamespace('${d.namespace}', '${v:URLencode(d.namespace.encoded)}')"></a>
+                <a type="button" class="deleteButton" onclick="deleteNamespace('${d.namespace}', '${d.namespace.encoded}')"></a>
             </div>
         </div>
         <div class="right"></div>

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/artifacts/artifacts.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/artifacts/artifacts.jsp
@@ -127,8 +127,8 @@ function artifactAddedSuccessfully(artifactInfo) {
                     <td>${a.a.interfaceName}</td>
                     <td>${a.a.operationName}</td>
                     </c:if>
-                    <td><c:if test="${not empty a.a.artifactRef}"><a href="${pageContext.request.contextPath}/artifacttemplates/${v:DoubleURLencode(a.a.artifactRef)}/">${a.a.artifactRef.localPart}</a></c:if></td>
-                    <td><a href="${pageContext.request.contextPath}/artifacttypes/${v:DoubleURLencode(a.a.artifactType)}">${a.a.artifactType.localPart}</a></td>
+                    <td><c:if test="${not empty a.a.artifactRef}"><a href="${pageContext.request.contextPath}/artifacttemplates/${v:URLencodeQName(a.a.artifactRef)}/">${a.a.artifactRef.localPart}</a></c:if></td>
+                    <td><a href="${pageContext.request.contextPath}/artifacttypes/${v:URLencodeQName(a.a.artifactType)}">${a.a.artifactType.localPart}</a></td>
                     <td><c:if test="${not empty a.a.any}">
                         <!--  TODO: convert to bootstrap <a href="javascript: $.msgBox({title: 'Artifact Specific Content', content: '${v:doubleEscapeHTMLAndThenConvertNL2BR(a.a.any)}', type: 'info'});">show</a> -->
                         (exists)

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/genericcomponentpage.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/genericcomponentpage.jsp
@@ -14,14 +14,13 @@
  *******************************************************************************/
 --%>
 <%@page import="org.eclipse.winery.repository.Utils"%>
-<%@page import="org.eclipse.winery.repository.backend.BackendUtils"%>
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@taglib prefix="c"  uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="v"  uri="http://www.eclipse.org/winery/repository/functions" %>
 <%@taglib prefix="t"  tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="wc" uri="http://www.eclipse.org/winery/functions" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 
 <%-- In English, one can usually form a plural by adding an "s". Therefore, we resue the label to form the window title --%>
 <t:genericpage windowtitle="${it.label}s" selected="${it.type}" cssClass="${it.CSSclass}">

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/interfaces/interfaces.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/interfaces/interfaces.jsp
@@ -253,7 +253,7 @@ $(function() {
     $("#generateiamodal").on("show.bs.modal", function() {
         // check whether the required artifact type exists
         $.ajax({
-            url: "${pageContext.request.contextPath}/artifacttypes/<%=Util.DoubleURLencode(Constants.NAMESPACE_ARTIFACTTYPE_WAR)%>/<%=Util.DoubleURLencode(Constants.LOCALNAME_ARTIFACTTYPE_WAR)%>/",
+            url: "${pageContext.request.contextPath}/artifacttypes/<%=Util.URLencode(Constants.NAMESPACE_ARTIFACTTYPE_WAR)%>/<%=Util.URLencode(Constants.LOCALNAME_ARTIFACTTYPE_WAR)%>/",
             type: "HEAD"
         }).fail(function(jqXHR, textStatus, errorThrown) {
             if (jqXHR.status == 404) {
@@ -428,7 +428,7 @@ function generateLifeCycleInterface() {
 
                     <div class="form-group">
                         <label for="artifacttype">Artifact Type</label>
-                        <a class="form-control" target="_blank" href="${pageContext.request.contextPath}/artifacttypes/<%=Util.DoubleURLencode(Constants.NAMESPACE_ARTIFACTTYPE_WAR)%>/<%=Util.DoubleURLencode(Constants.LOCALNAME_ARTIFACTTYPE_WAR)%>/">WAR</a>
+                        <a class="form-control" target="_blank" href="${pageContext.request.contextPath}/artifacttypes/<%=Util.URLencode(Constants.NAMESPACE_ARTIFACTTYPE_WAR)%>/<%=Util.URLencode(Constants.LOCALNAME_ARTIFACTTYPE_WAR)%>/">WAR</a>
                         <input type="hidden" name="artifactType" id="artifactType" value="{<%=Constants.NAMESPACE_ARTIFACTTYPE_WAR%>}<%=Constants.LOCALNAME_ARTIFACTTYPE_WAR%>">
                     </div>
 

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/AbstractResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/AbstractResourceTest.java
@@ -14,10 +14,10 @@ package org.eclipse.winery.repository.resources;
 import java.io.InputStream;
 import java.util.Scanner;
 
-import org.eclipse.winery.common.Util;
 import org.eclipse.winery.repository.AbstractWineryWithRepositoryTest;
 import org.eclipse.winery.repository.WineryUsingHttpServer;
 
+import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.jetty.server.Server;
@@ -41,6 +41,7 @@ public abstract class AbstractResourceTest extends AbstractWineryWithRepositoryT
         AbstractWineryWithRepositoryTest.init();
         server = WineryUsingHttpServer.createHttpServer(9080);
         server.start();
+        RestAssured.urlEncodingEnabled = false;
     }
 
     @AfterClass
@@ -63,7 +64,7 @@ public abstract class AbstractResourceTest extends AbstractWineryWithRepositoryT
     }
 
     protected String callURL(String restURL) {
-        return PREFIX + Util.URLdecode(restURL);
+        return PREFIX + restURL;
     }
 
     private boolean isXml(String fileName) {

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
@@ -33,54 +33,54 @@ public class NodeTypeResourceTest extends AbstractResourceTest {
     @Test
     public void baboabInitialExistsUsingRest() throws Exception {
         this.setRevisionTo("5b5ad1106a3a428020b6bc5d2f154841acb5f779");
-        this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/", "entitytypes/nodetypes/baobab_initial_with_definitions.xml");
+        this.assertGet("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/", "entitytypes/nodetypes/baobab_initial_with_definitions.xml");
     }
 
     @Test
     public void baobabCapabilitiesJSON() throws Exception {
         this.setRevisionTo("8b125a426721f8a0eb17340dc08e9b571b0cd7f7");
-        this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/", "entitytypes/nodetypes/baobab_capabilites.json");
+        this.assertGet("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/", "entitytypes/nodetypes/baobab_capabilites.json");
     }
 
     @Test
     public void tagsRoundTrip() throws Exception {
         this.setRevisionTo("8b125a426721f8a0eb17340dc08e9b571b0cd7f7");
-        this.assertPost("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/tags/", "entitytypes/nodetypes/baobab_tag_step1_add.json");
-        this.assertPost("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/tags/", "entitytypes/nodetypes/baobab_tag_step2_add.json");
-        this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/tags/", "entitytypes/nodetypes/baobab_tag_step3_values.json");
-        this.assertDelete("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/tags/931516286/");
-        this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/tags/", "entitytypes/nodetypes/baobab_tag_step5_values.json");
+        this.assertPost("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/tags/", "entitytypes/nodetypes/baobab_tag_step1_add.json");
+        this.assertPost("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/tags/", "entitytypes/nodetypes/baobab_tag_step2_add.json");
+        this.assertGet("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/tags/", "entitytypes/nodetypes/baobab_tag_step3_values.json");
+        this.assertDelete("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/tags/931516286/");
+        this.assertGet("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/tags/", "entitytypes/nodetypes/baobab_tag_step5_values.json");
     }
 
     @Test
     public void baobabRoundTrip() throws Exception {
         this.setRevisionTo("15cd64e30770ca7986660a34e1a4a7e0cf332f19"); // empty repository
-        this.assertNotFound("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/");
+        this.assertNotFound("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/");
 
         // this is not possible, we have to create it first (post) and then put data
         // this.assertPost("nodetypes/", "entitytypes/nodetypes/baobab_initial.xml");
         this.assertPost("nodetypes/", "http://winery.opentosca.org/test/nodetypes/fruits", "baobab");
-        this.assertPut("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/", "entitytypes/nodetypes/baobab_initial_with_definitions_put.xml");
+        this.assertPut("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/", "entitytypes/nodetypes/baobab_initial_with_definitions_put.xml");
 
-        this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/", "entitytypes/nodetypes/baobab_initial_with_definitions_expected.xml");
+        this.assertGet("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/", "entitytypes/nodetypes/baobab_initial_with_definitions_expected.xml");
 
-        this.assertPut("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/", "entitytypes/nodetypes/baobab_updated_put.xml");
-        this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/", "entitytypes/nodetypes/baobab_updated_expected.xml");
-        this.assertDelete("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/");
-        this.assertNotFound("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/");
+        this.assertPut("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/", "entitytypes/nodetypes/baobab_updated_put.xml");
+        this.assertGet("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/", "entitytypes/nodetypes/baobab_updated_expected.xml");
+        this.assertDelete("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/");
+        this.assertNotFound("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/");
     }
 
     @Test
     public void baboabHasNoImplementations() throws Exception {
         this.setRevisionTo("5b5ad1106a3a428020b6bc5d2f154841acb5f779");
-        this.assertGetSize("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/implementations", 0);
+        this.assertGetSize("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/implementations", 0);
     }
 
     @Test
     public void baboabHasNoImage() throws Exception {
         this.setRevisionTo("5b5ad1106a3a428020b6bc5d2f154841acb5f779");
         start()
-                .get(callURL("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/visualappearance/50x50"))
+                .get(callURL("nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/visualappearance/50x50"))
                 .then()
                 .statusCode(404);
     }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/servicetemplates/topologytemplates/TopologyTemplateResourceTest.java
@@ -24,32 +24,32 @@ public class TopologyTemplateResourceTest  extends AbstractResourceTest {
     @Test
     public void getComponentInstanceJSON() throws Exception {
         this.setRevisionTo("3fe0df76e98d46ead68295920e5d1cf1354bdea1");
-        this.assertGet("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Ffruits/baobab_serviceTemplate/topologytemplate/", "servicetemplates/baobab_topologytemplate.json");
+        this.assertGet("servicetemplates/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fservicetemplates%2Ffruits/baobab_serviceTemplate/topologytemplate/", "servicetemplates/baobab_topologytemplate.json");
     }
 
     @Test
     public void getComponentInstanceXML() throws Exception {
         this.setRevisionTo("3fe0df76e98d46ead68295920e5d1cf1354bdea1");
-        this.assertGet("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Ffruits/baobab_serviceTemplate/topologytemplate/", "servicetemplates/baobab_topologytemplate.xml");
+        this.assertGet("servicetemplates/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fservicetemplates%2Ffruits/baobab_serviceTemplate/topologytemplate/", "servicetemplates/baobab_topologytemplate.xml");
     }
 
     @Test
     public void topologyTemplateUpdate() throws Exception {
         this.setRevisionTo("3fe0df76e98d46ead68295920e5d1cf1354bdea1");
-        this.assertPut("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Ffruits/baobab_serviceTemplate/topologytemplate/", "servicetemplates/baobab_topologytemplate_v2.json");
-        this.assertGet("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Ffruits/baobab_serviceTemplate/topologytemplate/", "servicetemplates/baobab_topologytemplate_v2.json");
+        this.assertPut("servicetemplates/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fservicetemplates%2Ffruits/baobab_serviceTemplate/topologytemplate/", "servicetemplates/baobab_topologytemplate_v2.json");
+        this.assertGet("servicetemplates/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fservicetemplates%2Ffruits/baobab_serviceTemplate/topologytemplate/", "servicetemplates/baobab_topologytemplate_v2.json");
     }
 
     @Test
     public void farmTopologyTemplateIsCorrectlyReturnAsJson() throws Exception {
         this.setRevisionTo("2d35f0d3c15b384c53df10967164d97e4a7dd6f2");
-        this.assertGet("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Ffruits/farm/topologytemplate/", "servicetemplates/farm_topologytemplate.json");
+        this.assertGet("servicetemplates/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fservicetemplates%2Ffruits/farm/topologytemplate/", "servicetemplates/farm_topologytemplate.json");
     }
 
     @Test
     public void farmTopologyTemplateIsCorrectlyReturnedAsXml() throws Exception {
         this.setRevisionTo("2d35f0d3c15b384c53df10967164d97e4a7dd6f2");
-        this.assertGet("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Ffruits/farm/topologytemplate/", "servicetemplates/farm_topologytemplate.xml");
+        this.assertGet("servicetemplates/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fservicetemplates%2Ffruits/farm/topologytemplate/", "servicetemplates/farm_topologytemplate.xml");
     }
 
     @Test
@@ -60,7 +60,7 @@ public class TopologyTemplateResourceTest  extends AbstractResourceTest {
         ServiceTemplateId id = new ServiceTemplateId("http://winery.opentosca.org/test/servicetemplates/fruits", "farm", false);
         Repository.INSTANCE.flagAsExisting(id);
 
-        this.assertPut("servicetemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fservicetemplates%252Ffruits/farm/topologytemplate/", "servicetemplates/farm_topologytemplate.json");
+        this.assertPut("servicetemplates/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fservicetemplates%2Ffruits/farm/topologytemplate/", "servicetemplates/farm_topologytemplate.json");
     }
 
     @Test

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/baobab_capabilites.json
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/baobab_capabilites.json
@@ -78,8 +78,8 @@
           }
         ]
       },
-      "final": "NO",
-      "abstract": "NO"
+      "abstract": "NO",
+      "final": "NO"
     }
   ],
   "id": "winery-defs-for_ns0-baobab",
@@ -110,7 +110,7 @@
         "{http://www.opentosca.org/winery/extensions/tosca/2013/02/12}wpd": "true"
       },
       "namespace": "http://winery.opentosca.org/test/nodetypes/fruits",
-      "location": "../nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/propertiesdefinition/BaobabProperties.xsd",
+      "location": "../nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/propertiesdefinition/BaobabProperties.xsd",
       "importType": "http://www.w3.org/2001/XMLSchema"
     }
   ]

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/baobab_initial_with_definitions.xml
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/baobab_initial_with_definitions.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" standalone="no"?>
-<tosca:Definitions xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" id="winery-defs-for_ns0-baobab" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits">
-    <tosca:Import importType="http://www.w3.org/2001/XMLSchema" location="../nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/propertiesdefinition/BaobabProperties.xsd" namespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:wpd="true"/>
+<tosca:Definitions xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns0-baobab" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits">
+    <tosca:Import namespace="http://winery.opentosca.org/test/nodetypes/fruits" location="../nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/propertiesdefinition/BaobabProperties.xsd" importType="http://www.w3.org/2001/XMLSchema" winery:wpd="true"/>
     <tosca:NodeType name="baobab" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:bordercolor="#89ee01">
         <winery:PropertiesDefinition elementname="BaobabProperties" namespace="http://winery.opentosca.org/test/nodetypes/fruits">
             <winery:properties>

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/baobab_initial_with_definitions_expected.xml
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/baobab_initial_with_definitions_expected.xml
@@ -1,6 +1,6 @@
-<tosca:Definitions xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" id="empty" targetNamespace="http://www.example.org/empty">
-    <tosca:Import importType="http://www.w3.org/2001/XMLSchema" location="../nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/propertiesdefinition/BaobabProperties.xsd" namespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:wpd="true"/>
-    <tosca:NodeType abstract="no" final="no" name="baobab" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:bordercolor="#89ee01">
+<tosca:Definitions xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" id="empty" targetNamespace="http://www.example.org/empty">
+    <tosca:Import namespace="http://winery.opentosca.org/test/nodetypes/fruits" location="../nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/propertiesdefinition/BaobabProperties.xsd" importType="http://www.w3.org/2001/XMLSchema" winery:wpd="true"/>
+    <tosca:NodeType name="baobab" abstract="no" final="no" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:bordercolor="#89ee01">
         <winery:PropertiesDefinition elementname="BaobabProperties" namespace="http://winery.opentosca.org/test/nodetypes/fruits">
             <winery:properties>
                 <winery:key>Antioxidants</winery:key>

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/baobab_updated_expected.xml
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/baobab_updated_expected.xml
@@ -1,5 +1,5 @@
-<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" id="empty" targetNamespace="http://www.example.org/empty">
-    <tosca:Import namespace="http://winery.opentosca.org/test/nodetypes/fruits" location="../nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/propertiesdefinition/BaobabProperties.xsd" importType="http://www.w3.org/2001/XMLSchema" winery:wpd="true"/>
+<tosca:Definitions xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" id="empty" targetNamespace="http://www.example.org/empty">
+    <tosca:Import namespace="http://winery.opentosca.org/test/nodetypes/fruits" location="../nodetypes/http%3A%2F%2Fwinery.opentosca.org%2Ftest%2Fnodetypes%2Ffruits/baobab/propertiesdefinition/BaobabProperties.xsd" importType="http://www.w3.org/2001/XMLSchema" winery:wpd="true"/>
     <tosca:NodeType name="baobab" abstract="no" final="no" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:bordercolor="#89ee01">
         <winery:PropertiesDefinition elementname="BaobabProperties" namespace="http://winery.opentosca.org/test/nodetypes/fruits">
             <winery:properties>

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/helper/RESTHelper.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/helper/RESTHelper.java
@@ -54,7 +54,7 @@ public class RESTHelper {
                 url = new URL(topologyTemplateURL);
             } else {
                 // this is necessary to avoid encoding issues
-                topologyNamespace = Util.DoubleURLencode(topologyNamespace);
+                topologyNamespace = Util.URLencode(topologyNamespace);
                 // build the URL with the repositoryURL, the topology namespace and the topology name
                 url = new URL(repositoryURL + "/servicetemplates/" + topologyNamespace + "/" + topologyName + "/topologytemplate/");
 

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/common/templates/nodetemplates/nodeTemplateRenderer.tag
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/common/templates/nodetemplates/nodeTemplateRenderer.tag
@@ -95,7 +95,7 @@
 
     <div class="NodeTemplateShape unselectable <%=nodeTypeCSSName%> <%if (paletteMode){%> hidden<%}%>" id="<%=visualElementId%>" style="left: <%=left%>px; top: <%=top%>px">
         <div class="headerContainer">
-            <img class="icon" onerror="var that=this; require(['winery-common-topologyrendering'], function(wct){wct.imageError(that);});" src="<%=repositoryURL%>/nodetypes/<%=Util.DoubleURLencode(nodeTypeQName)%>/visualappearance/50x50" />
+            <img class="icon" onerror="var that=this; require(['winery-common-topologyrendering'], function(wct){wct.imageError(that);});" src="<%=repositoryURL%>/nodetypes/<%=Util.URLencode(nodeTypeQName)%>/visualappearance/50x50" />
             <%
                 String name;
                 if (paletteMode) {

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/common/templates/registerConnectionTypesAndConnectNodeTemplates.tag
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/common/templates/registerConnectionTypesAndConnectNodeTemplates.tag
@@ -75,7 +75,7 @@ require(["jquery", "jsplumb", "winery-common-topologyrendering"], function(globa
             whenRes = whenRes + fnName + ", ";
 %>
             function <%=fnName%>() { return $.ajax({
-                url: "<%=repositoryURL%>/relationshiptypes/<%=Util.DoubleURLencode(relationshipType.getTargetNamespace())%>/<%=Util.DoubleURLencode(relationshipType.getName())%>/visualappearance/",
+                url: "<%=repositoryURL%>/relationshiptypes/<%=Util.URLencode(relationshipType.getTargetNamespace())%>/<%=Util.URLencode(relationshipType.getName())%>/visualappearance/",
                 dataType: "json",
                 success: function(data, textStatus, jqXHR) {
                     jsPlumb.registerConnectionType(

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/palette.tag
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/palette.tag
@@ -53,7 +53,7 @@ Palette
 %>
         <div class="paletteEntry">
             <div class="iconContainer">
-                <img class="icon" onerror="var that=this; require(['winery-common-topologyrendering'], function(wct){wct.imageError(that);});" src="<%= repositoryURL %>/nodetypes/<%= Util.DoubleURLencode(nodeType.getTargetNamespace()) %>/<%=Util.DoubleURLencode(nodeType.getName())%>/visualappearance/50x50" />
+                <img class="icon" onerror="var that=this; require(['winery-common-topologyrendering'], function(wct){wct.imageError(that);});" src="<%= repositoryURL %>/nodetypes/<%= Util.URLencode(nodeType.getTargetNamespace()) %>/<%=Util.URLencode(nodeType.getName())%>/visualappearance/50x50" />
             </div>
             <div class="typeContainer">
                 <div class="typeContainerMiddle">

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/index.jsp
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/index.jsp
@@ -129,7 +129,7 @@
         return;
     }
 
-    String topologyTemplateURL = repositoryURL + "/servicetemplates/" + Util.DoubleURLencode(serviceTemplateQName) + "/topologytemplate/";
+    String topologyTemplateURL = repositoryURL + "/servicetemplates/" + Util.URLencode(serviceTemplateQName) + "/topologytemplate/";
     String serviceTemplateName = client.getName(new ServiceTemplateId(serviceTemplateQName));
 %>
 <!DOCTYPE html>


### PR DESCRIPTION
Winery used to have URLs like follows

    http://stable.winery.opentosca.org/winery/servicetemplates/http%253A%252F%252Fopentosca.org%252Fservicetemplates/MyTinyToDo_Bare_Docker/

This PR changes the URLs to

    http://stable.winery.opentosca.org/winery/servicetemplates/http%3A%2F%2Fopentosca.org%2Fservicetemplates/MyTinyToDo_Bare_Docker/

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- <s>[ ] Screenshots added (for UI changes)</s>
