### PR TITLE
remove bootstrap3-typeahead

### DIFF
--- a/org.eclipse.winery.repository/about.html
+++ b/org.eclipse.winery.repository/about.html
@@ -388,24 +388,6 @@ This library is required by jsPlumb only
 	</tr>
 </table>
 
-<h5>Bootstrap-3-Typeahead &ndash; Version 4.0.2</h5>
-<table>
-	<tr>
-		<td>Files</td>
-		<td>src/main/webapp/components/bootstrap3-typeahead</td>
-	</tr>
-	<tr>
-		<td>URL</td>
-		<td><a href="https://github.com/bassjobsen/Bootstrap-3-Typeahead">https://github.com/bassjobsen/Bootstrap-3-Typeahead</a></td>
-	</tr>
-	<tr>
-		<td>License</td>
-		<td>Apache 2.0 (<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>).
-		The Eclipse Foundation elects to include this software in this distribution under the Apache 2.0 license.
-		A copy of the license is contained in the file <a href="about_files/Apache-LICENSE-2.0.txt" target="_blank">Apache-LICENSE-2.0.txt</a>.</td>
-	</tr>
-</table>
-
 <h5>URI.js &ndash; Version 3.4.5</h5>
 <table>
 	<tr>

--- a/org.eclipse.winery.repository/bower.json
+++ b/org.eclipse.winery.repository/bower.json
@@ -46,7 +46,6 @@
     "KeyboardJS": "git://github.com/RobertWHurst/KeyboardJS.git#v0.4.2",
     "pnotify": "1.3.1",
     "requirejs": "2.1.5",
-	"bootstrap3-typeahead": "git://github.com/bassjobsen/Bootstrap-3-Typeahead.git#4.0.2",
     "uri.js": "v1.12.0",
     "x-editable": "1.5.1",
     "bootstrap3-wysihtml5-bower": "0.2.8",

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/addComponentInstance.tag
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/addComponentInstance.tag
@@ -84,22 +84,6 @@ function createResource(nameOfResource, fields, url, onSuccess) cannot be used a
 </div>
 
 <script>
