### PR TITLE
added new css grid style and selectors in sections

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entityContainer.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entityContainer.component.html
@@ -9,13 +9,14 @@
  *
  * Contributors:
  *     Lukas Harzenetter - initial API and implementation
+ *     Lukas Balzer - moved img element in left div to be displayed correctly
  */
 -->
 <div id="{{ data.namespace | urlEncode | urlEncode }}/{{ data.id }}"
      class="entityContainer {{ toscaType | toscaTypeToCamelCase }}"
      (click)="onClick()">
-    <img *ngIf="imageUrl" src="{{ imageUrl }}" class="nodeTypeImageIconInList">
     <div class="left">
+        <img *ngIf="imageUrl" src="{{ imageUrl }}" class="nodeTypeImageIconInList">
     </div>
     <div class="center">
         <div class="informationContainer">
@@ -27,7 +28,7 @@
             <a class="exportButton" (click)="exportComponent($event)"
                tooltip="Export CSAR. Hold CTRL to export XML."></a>
             <a class="editButton" (click)="editComponent($event)"
-               tooltip="{{editButtonToolTip}}" ></a>
+               tooltip="{{editButtonToolTip}}"></a>
             <a class="deleteButton" (click)="showRemoveDialog($event)" tooltip="Delete"></a>
         </div>
     </div>

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.css
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.css
@@ -8,15 +8,100 @@
  *
  * Contributors:
  *     Lukas Harzenetter - initial API and implementation
+ *     Lukas Balzer - enhanced stylesheet with css grid
  */
 
-.sidebar {
-    display: table-caption;
-    padding-bottom: 30px;
-    padding-left: 100px;
+#sectionsContentContainer {
+    min-height: 300px;
+    overflow: auto;
+    display: -ms-grid;
+    display: grid;
+    -ms-grid-columns: 700px 30px auto;
+    grid-template-columns: 700px 30px auto;
+    -ms-grid-rows: 50px 219px auto 100px;
+    grid-template-rows: 50px 219px auto 100px;
+    grid-column-gap: 5px;
 }
 
-.sidebar-btn {
-    width: 100%;
-    margin-bottom: 3px;
+#searchBoxContainer {
+    -ms-grid-column-span: 2;
+    -ms-grid-column: 1;
+    grid-column: 1 / span 1;
+    -ms-grid-row-span: 1;
+    -ms-grid-row: 1;
+    grid-row: 1 / span 1;
+}
+
+#sectionsComponentContainer {
+    -ms-grid-column-span: 2;
+    -ms-grid-column: 1;
+    grid-column: 1 / span 2;
+    -ms-grid-row-span: 2;
+    -ms-grid-row: 2;
+    grid-row: 2 / span 2;
+}
+
+#sectionsOverviewShadow {
+    -ms-grid-column-span: 1;
+    -ms-grid-column: 2;
+    grid-column: 2 / span 1;
+    -ms-grid-row-span: 2;
+    -ms-grid-row: 1;
+    grid-row: 1 / span 2;
+    background-image: url("../../assets/img/overviewShadowBottom.jpg");
+}
+
+#sectionSidebar {
+    -ms-grid-column-span: 1;
+    -ms-grid-column: 3;
+    grid-column: 3 / span 1;
+    -ms-grid-row-span: 3;
+    -ms-grid-row: 1;
+    grid-row: 1 / span 3;
+    display: inline-grid;
+    grid-template-columns: auto 200px auto;
+    -ms-grid-rows: auto;
+    grid-auto-rows: 30px;
+    grid-row-gap: 5px;
+}
+
+#sectionsAddNewBtn {
+    -ms-grid-column-span: 1;
+    -ms-grid-column: 2;
+    grid-column: 2 / span 1;
+    -ms-grid-row-span: 1;
+    -ms-grid-row: 1;
+    grid-row: 1 / span 1;
+}
+
+#sectionsImportCsarBtn {
+    -ms-grid-column-span: 1;
+    -ms-grid-column: 2;
+    grid-column: 2 / span 1;
+    -ms-grid-row-span: 1;
+    -ms-grid-row: 2;
+    grid-row: 2 / span 1;
+}
+
+#sectionsGroupBtn {
+    -ms-grid-column-span: 1;
+    -ms-grid-column: 2;
+    grid-column: 2 / span 1;
+    -ms-grid-row-span: 1;
+    -ms-grid-row: 3;
+    grid-row: 3 / span 1;
+}
+
+#sectionsFooterContainer {
+    -ms-grid-column-span: 3;
+    -ms-grid-column: 1;
+    grid-column: 1 / span 3;
+    -ms-grid-row-span: 1;
+    -ms-grid-row: 4;
+    grid-row: 4 / span 1;
+    grid-template-columns: auto 200px auto;
+    grid-auto-rows: 30px;
+    grid-row-gap: 5px;
+    justify-self: center;
+    -ms-grid-column-align: center;
 }

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.html
@@ -9,36 +9,39 @@
  *
  * Contributors:
  *     Lukas Harzenetter - initial API and implementation
+ *     Lukas Balzer - enhanced stylesheet with css grid
  */
 -->
 <div [class.hidden]="!loading">
     <winery-loader></winery-loader>
 </div>
