### PR TITLE
Added Rename componente for ToscaComponents in the instanceHeader

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/AbstractComponentInstanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/AbstractComponentInstanceResource.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
-import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -66,6 +65,7 @@ import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.export.TOSCAExportUtil;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.IPersistable;
+import org.eclipse.winery.repository.rest.resources.apiData.QNameApiData;
 import org.eclipse.winery.repository.rest.resources.documentation.DocumentationResource;
 import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.nodetypeimplementations.NodeTypeImplementationResource;
 import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.relationshiptypeimplementations.RelationshipTypeImplementationResource;
@@ -210,21 +210,23 @@ public abstract class AbstractComponentInstanceResource implements Comparable<Ab
 	}
 
 	@POST
-	@Path("id")
-	public Response putId(@FormParam("id") String id, @FormParam("namespace") String namespace) {
+	@Path("localName")
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response putId(QNameApiData data) {
 		TOSCAComponentId newId;
-		if (namespace == null) {
-			newId = BackendUtils.getTOSCAcomponentId(this.getId().getClass(), this.getId().getNamespace().getDecoded(), id, false);
+		if (data.namespace == null) {
+			newId = BackendUtils.getTOSCAcomponentId(this.getId().getClass(), this.getId().getNamespace().getDecoded(), data.localname, false);
 		} else {
-			newId = BackendUtils.getTOSCAcomponentId(this.getId().getClass(), namespace, this.getId().getXmlId().toString(), false);
+			newId = BackendUtils.getTOSCAcomponentId(this.getId().getClass(), data.namespace, this.getId().getXmlId().toString(), false);
 		}
 		return RestUtils.rename(this.getId(), newId);
 	}
 
 	@POST
 	@Path("namespace")
-	public Response putNamespace(@FormParam("ns") String namespace) {
-		TOSCAComponentId newId = BackendUtils.getTOSCAcomponentId(this.getId().getClass(), namespace, this.getId().getXmlId().getDecoded(), false);
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response putNamespace(QNameApiData data) {
+		TOSCAComponentId newId = BackendUtils.getTOSCAcomponentId(this.getId().getClass(), data.namespace, this.getId().getXmlId().getDecoded(), false);
 		return RestUtils.rename(this.getId(), newId);
 	}
 

--- a/org.eclipse.winery.repository.ui/src/app/instance/instance.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instance.module.ts
@@ -18,6 +18,9 @@ import { WineryModalModule } from '../wineryModalModule/winery.modal.module';
 import { WineryPipesModule } from '../wineryPipes/wineryPipes.module';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { PropertyRenameComponent } from './instanceHeader/propertyRename/propertyRename.component';
+import { FormsModule } from '@angular/forms';
+import { WineryDuplicateValidatorModule } from '../wineryValidators/wineryDuplicateValidator.module';
 
 @NgModule({
     imports: [
@@ -25,12 +28,14 @@ import { CommonModule } from '@angular/common';
         RouterModule,
         WineryLoaderModule,
         WineryModalModule,
-        WineryPipesModule
+        WineryPipesModule,
+        FormsModule
     ],
     exports: [InstanceComponent],
     declarations: [
         InstanceComponent,
         InstanceHeaderComponent,
+        PropertyRenameComponent
     ],
     providers: [],
 })

--- a/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/instanceHeader.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/instanceHeader.component.html
@@ -14,12 +14,8 @@
 <div class="top" [class.twolines]="needTwoLines">
     <img *ngIf="imageUrl" src="{{ imageUrl }}" class="nodeTypeImageIcon">
     <div class="informationContainer">
-        <div id="component_name" class="name editable editable-click">
-            {{ toscaComponent.localName }}
-        </div>
-        <div id="component_namespace" class="namespace editable editable-click">
-            {{ toscaComponent.namespace }}
-        </div>
+        <winery-property-rename [toscaComponent]="toscaComponent" [propertyName]="'localName'"></winery-property-rename>
+        <winery-property-rename [toscaComponent]="toscaComponent" [propertyName]="'namespace'"></winery-property-rename>
     </div>
     <div class="managementButtons">
         <button class="btn btn-danger" (click)="confirmDeleteModal.show()">Delete</button>
@@ -51,7 +47,7 @@
         </p>
     </winery-modal-body>
     <winery-modal-footer (onOk)="deleteConfirmed.emit();"
-                        [closeButtonLabel]="'Cancel'"
-                        [okButtonLabel]="'Delete'">
+                         [closeButtonLabel]="'Cancel'"
+                         [okButtonLabel]="'Delete'">
     </winery-modal-footer>
 </winery-modal>

--- a/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/instanceHeader.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/instanceHeader.component.ts
@@ -11,9 +11,7 @@
  */
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { backendBaseURL } from '../../configuration';
 import { RemoveWhiteSpacesPipe } from '../../wineryPipes/removeWhiteSpaces.pipe';
-import { InstanceService } from '../instance.service';
 import { ModalDirective } from 'ngx-bootstrap';
 import { ToscaComponent } from '../../wineryInterfaces/toscaComponent';
 

--- a/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/propertyRename/propertyRename.component.css
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/propertyRename/propertyRename.component.css
@@ -1,0 +1,23 @@
+<!--
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v10.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors:
+ *     Lukas Balzer - initial API and implementation
+ */
+-->
+
+#propertyRenameContainer {
+    display: grid;
+    grid-template-columns: 200px 40px 40px 40px;
+    grid-template-rows: 40px;
+}
+
+#renamePropertyInput {
+    width: 300px;
+}

--- a/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/propertyRename/propertyRename.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/propertyRename/propertyRename.component.html
@@ -1,0 +1,35 @@
+<!--
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v10.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors:
+ *     Lukas Balzer - initial API and implementation
+ */
+-->
+<div id="propertyRenameContainer">
+    <div *ngIf="editMode">
+        <form #renameComponentForm="ngForm">
+            <input type="text"
+                   class="input-sm"
+                   id="renamePropertyInput"
+                   name="propertyInput"
+                   #renameName="ngModel"
+                   [(ngModel)]="propertyValue"
+                   required>
+            <button class="btn btn-primary btn-xs" (click)="onSaveValue()" type="button"
+                    [disabled]="!(renameComponentForm?.form.valid || propertyValue?.length > 0)">Save
+            </button>
+            <button class="btn btn-danger btn-xs" (click)="onCancel()">Cancel</button>
+        </form>
+    </div>
+    <div *ngIf="!editMode">
+        <span (click)="onClickEdit()" *ngIf="propertyName === 'localName'">{{toscaComponent.localName}}</span>
+        <span (click)="onClickEdit()" *ngIf="propertyName === 'namespace'">{{toscaComponent.namespace}}</span>
+        <button *ngIf="!canEdit" class="btn btn-primary btn-xs" (click)="onClickEdit()">...</button>
+    </div>
+</div>

--- a/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/propertyRename/propertyRename.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/propertyRename/propertyRename.component.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v10.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors:
+ *     Lukas Balzer - initial API and implementation
+ */
+
+import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
+import { WineryNotificationService } from '../../../wineryNotificationModule/wineryNotification.service';
+import { PropertyRenameService } from './propertyRename.service';
+import { ToscaComponent } from '../../../wineryInterfaces/toscaComponent';
+import { NgForm } from '@angular/forms';
+import { Router } from '@angular/router';
+
+/**
+ * This adds a an editable field to the html that manipulates either the namespace or the id/name of a ToscaComponent
+ *
+ * @Input id: this is the id of the property which must either be 'id' or 'namespace'
+ * @Input toscaComponent: the toscaComponent which's id/namespace is edited/displayed
+ */
+@Component({
+    selector: 'winery-property-rename',
+    templateUrl: 'propertyRename.component.html',
+    providers: [PropertyRenameService],
+    styleUrls: [
+        'propertyRename.component.css'
+    ]
+})
+export class PropertyRenameComponent implements OnInit, OnChanges {
+    @Input() propertyName: string;
+    @Input() toscaComponent: ToscaComponent;
+    @ViewChild('renameComponentForm') renameComponentForm: NgForm;
+    editMode = false;
+    canEdit = true;
+    propertyValue = '';
+
+    constructor(private service: PropertyRenameService,
+                private notify: WineryNotificationService,
+                private router: Router) {
+    }
+
+    ngOnInit(): void {
+        this.service.setToscaComponent(this.toscaComponent);
+        this.service.setPropertyName(this.propertyName);
+        this.canEdit = this.router.url.includes('admin');
+    }
+
+    ngOnChanges() {
+        this.service.setToscaComponent(this.toscaComponent);
+    }
+
+    updateValue() {
+        this.service.setPropertyValue(this.propertyValue).subscribe(
+            data => this.handleUpdateValue(),
+            error => this.handleError(error)
+        )
+    }
+
+    onClickEdit() {
+        if (this.propertyName === 'localName') {
+            this.propertyValue = this.toscaComponent.localName;
+        } else {
+            this.propertyValue = this.toscaComponent.namespace;
+        }
+        this.editMode = true;
+    }
+
+    onSaveValue() {
+        this.editMode = false;
+        this.updateValue();
+    }
+
+    onCancel() {
+        this.editMode = false;
+    }
+
+    private handleUpdateValue() {
+        this.notify.success('Renamed ' + this.propertyName + ' to ' + this.propertyValue);
+        this.service.reload(this.propertyValue);
+    }
+
+    private handleError(error: any): void {
+        this.notify.error('id/name ' + this.propertyValue
+            + ' already exists in the current namespace, please enter a different ' + this.propertyName);
+    }
+}

--- a/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/propertyRename/propertyRename.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/propertyRename/propertyRename.service.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v10.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors:
+ *     Lukas Balzer - initial API and implementation
+ */
+import { Injectable } from '@angular/core';
+import { Headers, Http, RequestOptions, Response } from '@angular/http';
+import { Router } from '@angular/router';
+import { backendBaseURL } from '../../../configuration';
+import { ToscaComponent } from '../../../wineryInterfaces/toscaComponent';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class PropertyRenameService {
+
+    private propertyName: string;
+    private toscaComponent: ToscaComponent;
+
+    constructor(private http: Http,
+                private route: Router) {
+    }
+
+    setPropertyName(propertyName: string) {
+        this.propertyName = propertyName;
+    }
+
+    setToscaComponent(toscaComponent: ToscaComponent) {
+        this.toscaComponent = toscaComponent;
+        console.log(toscaComponent);
+    }
+
+    setPropertyValue(value: string): Observable<Response> {
+        const headers = new Headers({ 'Content-Type': 'application/json' });
+        const options = new RequestOptions({ headers: headers });
+        let payload;
+        if (this.propertyName === 'localName') {
+            payload = {
+                localname: value
+            }
+        } else {
+            payload = {
+                namespace: value
+            }
+        }
+        return this.http.post(backendBaseURL + this.toscaComponent.path + '/' + this.propertyName, payload, options);
+    }
+
+    reload(property: string) {
+        if (this.propertyName === 'localName') {
+            this.route.navigateByUrl(this.toscaComponent.toscaType + '/'
+                + encodeURIComponent(encodeURIComponent(this.toscaComponent.namespace)) + '/' + property);
+        } else {
+            this.route.navigateByUrl(this.toscaComponent.toscaType + '/'
+                + encodeURIComponent(encodeURIComponent(property)) + '/' + this.toscaComponent.localName);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Lukas Balzer <balzer814_dev@web.de>

added renaming component in instance header,
allowing renaming of the id/name or creation/change of/to a new namespace
the input is than validated in the backend

![grafik](https://user-images.githubusercontent.com/23092994/30072716-7e53d8f0-926b-11e7-9b58-c6cbaab7767d.png)

