### PR TITLE
Add support for error handling in JSP files

### DIFF
--- a/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/web.xml
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/WEB-INF/web.xml
@@ -11,6 +11,7 @@
  * Contributors:
  *    Oliver Kopp - initial API and implementation and/or initial documentation
  *    Karoline Saatkamp - maintenance
+ *    Michael Wurster - Support for error handling
  *******************************************************************************/
 -->
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
@@ -19,4 +20,8 @@
 		 id="winery-topologymodeler"
 		 version="3.1">
 	<display-name>Winery Topology Modeler</display-name>
+	<error-page>
+		<exception-type>java.lang.Throwable</exception-type>
+		<location>/error.jsp</location>
+	</error-page>
 </web-app>

--- a/org.eclipse.winery.topologymodeler/src/main/webapp/error.jsp
+++ b/org.eclipse.winery.topologymodeler/src/main/webapp/error.jsp
@@ -1,0 +1,33 @@
+<%--
+/*******************************************************************************
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v10.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors:
+ *    Michael Wurster - Initial implementation
+ *******************************************************************************/
+--%>
+<%@page language="java" contentType="text/html; charset=utf-8"
+		pageEncoding="utf-8" isErrorPage="true" %>
+
+<%@ page import="org.slf4j.Logger" %>
+<%@ page import="org.slf4j.LoggerFactory" %>
+
+<%! static Logger logger = LoggerFactory.getLogger("error.jsp"); %>
+<% logger.error("An error occurred: {}", exception.getMessage(), exception); %>
+
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Winery Topologymodeler &ndash; Error Page</title>
+	<meta http-equiv="content-type" content="text/html;charset=utf-8"/>
+</head>
+<body>
+<h3>Error: <%=exception.getMessage() %></h3>
+<code><%=exception.printStackTrace() %></code>
+</body>
+</html>


### PR DESCRIPTION
Added a global `error.jsp` being able to handle any thrown exception by the runtime. The `error.jsp` displays the current exception in the browser as well as logs the exception using slf4j.
