### PR TITLE
implements get templates of type for artifact- and policy types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ### Changed
 
 - Fixed GroupByNamespace issue. Each tosca type has its own namespace state.
+- Add templates tab to policy types and artifact types. It shows the templates of the current artifact or policy type.
 - Add artifact source editor to create/upload and edit source files 
 - Initial support for BPMN4TOSCA implemented using Angular
 - Added initial CLI. Current funtionality: Consistency check of the repository.
@@ -31,7 +32,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 
 ## [v1.0.0] - not yet released
 
-- Remove autocompletion for namespaces
+- Remove autocompletion for namespaces  
 
 ## [v2.0.0-M1] - 2017-07-03
 

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/TemplatesOfOneType.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/TemplatesOfOneType.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2017 University of Stuttgart
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *******************************************************************************/
+package org.eclipse.winery.repository.rest.resources.entitytypes;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.repository.rest.resources.apiData.QNameApiData;
+import org.eclipse.winery.repository.rest.resources.apiData.converter.QNameConverter;
+
+/**
+ * Gets all templates/implementations of a type.
+ * Returns the templates/implementations in JSON format see: getJSON method
+ */
+public abstract class TemplatesOfOneType {
+	
+	/**
+	 * returns a collection of a templates/implementations of a type
+	 * has to be implemented in the concrete class for examples see {@link org.eclipse.winery.repository.rest.resources.entitytypes.policytypes.TemplatesOfOnePolicyTypeResource} and
+	 * {@link org.eclipse.winery.repository.rest.resources.entitytypes.artifacttypes.TemplatesOfOneArtifactTypeResource}
+	 */
+	protected abstract Collection<? extends DefinitionsChildId> getAllImplementations();
+
+	/**
+	 * returns a list of all implementations of a type using the getAllImplementations method
+	 */
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	public Response getJSON() {
+		Collection<? extends DefinitionsChildId> allImplementations = this.getAllImplementations();
+		List<QNameApiData> res = new ArrayList<>(allImplementations.size());
+		QNameConverter adapter = new QNameConverter();
+		for (DefinitionsChildId id : allImplementations) {
+			res.add(adapter.marshal(id.getQName()));
+		}
+		return Response.ok().entity(res).build();
+	}
+}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/ArtifactTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/ArtifactTypeResource.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Oliver Kopp - initial API and implementation
+ *     Niko Stadelmaier - add get templates
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.artifacttypes;
 
@@ -66,5 +67,10 @@ public class ArtifactTypeResource extends EntityTypeResource {
 		} catch (RepositoryCorruptException e) {
 			throw new WebApplicationException(e);
 		}
+	}
+
+	@Path("templates/")
+	public TemplatesOfOneArtifactTypeResource getImplementations() {
+		return new TemplatesOfOneArtifactTypeResource((ArtifactTypeId) this.id);
 	}
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/TemplatesOfOneArtifactTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/TemplatesOfOneArtifactTypeResource.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *******************************************************************************/
+package org.eclipse.winery.repository.rest.resources.entitytypes.artifacttypes;
+
+import java.util.Collection;
+
+import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
+import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.rest.resources.entitytypes.TemplatesOfOneType;
+
+public class TemplatesOfOneArtifactTypeResource extends TemplatesOfOneType {
+
+	private ArtifactTypeId artifactTypeId;
+
+	/**
+	 * Resource returns all templates/implementations of the given artifact type
+	 * @param artifactTypeId the Id of the artifact type
+	 */
+	public TemplatesOfOneArtifactTypeResource(ArtifactTypeId artifactTypeId) {
+		this.artifactTypeId = artifactTypeId;
+	}
+
+	@Override
+	public Collection<ArtifactTemplateId> getAllImplementations() {
+		return RepositoryFactory.getRepository().getAllElementsReferencingGivenType(ArtifactTemplateId.class, this.artifactTypeId.getQName());
+	}
+}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypeResource.java
@@ -69,5 +69,10 @@ public final class PolicyTypeResource extends EntityTypeResource {
 			throw new WebApplicationException(e);
 		}
 	}