-<c:if test="${empty type and not empty typeSelectorData}">
-	require(["bootstrap3-typeahead"], function(){
-
-
-		$("#ciType").typeahead({
-			source : [
-				<c:forEach var="typeId" items="${typeSelectorData}" varStatus="loop">
-				{id:"${typeId.QName}",name:"${typeId.xmlId.decoded}"}<c:if test="${!loop.last}">,</c:if>
-				</c:forEach>
-			],
-			autoSelect: true,
-			showHintOnFocus: true
-		});
-	});
-
-</c:if>
 
 $("#addComponentInstanceDiag").on("shown.bs.modal", function() {
 	$("#nameOfNewCI").focus();

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/genericpage.tag
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/genericpage.tag
@@ -86,8 +86,6 @@
 
 				"pnotify": "../components/pnotify/jquery.pnotify",
 
-				"bootstrap3-typeahead": "../components/bootstrap3-typeahead/bootstrap3-typeahead",
-
 				"tmpl": "../components/blueimp-tmpl/js/tmpl",
 
 				"URIjs": '../components/uri.js/src',

--- a/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
+++ b/org.eclipse.winery.repository/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
@@ -36,22 +36,3 @@
 	<label for="${idOfInput}" class="control-label">Namespace</label>
 	<input type="select" class="form-control" name="${nameOfInput}" id="${idOfInput}"></input>
 </div>
-
-<script>
-
-require(["bootstrap3-typeahead"], function () {
-
-    $("#${idOfInput}").typeahead({
-
-        source:[
-            <c:forEach var="ns" items="${allNamespaces}" varStatus="loop">
-            {id:"${ns.decoded}",name:"${ns.decoded}"}<c:if test="${!loop.last}">,</c:if>
-            </c:forEach>
-        ],
-        autoSelect : true,
-        showHintOnFocus: true
-    });
-            <%--.typeahead("val", "${selected}");--%>
-})
-
-</script>

--- a/org.eclipse.winery.repository/src/main/webapp/jsp/servicetemplates/boundarydefinitions/boundarydefinitions.jsp
+++ b/org.eclipse.winery.repository/src/main/webapp/jsp/servicetemplates/boundarydefinitions/boundarydefinitions.jsp
@@ -10,7 +10,7 @@
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
  *    Tobias Binz - communication with the nested iframe
- *    Niko Stadelmaier - removal of select2 library
+ *    Niko Stadelmaier - removal of select2 library, remove typeahead
  *******************************************************************************/
 --%>
 
@@ -337,19 +337,18 @@
 			<div class="form-group">
 				<label for="interface" class="col-sm-1 control-label">Interface</label>
 				<div class="col-sm-8">
-					<input id="interface" autocomplete="off" class="form-control" placeholder="NCName or URI">
+					<input id="interface" autocomplete="off" class="form-control" placeholder="NCName or URI"></input>
 				</div>
 				<button type="button" class="btn btn-danger btn-sm col-sm-1" onclick="deleteCurrentlySelectedInterface();">Delete</button>
 			</div>
 			<div class="form-group">
 				<label for="operation" class="col-sm-1 control-label">Operation</label>
 				<div class="col-sm-8">
-					<input id="operation" autocomplete="off" class="form-control" placeholder="NCName">
+					<input id="operation" autocomplete="off" class="form-control" placeholder="NCName"></input>
 				</div>
 				<button type="button" class="btn btn-danger btn-sm col-sm-1" onclick="deleteCurrentlySelectedOperation();">Delete</button>
 			</div>
 		</form>
-
 		<h4>Target</h4>
 
 		<form id="reftargettypeForm">
@@ -404,18 +403,18 @@
 			<div class="form-group" id="selectInterfaceNameDiv">
 				<label for="TargetInterface" class="col-sm-1 control-label">Interface</label>
 				<div class="col-sm-8">
-					<input id="TargetInterface" class="form-control">
+					<select id="TargetInterface" class="form-control"></select>
 				</div>
 			</div>
 
 			<div class="form-group" id="selectOperationNameDiv">
 				<label for="TargetOperation" class="col-sm-1 control-label">Operation</label>
 				<div class="col-sm-8">
-					<input id="TargetOperation" class="form-control">
+					<select id="TargetOperation" class="form-control"></select>
 				</div>
 			</div>
 		</form>
-
+		
 		<div id="notApplicableDiv" style="display:none;">
 			<p>not applicable in the case of plans</p>
 		</div>
@@ -425,7 +424,7 @@
 	<script type="text/x-tmpl" id="select-template">
 
 		{% for (var i=0; i<o.source.length; i++) { %}
-    		<option value={% o.source[i].id %}>{%=o.source[i].name%}</option>
+    		<option value={% o.source[i].id %}>{%=o.source[i].text%}</option>
 		{% } %}
 
 	</script>
@@ -444,14 +443,7 @@
 			}
 		}, true);
 	});
-
-	function updateInterfaces(){
-		require(["winery-support-common"], function(wsc) {
-		    //pass null as callback since event handler for interfaces are alredy set above, therefore no callback required
-			wsc.fetchSelect2DataAndInitSelect2("interface", "boundarydefinitions/interfaces/?select2", null, true);
-		});
-	}
-
+	
 	function getInterfacesAndInterfaceURLs() {
 		var iface = $("#interface").val();
 		iface = encodeID(iface);
@@ -499,7 +491,6 @@
 						contentType: "application/json"
 					}).done(function (result) {
 						vShowSuccess("Sucessfully created interface");
-						updateInterfaces();
 					}).fail(function(jqXHR, textStatus, errorThrown) {
 						vShowAJAXError("Could not create interface", jqXHR, errorThrown);
 					});
@@ -898,6 +889,12 @@ function getDataForUpdateTargetOperation(url, showError) {
 	});
 	return select2data;
 }
