### PR TITLE
fix highlighting of 'Other Elements' tab

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/header/header.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/header/header.component.html
@@ -41,7 +41,7 @@
         </a>
         <a class="styledTabMenuButton"
            [routerLink]="['/other']"
-           [routerLinkActive]="['selected']">
+           [class.selected]="otherActive">
             <div class="left"></div>
             <div class="center">Other Elements{{ selectedOtherComponent }}</div>
             <div class="right"></div>

--- a/org.eclipse.winery.repository.ui/src/app/header/header.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/header/header.component.ts
@@ -23,6 +23,7 @@ import { Utils } from '../wineryUtils/utils';
 export class HeaderComponent implements OnInit {
 
     selectedOtherComponent = '';
+    otherActive = true;
     @ViewChild('aboutModal') aboutModal: ModalDirective;
 
     constructor(public router: Router) {
@@ -39,7 +40,6 @@ export class HeaderComponent implements OnInit {
             if (others.includes('/')) {
                 others = others.split('/')[0];
             }
-
             if (!(others.includes(ToscaTypes.ServiceTemplate) ||
                     others.includes(ToscaTypes.NodeType) ||
                     others.includes(ToscaTypes.RelationshipType) ||
@@ -47,8 +47,10 @@ export class HeaderComponent implements OnInit {
                     others.includes('admin')
                 )
             ) {
+                this.otherActive = true;
                 this.selectedOtherComponent = ': ' + Utils.getToscaTypeNameFromToscaType(Utils.getToscaTypeFromString(others)) + 's';
             } else {
+                this.otherActive = others.includes('other');
                 this.selectedOtherComponent = '';
             }
         });


### PR DESCRIPTION
Fixes the highlighting of the "Other Elements" tab.
The tab did not stay active when navigation to sub elements of the tab. This is now fixed.