### PR TITLE
move getProperty from ModelUtilities to TEntityTemplate 

### DIFF
--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ModelUtilities.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ModelUtilities.java
@@ -63,8 +63,6 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -128,26 +126,12 @@ public class ModelUtilities {
 	 * @param template the node template to get the associated properties
 	 */
 	public static Properties getPropertiesKV(TEntityTemplate template) {
-		Properties properties = new Properties();
-		org.eclipse.winery.model.tosca.TEntityTemplate.Properties tprops = template.getProperties();
-		if (tprops != null) {
-			// no checking for validity, just reading
-			Element el = (Element) tprops.getAny();
-			if (el == null) {
-				// somehow invalid .tosca. We return empty properties instead of throwing a NPE
-				return properties;
-			}
-			NodeList childNodes = el.getChildNodes();
-			for (int i = 0; i < childNodes.getLength(); i++) {
-				Node item = childNodes.item(i);
-				if (item instanceof Element) {
-					String key = item.getLocalName();
-					String value = item.getTextContent();
-					properties.put(key, value);
-				}
-			}
+		if (template.getProperties() != null) {
+			return template.getProperties().getProperties();
+		} else {
+			return null;
 		}
-		return properties;
+		
 	}
 
 	/**

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityTemplate.java
@@ -21,10 +21,14 @@ import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 
 /**
@@ -160,6 +164,40 @@ public abstract class TEntityTemplate extends HasId {
 		public void setAny(Object value) {
 			this.any = value;
 		}
+
+		/**
+		 * This is a special method for Winery. Winery allows to define a property
+		 * by specifying name/value values. Instead of parsing the XML contained in
+		 * TNodeType, this method is a convenience method to access this information
+		 * Assumes the properties are key/value pairs (see WinerysPropertiesDefinition), all other cases are not implemented yet.
+		 * 
+		 * The return type "Properties" is used because of the key/value properties.
+		 */
+		@XmlTransient
+		@JsonIgnore
+		public java.util.Properties getProperties() {
+			java.util.Properties properties = new java.util.Properties();
+			org.eclipse.winery.model.tosca.TEntityTemplate.Properties tprops = this;
+			if (tprops != null) {
+				// no checking for validity, just reading
+				Element el = (Element) tprops.getAny();
+				if (el == null) {
+					// somehow invalid .tosca. We return empty properties instead of throwing a NPE
+					return properties;
+				}
+				NodeList childNodes = el.getChildNodes();
+				for (int i = 0; i < childNodes.getLength(); i++) {
+					Node item = childNodes.item(i);
+					if (item instanceof Element) {
+						String key = item.getLocalName();
+						String value = item.getTextContent();
+						properties.put(key, value);
+					}
+				}
+			}
+			return properties;
+		}
+		
 	}
 
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
@@ -412,17 +412,19 @@ public class Splitting {
 				for (TNodeTemplate predecessor : predecessorsOfReplacementCandidate) {
 					// Check if a compatible node for the predecessor from the right provider is available
 					if (predecessor.getRequirements() == null) {
-						throw new SplittingException("The Node Template with the ID " + predecessor.getId() + " has no requirement assigned and the injected can't be processed");
-					}
-					List<TRequirement> openHostedOnRequirements = predecessor.getRequirements().getRequirement().stream()
-							.filter(req -> getBasisCapabilityType(getRequiredCapabilityTypeQNameOfRequirement(req)).getName().equalsIgnoreCase("Container")).collect(Collectors.toList());
-
-					List<TTopologyTemplate> compatibleTopologyFragments = repository
-							.getAllTopologyFragmentsForLocationAndOfferingCapability(targetLabel, openHostedOnRequirements.get(0));
-					//Add compatible nodes to the injectionOptions to host the considered lowest level node
-					if (!compatibleTopologyFragments.isEmpty()) {
-						injectionOptions.put(predecessor.getId(), compatibleTopologyFragments);
 						nodesForWhichHostsFound.add(predecessor);
+						//throw new SplittingException("The Node Template with the ID " + predecessor.getId() + " has no requirement assigned and the injected can't be processed");
+					} else {
+						List<TRequirement> openHostedOnRequirements = predecessor.getRequirements().getRequirement().stream()
+								.filter(req -> getBasisCapabilityType(getRequiredCapabilityTypeQNameOfRequirement(req)).getName().equalsIgnoreCase("Container")).collect(Collectors.toList());
+
+						List<TTopologyTemplate> compatibleTopologyFragments = repository
+								.getAllTopologyFragmentsForLocationAndOfferingCapability(targetLabel, openHostedOnRequirements.get(0));
+						//Add compatible nodes to the injectionOptions to host the considered lowest level node
+						if (!compatibleTopologyFragments.isEmpty()) {
+							injectionOptions.put(predecessor.getId(), compatibleTopologyFragments);
+							nodesForWhichHostsFound.add(predecessor);
+						}	
 					}
 				}
 			}
@@ -798,7 +800,8 @@ public class Splitting {
 
 		/* If the property "requiredRelationshipType" is defined for the requirement and the capability this relationship type
 		   has to be taken - if the specified relationship type is not available, no relationship type is chosen */
-		if (requirementProperties.containsKey("requiredRelationshipType") && capabilityProperties.containsKey("requiredRelationshipType")
+		if (requirementProperties != null && capabilityProperties != null && 
+				requirementProperties.containsKey("requiredRelationshipType") && capabilityProperties.containsKey("requiredRelationshipType")
 				&& requirementProperties.get("requiredRelationshipType").equals(capabilityProperties.get("requiredRelationshipType"))
 				&& requirementProperties.get("requiredRelationshipType") != null) {
 			QName referencedRelationshipType = (QName) requirementProperties.get("requiredRelationshipType");


### PR DESCRIPTION
move getProperty from ModelUtilities to TEntityTemplate to enable a proper access to key value pairs in Properties of all Templates

Signed-off-by: Karoline Saatkamp <karoline.saatkamp@iaas.uni-stuttgart.de>

<!-- describe the changes you have made here: what, why, ... -->

- [x ] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