+function fillSelectWithId(fieldId, data){
+	$("#" + fieldId).empty();
+	$.each(data, function(index, item){
+		$("#" + fieldId).append($("<option/>").val(item.id).text(item.name));
+	});
+}
 
 function updateTargetOperation(operationNameToSelect) {
 	var ifaceURL = $("#TargetInterface").data("url2");
@@ -921,8 +918,7 @@ function updateTargetOperation(operationNameToSelect) {
 	var convDataArray = select2data.map(function(item){
 		return {id: item.id, name: item.text};
 	});
-
-		$("#TargetOperation").html(tmpl("select-template", convDataArray));
+		fillSelectWithId("TargetOperation", convDataArray);
 		var valueToSelect = null;
 		if ((typeof operationNameToSelect !== "undefined") && (operationNameToSelect != null)) {
 			valueToSelect = operationNameToSelect;
@@ -957,7 +953,7 @@ function updateTargetInterfaceAndOperationFromInterfaceURL(ifaceURL, interfaceNa
 	var convDataArray = select2data.map(function(item){
 		return {id: item.id, name: item.text};
 	});
-	$("#TargetInterface").html(tmpl("select-template", convDataArray));
+	fillSelectWithId("TargetInterface", convDataArray);
 
 	var valueToSelect = null;
 	if ((typeof interfaceNameToSelect !== "undefined") && (interfaceNameToSelect != null)) {

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/tags/namespaceChooser.tag
@@ -37,21 +37,3 @@
 	<input type="text" class="form-control" name="${nameOfInput}" id="${idOfInput}"></input>
 </div>
 
-<script>
-	// we have to use data as select2 does not allow "createSearchChoice" when using <select> as underlying html element
-	require(["bootstrap3-typeahead"], function () {
-
-	$("#${idOfInput}").typeahead({
-
-		source:[
-			<c:forEach var="ns" items="${allNamespaces}" varStatus="loop">
-			{id:"${ns}",name:"${ns}"}<c:if test="${!loop.last}">,</c:if>
-			</c:forEach>
-		],
-		autoSelect : true,
-		showHintOnFocus: true
-	});
-	$("#${idOfInput}").val("${selected}");
-	$("#${idOfInput}").typeahead("lookup", "${selected}");
-})
-</script>

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-support-common.js
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/js/winery-support-common.js
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
- *    Niko Stadelmaier - removal of select2 library
+ *    Niko Stadelmaier - removal of select2 library, remove typeahead
  *******************************************************************************/
 
 /**
@@ -168,37 +168,16 @@ define([], function() {
 				url: url,
 				dataType: "json"
 			}).done(function (result) {
-
-				var convResult = result.map(function(item){
-					return {id: item.id, name: item.text};
-				});
-				var params = {"source": convResult,
-					showHintOnFocus: "all"
-				};
+				
+				// };
 				if (typeof allowAdditions === "boolean") {
-					// params.createSearchChoice = function(term) {
-					// 	// enables creation of new namespaces
-					// 	return {id:term, text:term};
-					// }
 				}
-				// console.log("params", params);
-				// init select2 and select first item
-				require(["bootstrap3-typeahead"], function() {
-					$("#" + fieldId).typeahead('destroy');
-					$("#" + fieldId).typeahead(params);
-					if (result.length === 0) {
-						$("#" + fieldId).val("");
-					} else {
-						$("#" + fieldId).val(result[0].id);
-						$("#" + fieldId).typeahead("lookup", result[0].name);
-					}
-				});
 
 				if (typeof onSuccess === "function") {
 					onSuccess();
 				}
 			}).fail(function(jqXHR, textStatus, errorThrown) {
-				vShowAJAXError("Could not fetch select2 data from " + url, jqXHR, errorThrown);
+				vShowAJAXError("Could not fetch data from " + url, jqXHR, errorThrown);
 			});
 
 		}


### PR DESCRIPTION
Removes bootstrap3-typeahead lib.

The library lists 2 different licenses therefore it has to be removed form the project.