-<div *ngIf="!loading">
-    <div id="contentContainer">
-        <div id="searchBoxContainer">
-            <input type="text" id="searchBox" [(ngModel)]="filterString">
-        </div>
-        <div id="componentContainer">
-            <winery-entity-container
-                *ngFor="let item of componentData
+<div *ngIf="!loading" id="sectionsContentContainer">
+    <div id="searchBoxContainer">
+        <input type="text" id="searchBox" [(ngModel)]="filterString">
+    </div>
+    <div id="sectionsOverviewShadow">
+    </div>
+    <div class="floatSection" id="sectionsComponentContainer">
+        <winery-entity-container
+            *ngFor="let item of componentData
                 | filterSections: { showNamespaces: showNamespace, filterString: filterString }
                 | paginate: { itemsPerPage: itemsPerPage, currentPage: currentPage }"
-                [toscaType]="toscaType"
-                [data]="item"
-                (deleted)="getSectionsData()">
-            </winery-entity-container>
-        </div>
-        <div class="sidebar">
-            <button class="btn btn-default sidebar-btn" (click)="onAdd();">Add new</button>
-            <button class="btn btn-default sidebar-btn" (click)="addCsarModal.show();">Import CSAR</button>
-            <button class="btn btn-default sidebar-btn" (click)="onChangeView()"
-                    [disabled]="showSpecificNamespaceOnly()">
-                {{ changeViewButtonTitle }}
-            </button>
-        </div>
+            [toscaType]="toscaType"
+            [data]="item"
+            (deleted)="getSectionsData()">
+        </winery-entity-container>
     </div>
-    <div class="footerContainer">
+    <div class="floatSection" id="sectionSidebar">
+        <button class="btn btn-default sidebar-btn" id="sectionsAddNewBtn" (click)="onAdd();">Add new</button>
+        <button class="btn btn-default sidebar-btn" id="sectionsImportCsarBtn" (click)="addCsarModal.show();">Import
+            CSAR
+        </button>
+        <button class="btn btn-default sidebar-btn" id="sectionsGroupBtn" (click)="onChangeView()"
+                [disabled]="showSpecificNamespaceOnly()">
+            {{ changeViewButtonTitle }}
+        </button>
+    </div>
+    <div id="sectionsFooterContainer">
         <label for="selectItemsPerPage">Items per Page:</label>
         <select id="selectItemsPerPage" [(ngModel)]="itemsPerPage">
             <option value="10">10</option>
@@ -81,7 +84,8 @@
             </winery-namespace-selector>
             <div class="form-group" *ngIf="types">
                 <label for="typeSelect" class="control-label">Type</label>
-                <ng-select id="typeSelect" [items]="types" (selected)="typeSelected($event)" [active]="[newComponentSelectedType]"></ng-select>
+                <ng-select id="typeSelect" [items]="types" (selected)="typeSelected($event)"
+                           [active]="[newComponentSelectedType]"></ng-select>
             </div>
         </form>
     </winery-modal-body>
@@ -96,7 +100,8 @@
 <winery-modal bsModal #addCsarModal="bs-modal" [modalRef]="addCsarModal">
     <winery-modal-header [title]="'Add CSAR'"></winery-modal-header>
     <winery-modal-body>
-        <winery-uploader [modalRef]="addCsarModal" [uploadUrl]="fileUploadUrl" (onSuccess)="getSectionsData();"></winery-uploader>
+        <winery-uploader [modalRef]="addCsarModal" [uploadUrl]="fileUploadUrl"
+                         (onSuccess)="getSectionsData();"></winery-uploader>
     </winery-modal-body>
     <winery-modal-footer [showDefaultButtons]="false">
         <button type="button" class="btn btn-default" (click)="addCsarModal.hide()">Cancel</button>
@@ -111,5 +116,5 @@
         </p>
     </winery-modal-body>
     <winery-modal-footer [closeButtonLabel]="'No'" [okButtonLabel]="'Yes'"
-                        (onOk)="onRemoveElement()"></winery-modal-footer>
+                         (onOk)="onRemoveElement()"></winery-modal-footer>
 </winery-modal>


### PR DESCRIPTION
Signed-off-by: Lukas Balzer <balzer814_dev@web.de>

Introduced CSS3 Grid styleing in the winery-sections componnent

Pageinator is now displayed at the bottom center instead of under the sidebar buttons
before:
![grafik](https://user-images.githubusercontent.com/23092994/30026608-edd320d0-917d-11e7-8e1d-ac178a1ce8d7.png)
after:
![grafik](https://user-images.githubusercontent.com/23092994/30025910-007119a2-917b-11e7-8f0c-fe15229cc427.png)


In firefox the images are now displayed inside an entityContainer
before:
![grafik](https://user-images.githubusercontent.com/23092994/30026637-1448d62e-917e-11e7-8fe7-575882019186.png)
after:
![grafik](https://user-images.githubusercontent.com/23092994/30026049-8cc67cee-917b-11e7-8218-fdec21f9aaeb.png)

Styling for Microsoft Edge is now the same as in Firefox and Chrome for the Sections Component