### PR TITLE
Enable Hash-Routes in Angular

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/wineryRepositoryRouting.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryRepositoryRouting.module.ts
@@ -28,7 +28,7 @@ const appRoutes: Routes = [
 
 @NgModule({
     imports: [
-        RouterModule.forRoot(appRoutes),
+        RouterModule.forRoot(appRoutes, {useHash: true}),
     ],
     exports: [
         RouterModule

--- a/org.eclipse.winery.repository.ui/src/index.html
+++ b/org.eclipse.winery.repository.ui/src/index.html
@@ -14,17 +14,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <!--
-    The base MUST be set before ANYTHING else is referenced, otherwise angular won't find anything.
-    If hosted on a tomcat server, the base MUST be href="./".
-    If hosted on lite server, it MUST be href="/".
-    -->
-    <base href="/">
+    <base href="./">
     <title>Winery Repository</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" type="image/x-icon" href="favicon-winery.ico?" />
-
 </head>
 
 <body>


### PR DESCRIPTION
In order to have a simple deployment of the `war` file, we have to enable hash routes in the angular app.

Further, it's now possible to use `<base href="./">` also on the lite server, therefore we no longer need to change this before we deploy the app on a tomcat server.