+	
+	@Path("templates/")
+	public TemplatesOfOnePolicyTypeResource getImplementations() {
+		return new TemplatesOfOnePolicyTypeResource((PolicyTypeId) this.id);
+	}
 
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/TemplatesOfOnePolicyTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/TemplatesOfOnePolicyTypeResource.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *******************************************************************************/
+package org.eclipse.winery.repository.rest.resources.entitytypes.policytypes;
+
+import java.util.Collection;
+
+import org.eclipse.winery.common.ids.definitions.PolicyTemplateId;
+import org.eclipse.winery.common.ids.definitions.PolicyTypeId;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.rest.resources.entitytypes.TemplatesOfOneType;
+
+public class TemplatesOfOnePolicyTypeResource extends TemplatesOfOneType {
+
+	private PolicyTypeId policyTypeId;
+	/**
+	 * Resource returns all templates/implementations of the given policy type
+	 * @param policyTypeId the Id of the policy type
+	 */
+	public TemplatesOfOnePolicyTypeResource(PolicyTypeId policyTypeId) {
+		this.policyTypeId = policyTypeId;
+	}
+
+	@Override
+	public Collection<PolicyTemplateId> getAllImplementations() {
+		return RepositoryFactory.getRepository().getAllElementsReferencingGivenType(PolicyTemplateId.class, this.policyTypeId.getQName());
+	}
+}

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/TemplatesOfOneArtifactTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/TemplatesOfOneArtifactTypeResourceTest.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *******************************************************************************/
+package org.eclipse.winery.repository.rest.resources.entitytypes.artifacttypes;
+
+
+import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
+
+import org.junit.Test;
+
+public class TemplatesOfOneArtifactTypeResourceTest extends AbstractResourceTest {
+
+	@Test
+	public void getTemplatesOfArtifactType() throws Exception {
+		this.setRevisionTo("6aabc1c52ad74ab2692e7d59dbe22a263667e2c9");
+		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/JAR/templates/", "entitytypes/artifacttypes/templates_of_jar_artifact_type.json");
+	}
+}

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/TemplatesOfOnePolicyTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/TemplatesOfOnePolicyTypeResourceTest.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources.entitytypes.policytypes;
+
+
+import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
+
+import org.junit.Test;
+
+public class TemplatesOfOnePolicyTypeResourceTest extends AbstractResourceTest {
+	
+	@Test
+	public void getTemplatesOfPolicyType() throws Exception{
+		this.setRevisionTo("88e5ccd6c35aeffdebc19c8dda9cd76f432538f8");
+		this.assertGet("policytypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fpolicytypes%252Ffruits/european/templates/","entitytypes/policytypes/templates_of_european_policytype.json");
+	}
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/templates_of_jar_artifact_type.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/templates_of_jar_artifact_type.json
@@ -1,0 +1,1 @@
+[{"localname":"baobab-ArtifactTemplate-Peel","namespace":"http://winery.opentosca.org/test/artifacttemplates/fruits"}]

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/policytypes/templates_of_european_policytype.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/policytypes/templates_of_european_policytype.json
@@ -1,0 +1,1 @@
+[{"localname":"german","namespace":"http://winery.opentosca.org/test/policytemplates/fruits"},{"localname":"italian","namespace":"http://winery.opentosca.org/test/policytemplates/fruits"}]

--- a/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
@@ -54,7 +54,7 @@ export class InstanceService {
                     'Inheritance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.ArtifactType:
-                subMenu = ['Properties Definition', 'Inheritance', 'Documentation', 'XML'];
+                subMenu = ['Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.ArtifactTemplate:
                 subMenu = ['Files', 'Source', 'Properties', 'Documentation', 'XML'];
@@ -72,7 +72,7 @@ export class InstanceService {
                 subMenu = ['Implementation Artifacts', 'Inheritance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.PolicyType:
-                subMenu = ['Language', 'Applies To', 'Properties Definition', 'Inheritance', 'Documentation', 'XML'];
+                subMenu = ['Language', 'Applies To', 'Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.PolicyTemplate:
                 subMenu = ['Properties', 'Documentation', 'XML'];

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/templatesOfTypes/templatesOfType.Module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/templatesOfTypes/templatesOfType.Module.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { WineryLoaderModule } from '../../../wineryLoader/wineryLoader.module';
+import { WineryModalModule } from '../../../wineryModalModule/winery.modal.module';
+import { WineryPipesModule } from '../../../wineryPipes/wineryPipes.module';
+import { TemplatesOfTypeComponent } from './templatesOfTypes.component';
+import { WineryTableModule } from '../../../wineryTableModule/wineryTable.module';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        RouterModule,
+        WineryLoaderModule,
+        WineryModalModule,
+        WineryPipesModule,
+        WineryTableModule
+    ],
+    declarations: [
+        TemplatesOfTypeComponent
+    ],
+    providers: [],
+})
+export class TemplatesOfTypeModule {
+}

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/templatesOfTypes/templatesOfType.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/templatesOfTypes/templatesOfType.component.html
@@ -1,0 +1,25 @@
+<!--
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+-->
+<p>This page shows templates available for this type. Go to
+    <a [routerLink]="['/other']">Other Elements</a>
+    to get an overview on all implementations stored in this repository. </p>
+<div class="localLoader" [class.hidden]="!loading">
+    <winery-loader></winery-loader>
+</div>
+<div *ngIf="!loading">
+    <winery-table
+        [data]="templateData"
+        [columns]="columns"
+        (cellSelected)="onCellSelected($event)"
+        [itemsPerPage]="10"
+        [disableButtons]="true">
+    </winery-table>
+</div>

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/templatesOfTypes/templatesOfTypes.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/templatesOfTypes/templatesOfTypes.component.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { Component, OnInit } from '@angular/core';
+import { isNullOrUndefined } from 'util';
+import { WineryNotificationService } from '../../../wineryNotificationModule/wineryNotification.service';
+import { WineryValidatorObject } from '../../../wineryValidators/wineryDuplicateValidator.directive';
+import { TemplatesOfTypeService } from './templatesOfTypes.service';
+import { ImplementationAPIData } from '../implementations/implementationAPIData';
+
+@Component({
+    selector: 'winery-templates-of-type',
+    templateUrl: 'templatesOfType.component.html',
+    providers: [TemplatesOfTypeService,
+        WineryNotificationService],
+})
+export class TemplatesOfTypeComponent implements OnInit {
+    templateData: ImplementationAPIData[];
+    loading = true;
+    selectedCell: any;
+    validatorObject: WineryValidatorObject;
+    columns: Array<any> = [
+        {title: 'Namespace', name: 'namespace', sort: true},
+        {title: 'Name', name: 'localname', sort: true},
+    ];
+
+    constructor(private service: TemplatesOfTypeService,
+                private notificationService: WineryNotificationService) {
+        this.templateData = [];
+    }
+
+    ngOnInit() {
+        this.getImplementationData();
+    }
+
+    // region ######## table methods ########
+    onCellSelected(data: any) {
+        if (!isNullOrUndefined(data)) {
+            this.selectedCell = data.row;
+        }
+    }
+
+    // endregion
+
+    // region ######## call service methods and subscription handlers ########
+    private getImplementationData(): void {
+        this.service.getTemplateData()
+            .subscribe(
+                data => this.handleData(data),
+                error => this.handleError(error)
+            );
+    }
+
+    private handleData(impl: ImplementationAPIData[]) {
+        this.templateData = impl;
+        if (this.service.getPath().includes('artifact')) {
+            this.templateData = this.templateData.map(item => {
+                const url = '#/' + 'artifacttemplates' + '/' + encodeURIComponent(encodeURIComponent(item.namespace))
+                    + '/' + item.localname;
+                item.localname = '<a href="' + url + '">' + item.localname + '</a>';
+                return item;
+            })
+        } else if (this.service.getPath().includes('policy')) {
+            this.templateData = this.templateData.map(item => {
+                const url = '#/' + 'policytemplates' + '/' + encodeURIComponent(encodeURIComponent(item.namespace))
+                    + '/' + item.localname;
+                item.localname = '<a href="' + url + '">' + item.localname + '</a>';
+                return item;
+            })
+        }
+        this.loading = false;
+    }
+
+    private handleError(error: any): void {
+        this.loading = false;
+        this.notificationService.error('Action caused an error:\n', error);
+    }
+
+    // endregion
+}

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/templatesOfTypes/templatesOfTypes.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/templatesOfTypes/templatesOfTypes.service.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { Injectable } from '@angular/core';
+import { Headers, Http, RequestOptions, Response } from '@angular/http';
+import { Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { backendBaseURL } from '../../../configuration';
+import { ImplementationAPIData } from '../implementations/implementationAPIData';
+import { ImplementationWithTypeAPIData } from '../implementations/implementationWithTypeAPIData';
+
+@Injectable()
+export class TemplatesOfTypeService {
+    private path: string;
+
+    constructor(private http: Http,
+                private route: Router) {
+        this.path = decodeURIComponent(this.route.url);
+    }
+
+    getTemplateData(): Observable<ImplementationAPIData[]> {
+        const headers = new Headers({'Accept': 'application/json'});
+        const options = new RequestOptions({headers: headers});
+        return this.http.get(backendBaseURL + this.path + '/', options)
+            .map(res => res.json());
+    }
+
+    getPath(): string {
+        return this.path;
+    }
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artifactTypes/artifactTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artifactTypes/artifactTypeRouter.module.ts
@@ -20,6 +20,7 @@ import { DocumentationComponent } from '../../instance/sharedComponents/document
 import { ToscaTypes } from '../../wineryInterfaces/enums';
 import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
 import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
+import { TemplatesOfTypeComponent } from '../../instance/sharedComponents/templatesOfTypes/templatesOfTypes.component';
 
 const toscaType = ToscaTypes.ArtifactType;
 
@@ -34,7 +35,8 @@ const artifactTypeRoutes: Routes = [
             { path: 'propertiesdefinition', component: PropertiesDefinitionComponent },
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
-            { path: 'xml', component: EditXMLComponent }
+            { path: 'xml', component: EditXMLComponent },
+            { path: 'templates', component:  TemplatesOfTypeComponent}
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyTypeRouter.module.ts
@@ -22,6 +22,7 @@ import { InheritanceComponent } from '../../instance/sharedComponents/inheritanc
 import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
 import { LanguageComponent } from '../../instance/policyTypes/language/language.component';
 import { AppliesToComponent } from '../../instance/policyTypes/appliesTo/appliesTo.component';
+import { TemplatesOfTypeComponent } from '../../instance/sharedComponents/templatesOfTypes/templatesOfTypes.component';
 
 const toscaType = ToscaTypes.PolicyType;
 
@@ -38,7 +39,9 @@ const policyTypeRoutes: Routes = [
             { path: 'propertiesdefinition', component: PropertiesDefinitionComponent },
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
-            { path: 'xml', component: EditXMLComponent }
+            { path: 'xml', component: EditXMLComponent },
+            { path: 'templates', component:  TemplatesOfTypeComponent}
+
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryRepository.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryRepository.module.ts
@@ -41,6 +41,7 @@ import { CapabilityTypeModule } from './wineryMainModules/capabilityTypes/capabi
 import { NodeTypeImplementationModule } from './wineryMainModules/nodeTypeImplementations/nodeTypeImplementation.module';
 import { RelationshipTypeImplementationModule } from './wineryMainModules/relationshipTypeImplementations/relationshipTypeImplementation.module';
 import { PolicyTemplateModule } from './wineryMainModules/policyTemplates/policyTemplate.module';
+import { TemplatesOfTypeModule } from './instance/sharedComponents/templatesOfTypes/templatesOfType.Module';
 
 @NgModule({
     imports: [
@@ -54,7 +55,7 @@ import { PolicyTemplateModule } from './wineryMainModules/policyTemplates/policy
         SectionModule,
         WineryModalModule,
         TooltipModule.forRoot(),
-
+        TemplatesOfTypeModule,
         ServiceTemplateModule,
         NodeTypeModule,
         RelationshipTypeModule,


### PR DESCRIPTION
Implements get templates of type for artifact- and policy templates

UI shows a new "Templates" tab for artifact types and policy types.
Inside this tab there is a table which lists all templates for the selected type. (similar to Nodetype implementations)

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added (for UI changes)

Screenshot:
![templatesoftype](https://user-images.githubusercontent.com/23076947/30811729-56cf69e0-a209-11e7-87db-a49882d8b4c0.PNG)

