### PR TITLE
Fix PropertiesDefinition Element

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/ImportUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/ImportUtils.java
@@ -96,6 +96,6 @@ public class ImportUtils {
 	}
 
 	public static Optional<String> getLocation(GenericImportId id) {
-		return getTheImport(id).map(TImport::getLocation).filter(Objects::isNull);
+		return getTheImport(id).map(TImport::getLocation).filter(Objects::nonNull);
 	}
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/ImportUtilsTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/ImportUtilsTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart. All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 and the Apache License 2.0 which both accompany this
+ * distribution, and are available at http://www.eclipse.org/legal/epl-v10.html and
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors: Lukas Harzenetter - initial API and implementation
+ */
+package org.eclipse.winery.repository;
+
+import java.util.Optional;
+
+import org.eclipse.winery.common.ids.Namespace;
+import org.eclipse.winery.common.ids.XMLId;
+import org.eclipse.winery.common.ids.definitions.imports.XSDImportId;
+import org.eclipse.winery.repository.backend.ImportUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImportUtilsTest extends TestWithGitBackedRepository {
+
+	@Test
+	public void getLocationForImportTest() throws Exception {
+		this.setRevisionTo("5fdcffa9ccd17743d5498cab0914081fc33606e9");
+
+		XSDImportId id = new XSDImportId(
+			new Namespace("http://opentosca.org/nodetypes", false),
+			new XMLId("CloudProviderProperties", false));
+		Optional<String> importLocation = ImportUtils.getLocation(id);
+
+		Assert.assertEquals(true, importLocation.isPresent());
+	}
+}

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/FilebasedRepositoryTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/FilebasedRepositoryTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart. All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 and the Apache License 2.0 which both accompany this
+ * distribution, and are available at http://www.eclipse.org/legal/epl-v10.html and
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors: Lukas Harzenetter - initial API and implementation
+ */
+package org.eclipse.winery.repository.backend.filebased;
+
+import java.util.SortedSet;
+
+import org.eclipse.winery.common.ids.definitions.imports.XSDImportId;
+import org.eclipse.winery.repository.TestWithGitBackedRepository;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
+
+	@Test
+	public void getAllTOSCAComponentIds() throws Exception {
+		this.setRevisionTo("5fdcffa9ccd17743d5498cab0914081fc33606e9");
+		SortedSet<XSDImportId> allImports = this.repository.getAllTOSCAComponentIds(XSDImportId.class);
+
+		Assert.assertEquals(1, allImports.size());
+	}
+}

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/xsd/RepositoryBasedXsdImportManagerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/xsd/RepositoryBasedXsdImportManagerTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart. All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 and the Apache License 2.0 which both accompany this
+ * distribution, and are available at http://www.eclipse.org/legal/epl-v10.html and
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors: Lukas Harzenetter - initial API and implementation
+ */
+package org.eclipse.winery.repository.backend.xsd;
+
+import java.util.List;
+
+import org.eclipse.winery.repository.TestWithGitBackedRepository;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class RepositoryBasedXsdImportManagerTest extends TestWithGitBackedRepository {
+
+	@Test
+	public void getAllDeclaredElementsLocalNamesTest() throws Exception {
+		this.setRevisionTo("5fdcffa9ccd17743d5498cab0914081fc33606e9");
+
+		RepositoryBasedXsdImportManager manager = (RepositoryBasedXsdImportManager) this.repository.getXsdImportManager();
+		List<NamespaceAndDefinedLocalNames> list = manager.getAllDeclaredElementsLocalNames();
+
+		Assert.assertEquals(1, list.size());
+	}
+
+	@Test
+	@Ignore("Not yet implemented.")
+	public void getAllDefinedLocalNamesForElementsTest() throws Exception {
+		this.setRevisionTo("5fdcffa9ccd17743d5498cab0914081fc33606e9");
+
+		RepositoryBasedXsdImportManager manager = (RepositoryBasedXsdImportManager) this.repository.getXsdImportManager();
+		List<NamespaceAndDefinedLocalNames> list = manager.getAllDefinedTypesLocalNames();
+
+		Assert.assertEquals(1, list.size());
+	}
+}


### PR DESCRIPTION
When selecting a PropertiesDefinition Element, the list was empty.
This was because the `filter` function filtered `Objects::isNull` instead of `Objects.nonNull`.

There are some test now in order to ensure correctness.
