### PR TITLE
Fix Save VisualAppearance in RelationshipTypes

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/relationshipTypesVisualsApiData.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/relationshipTypesVisualsApiData.ts
@@ -15,16 +15,16 @@ export class RelationshipTypesVisualsApiData {
     targetArrowHead: string;
     dash: string;
     color: string;
-    hovercolor: string;
+    hoverColor: string;
     boolData: any;
 
-    public constructor(data: any, createBools: boolean) {
+    public constructor(data: any, create: boolean) {
         this.sourceArrowHead = data.sourceArrowHead;
         this.targetArrowHead = data.targetArrowHead;
         this.dash = data.dash;
         this.color = data.color;
-        this.hovercolor = data.hovercolor;
-        if (createBools) {
+        this.hoverColor = data.hoverColor;
+        if (create) {
             this.boolData = new DataInfo();
         }
     }

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.ts
@@ -158,11 +158,11 @@ export class VisualAppearanceComponent implements OnInit {
     }
 
     public get hoverColorLocal() {
-        return this.relationshipData.hovercolor;
+        return this.relationshipData.hoverColor;
     }
 
     public set hoverColorLocal(color: string) {
-        this.relationshipData.hovercolor = color;
+        this.relationshipData.hoverColor = color;
     }
 
     private handleResponse(response: any) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/apiData/RelationshipTypesVisualsApiData.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/apiData/RelationshipTypesVisualsApiData.java
@@ -14,26 +14,22 @@ package org.eclipse.winery.repository.resources.apiData;
 import org.eclipse.winery.repository.resources.entitytypes.relationshiptypes.VisualAppearanceResource;
 
 public class RelationshipTypesVisualsApiData {
-	public String sourcearrowhead;
-	public String targetarrowhead;
+
+	public String sourceArrowHead;
+	public String targetArrowHead;
 	public String dash;
 	public String color;
-	public String hovercolor;
+	public String hoverColor;
 
-	public RelationshipTypesVisualsApiData (VisualAppearanceResource visuals) {
-		this.sourcearrowhead = visuals.getSourceArrowHead();
-		this.targetarrowhead = visuals.getTargetArrowHead();
+	public RelationshipTypesVisualsApiData(VisualAppearanceResource visuals) {
+		this.sourceArrowHead = visuals.getSourceArrowHead();
+		this.targetArrowHead = visuals.getTargetArrowHead();
 		this.dash = visuals.getDash();
 		this.color = visuals.getColor();
-		this.hovercolor = visuals.getHoverColor();
+		this.hoverColor = visuals.getHoverColor();
 	}
 
 	public RelationshipTypesVisualsApiData() {
 
-	}
-
-	@Override
-	public String toString() {
-		return "{sourcearrowhead: " + sourcearrowhead + "}";
 	}
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/entitytypes/relationshiptypes/VisualAppearanceResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/entitytypes/relationshiptypes/VisualAppearanceResource.java
@@ -49,7 +49,7 @@ public class VisualAppearanceResource extends GenericVisualAppearanceResource {
 	private static final QName QNAME_ARROWHEAD_TARGET = new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "targetArrowHead");
 	private static final QName QNAME_DASH = new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "dash");
 	private static final QName QNAME_LINEWIDTH = new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "linewidth");
-	private static final QName QNAME_HOVER_COLOR = new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "hovercolor");
+	private static final QName QNAME_HOVER_COLOR = new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "hoverColor");
 
 
 	public VisualAppearanceResource(RelationshipTypeResource res, Map<QName, String> map, RelationshipTypeId parentId) {
@@ -103,10 +103,10 @@ public class VisualAppearanceResource extends GenericVisualAppearanceResource {
 			jg.writeEndObject();
 
 			jg.writeStringField("dash", getDash());
-			jg.writeStringField("sourcearrowhead", this.getSourceArrowHead());
-			jg.writeStringField("targetarrowhead", this.getTargetArrowHead());
+			jg.writeStringField("sourceArrowHead", this.getSourceArrowHead());
+			jg.writeStringField("targetArrowHead", this.getTargetArrowHead());
 			jg.writeStringField("color", this.getColor());
-			jg.writeStringField("hovercolor", this.getHoverColor());
+			jg.writeStringField("hoverColor", this.getHoverColor());
 			// BEGIN: Overlays
 
 			jg.writeFieldName("overlays");
@@ -196,10 +196,10 @@ public class VisualAppearanceResource extends GenericVisualAppearanceResource {
 			return Response.status(Status.BAD_REQUEST).entity("config must not be empty").build();
 		}
 
-		this.otherAttributes.put(VisualAppearanceResource.QNAME_ARROWHEAD_TARGET, data.targetarrowhead);
-		this.otherAttributes.put(VisualAppearanceResource.QNAME_ARROWHEAD_SOURCE, data.sourcearrowhead);
+		this.otherAttributes.put(VisualAppearanceResource.QNAME_ARROWHEAD_TARGET, data.targetArrowHead);
+		this.otherAttributes.put(VisualAppearanceResource.QNAME_ARROWHEAD_SOURCE, data.sourceArrowHead);
 		this.otherAttributes.put(VisualAppearanceResource.QNAME_DASH, data.dash);
-		this.otherAttributes.put(VisualAppearanceResource.QNAME_HOVER_COLOR, data.hovercolor);
+		this.otherAttributes.put(VisualAppearanceResource.QNAME_HOVER_COLOR, data.hoverColor);
 		this.otherAttributes.put(QNames.QNAME_COLOR, data.color);
 		return BackendUtils.persist(this.res);
 	}

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/relationshiptypes/kiwi_visualAppearance.json
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/relationshiptypes/kiwi_visualAppearance.json
@@ -8,10 +8,10 @@
         "strokeStyle": "black"
     },
     "dash": "plain",
-    "sourcearrowhead": "none",
-    "targetarrowhead": "PlainArrow",
+    "sourceArrowHead": "none",
+    "targetArrowHead": "PlainArrow",
     "color": "#323cb0",
-    "hovercolor": "black",
+    "hoverColor": "black",
     "overlays": [
         [
             "PlainArrow",

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/relationshiptypes/kiwi_visualAppearance_put.json
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/relationshiptypes/kiwi_visualAppearance_put.json
@@ -1,7 +1,7 @@
 {
     "dash": "plain",
-    "sourcearrowhead": "none",
-    "targetarrowhead": "PlainArrow",
+    "sourceArrowHead": "none",
+    "targetArrowHead": "PlainArrow",
     "color": "#323cb0",
-    "hovercolor": "black"
+    "hoverColor": "black"
 }


### PR DESCRIPTION
The VisualAppearanceComponent wasn't saving properly in the RelationshipTypes section. Now it works again.

Signed-off-by: Lukas Harzenetter <lharzenetter@gmx.de>

