### PR TITLE
implement select boxes and radio buttons for property mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ## [unreleased]
 
 ### Changed
+- Add select boxes to select templates and target properties when adding a property mapping. Radio buttons are used to select the required template type.
 - Add grouping of Nodetypes by namespace at `Nodetype->Inheritance`. The Dropdown provides a search for the wanted Nodetype.
 - Fixed GroupByNamespace issue. Each tosca type has its own namespace state.
 - Add templates tab to policy types and artifact types. It shows the templates of the current artifact or policy type.

--- a/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
@@ -118,7 +118,7 @@ export class InstanceService {
             .map(res => res.json());
     }
 
-    private getTopologyTemplate(): Observable<WineryTopologyTemplate> {
+    public getTopologyTemplate(): Observable<WineryTopologyTemplate> {
         const headers = new Headers({'Content-Type': 'application/json'});
         const options = new RequestOptions({headers: headers});
         return this.http.get(backendBaseURL + this.path + '/topologytemplate/', options)

--- a/org.eclipse.winery.repository.ui/src/app/instance/nodeTypes/capabilityOrRequirementDefinitions/capOrReqDef.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/nodeTypes/capabilityOrRequirementDefinitions/capOrReqDef.html
@@ -59,7 +59,7 @@
                     [width]="'none'"
                     [title]="'Types'"
                     [displayList]="capabilityTypesList"
-                    [selectedResource]=""
+                    [toscaType]=""
                     [selectedValue]="capOrReqDefToBeAdded.type"
                     [showOpenButton]="false"
                     (selectedValueChanged)="onSelectedValueChanged($event.value)"

--- a/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/boundaryDefinitions/boundaryDefinitions.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/boundaryDefinitions/boundaryDefinitions.module.ts
@@ -32,6 +32,7 @@ import { EditXMLComponent } from '../../sharedComponents/editXML/editXML.compone
 import { WineryEditXMLModule } from '../../sharedComponents/editXML/editXML.module';
 import { InterfacesComponent } from '../../sharedComponents/interfaces/interfaces.component';
 import { InterfacesModule } from '../../sharedComponents/interfaces/interfaces.module';
+import { WineryQNameSelectorModule } from '../../../wineryQNameSelector/wineryQNameSelector.module';
 
 export const boundaryDefinitionsRoutes: Routes = [
     { path: 'properties', component: EditXMLComponent },
@@ -57,6 +58,7 @@ export const boundaryDefinitionsRoutes: Routes = [
         WineryTableModule,
         WineryDuplicateValidatorModule,
         WineryEditXMLModule,
+        WineryQNameSelectorModule,
         RouterModule
         // RouterModule.forChild(boundaryDefinitionsRoutes),
     ],

--- a/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/boundaryDefinitions/propertyMappings/propertyMappings.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/boundaryDefinitions/propertyMappings/propertyMappings.component.html
@@ -39,13 +39,11 @@
                                    class="form-control"
                                    type="text"
                                    required
-                                   ngModel
-                                   [value]="currentSelectedItem?.serviceTemplatePropertyRef">
+                                   [(ngModel)]="currentSelectedItem.serviceTemplatePropertyRef">
                         </div>
-                        <div class="col-xs-2">
-                            <button disabled type="button" class="btn btn-default btn-sm" >Browse</button>
-                        </div>
-                        <div style="clear:both" *ngIf="serviceTemplateProp.errors && (serviceTemplateProp.dirty || serviceTemplateProp.touched)"
+
+                        <div style="clear:both"
+                             *ngIf="serviceTemplateProp.errors && (serviceTemplateProp.dirty || serviceTemplateProp.touched)"
                              class="alert alert-danger">
                             <div [hidden]="!serviceTemplateProp.errors.required">
                                 Property name is required!
@@ -55,21 +53,43 @@
                 </div>
 
                 <div class="form-group">
-                    <label for="targetObjectRef">Target: Node Template, Requirement, Capability, or Relationship Template</label>
+                    <label for="targetObjectRef">Target: Node Template, Requirement, Capability, or Relationship
+                        Template</label>
+                    <br>
+                    <input type="radio" name="typeSelect" id="nodeTemplate" value="nodeTemplates"
+                           (change)="radioBtnSelected($event)">
+                    <label for="nodeTemplate">Node Template</label>
+                    <input type="radio" name="typeSelect" id="RequirementTemplate" value="requirementTemplates"
+                           (change)="radioBtnSelected($event)">
+                    <label for="RequirementTemplate">Requirement Template</label>
+                    <input type="radio" name="typeSelect" id="CapabilityTemplate" value="capabilityTemplates"
+                           (change)="radioBtnSelected($event)">
+                    <label for="CapabilityTemplate">Capability Tempalte</label>
+                    <input type="radio" name="typeSelect" id="RelationshipTemplate" value="relationshipTemplates"
+                           (change)="radioBtnSelected($event)">
+                    <label for="RelationshipTemplate">Relationship Template</label>
                     <div class="row">
                         <div class="col-xs-4">
+
+                            <ng-select #tempList
+                                       name="tempList"
+                                       [items]="templateList"
+                                       [(ngModel)]="templateList"
+                                       [active]="initialSelectedTempalte"
+                                       (selected)="targetObjectSelected($event)"
+                                       placeholder="no template selected">
+                            </ng-select>
+
+                            <br>
                             <input #targetObj="ngModel"
                                    name="targetObjectRef"
                                    id="targetObjectRef"
                                    class="form-control"
                                    type="text"
                                    required
-                                   ngModel
-                                   [value]="currentSelectedItem?.targetObjectRef">
+                                   [(ngModel)]="currentSelectedItem.targetObjectRef">
                         </div>
-                        <div class="col-xs-2">
-                            <button disabled type="button" class="btn btn-default btn-sm" >Browse</button>
-                        </div>
+
                         <div style="clear:both" *ngIf="targetObj.errors && (targetObj.dirty || targetObj.touched)"
                              class="alert alert-danger">
                             <div [hidden]="!targetObj.errors.required">
@@ -80,15 +100,24 @@
                 </div>
 
                 <div class="form-group">
-                    <label for="targetPropertyRef">Target Property</label>
+                    <span>Target Property</span>
+                    <ng-select *ngIf="targetProperties !== null && targetProperties.length > 0"
+                               #propertiesSelect
+                               name="propertiesSelect"
+                               [items]="targetProperties"
+                               [active]="initialSelectProp"
+                               [(ngModel)]="targetProperties"
+                               (data)="targetPropertySelected($event)"
+                               placeholder="Please select a property">
+                    </ng-select>
+                    <br>
                     <input #targetProp="ngModel"
                            name="targetPropertyRef"
                            id="targetPropertyRef"
                            class="form-control"
                            type="text"
                            required
-                           ngModel
-                           [value]="currentSelectedItem?.targetPropertyRef"/>
+                           [(ngModel)]="currentSelectedItem.targetPropertyRef">
                 </div>
                 <div style="clear:both" *ngIf="targetProp.errors && (targetProp.dirty || targetProp.touched)"
                      class="alert alert-danger">
@@ -107,24 +136,25 @@
 </winery-modal>
 
 <winery-modal bsModal #confirmDeleteModal="bs-modal" [modalRef]="confirmDeleteModal">
-     <winery-modal-header [title]="'Delete Property'">
-     </winery-modal-header>
-     <winery-modal-body>
-         <p *ngIf="currentSelectedItem != null">
-             Do you want to delete the Element
-                 <span style="font-weight:bold;">
+    <winery-modal-header [title]="'Delete Property'">
+    </winery-modal-header>
+    <winery-modal-body>
+        <p *ngIf="currentSelectedItem != null">
+            Do you want to delete the Element
+            <span style="font-weight:bold;">
                   {{ currentSelectedItem.serviceTemplatePropertyRef }}
               </span>
-             ?
-         </p>
-     </winery-modal-body>
+            ?
+        </p>
+    </winery-modal-body>
     <winery-modal-footer
-         (onOk)="removeConfirmed();"
-         [okButtonLabel]="'Yes'">
+        (onOk)="removeConfirmed();"
+        [okButtonLabel]="'Yes'">
     </winery-modal-footer>
 </winery-modal>
 
-<winery-modal bsModal #browseForServiceTemplatePropertyDiag="bs-modal" [modalRef]="browseForServiceTemplatePropertyDiag">
+<winery-modal bsModal #browseForServiceTemplatePropertyDiag="bs-modal"
+              [modalRef]="browseForServiceTemplatePropertyDiag">
     <winery-modal-header [title]="'Choose Property of Service Template'">
     </winery-modal-header>
     <winery-modal-body>
@@ -134,7 +164,7 @@
             <fieldset>
                 <div class="form-group">
                     <label for="newServiceTemplatePropertyRef">Reference to the property of the Service Template</label>
-                    <input type="text" id="newServiceTemplatePropertyRef" class="form-control" />
+                    <input type="text" id="newServiceTemplatePropertyRef" class="form-control"/>
                 </div>
             </fieldset>
         </form>

--- a/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/boundaryDefinitions/propertyMappings/propertyMappings.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/boundaryDefinitions/propertyMappings/propertyMappings.service.ts
@@ -15,8 +15,12 @@ import { Headers, Http, RequestOptions } from '@angular/http';
 import { Observable } from 'rxjs';
 import { backendBaseURL } from '../../../../configuration';
 import { ModalDirective } from 'ngx-bootstrap';
+import {
+    PropertiesDefinition,
+    PropertiesDefinitionsResourceApiData
+} from '../../../sharedComponents/propertiesDefinition/propertiesDefinitionsResourceApiData';
 
-export interface Property {
+export class Property {
     serviceTemplatePropertyRef: string;
     targetObjectRef: any;
     targetPropertyRef: string;
@@ -46,7 +50,7 @@ export class PropertyMappingService {
         const options = new RequestOptions({headers: headers});
 
         return this.http.get(backendBaseURL + this.path + '/', options)
-                   .map(res => res.json());
+            .map(res => res.json());
     }
 
     addPropertyMapping(propertyMapping: Property) {
@@ -57,7 +61,33 @@ export class PropertyMappingService {
     }
 
     removePropertyMapping(elementToDelete: string) {
-        return this.http.delete(backendBaseURL + this.path + '/' +  encodeURIComponent(encodeURIComponent(elementToDelete)));
+        return this.http.delete(backendBaseURL + this.path + '/' + encodeURIComponent(encodeURIComponent(elementToDelete)));
+    }
+
+    getPropertiesOfServiceTemplate(): Observable<string> {
+        const headers = new Headers({'Accept': 'application/xml'});
+        const options = new RequestOptions({headers: headers});
+
+        const newPath: string = this.path.replace('propertymappings', 'properties');
+
+        return this.http.get(backendBaseURL + newPath + '/', options)
+            .map(res => res.text());
+    }
+
+    getTemplatesOfType(type: string): Observable <any> {
+        const headers = new Headers({'Accept': 'application/json'});
+        const options = new RequestOptions({headers: headers});
+
+        return this.http.get(backendBaseURL + '/' + type + '/', options)
+            .map(res => res.json());
+    }
+
+    getTargetObjKVProperties(targetPath: string): Observable<PropertiesDefinitionsResourceApiData> {
+        const headers = new Headers({'Accept': 'application/json'});
+        const options = new RequestOptions({headers: headers});
+
+        return this.http.get(backendBaseURL + '/' + targetPath + '/' + 'propertiesdefinition', options)
+            .map(res => res.json());
     }
 
 }

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.component.html
@@ -9,7 +9,6 @@
  *
  * Contributors:
  *     Lukas Harzenetter - initial API and implementation
- *     Niko Stadelmaier - use ng-select for grouping and search
  */
 -->
 <div [class.hidden]="!loading">

--- a/org.eclipse.winery.repository.ui/src/app/wineryInterfaces/enums.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryInterfaces/enums.ts
@@ -30,5 +30,9 @@ export enum ToscaTypes {
     PolicyType = 'policytypes',
     PolicyTemplate = 'policytemplates',
     Imports = 'imports',
-    Admin = 'admin'
+    Admin = 'admin',
+    NodeTemplate = 'nodetemplate',
+    RelationshipTemplate = 'relationshiptemplate',
+    CapabilityTempalte = 'capabilitytemplate',
+    RequirementTemplate = 'requirementtemplate'
 }

--- a/org.eclipse.winery.repository.ui/src/app/wineryQNameSelector/wineryQNameSelector.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryQNameSelector/wineryQNameSelector.component.ts
@@ -12,6 +12,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { isNullOrUndefined } from 'util';
 import { NameAndQNameApiDataList } from './wineryNameAndQNameApiData';
+import { ToscaTypes } from '../wineryInterfaces/enums';
 
 /**
  * This component provides a selector for QNames in addition with a link to the currently
@@ -54,7 +55,7 @@ export class WineryQNameSelectorComponent implements OnInit {
 
     @Input() title: string;
     @Input() displayList: NameAndQNameApiDataList;
-    @Input() selectedResource: string;
+    @Input() toscaType: ToscaTypes;
     @Input() selectedValue: string;
     @Input() width = 600;
     @Input() showOpenButton = true;
@@ -94,7 +95,7 @@ export class WineryQNameSelectorComponent implements OnInit {
         if (parts.length > 1) {
             const namespace = parts[0].slice(1);
             const name = parts[1];
-            this.openSuperClassLink = '/' + this.selectedResource + '/' + encodeURIComponent(encodeURIComponent(namespace)) + '/' + name;
+            this.openSuperClassLink = '/' + this.toscaType + '/' + encodeURIComponent(encodeURIComponent(namespace)) + '/' + name;
         }
     }
 }

--- a/org.eclipse.winery.repository.ui/src/app/wineryUtils/utils.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryUtils/utils.ts
@@ -56,6 +56,14 @@ export class Utils {
                 return ToscaTypes.PolicyTemplate;
             case ToscaTypes.Imports:
                 return ToscaTypes.Imports;
+            case ToscaTypes.RelationshipTemplate:
+                return ToscaTypes.RelationshipTemplate;
+            case ToscaTypes.CapabilityTempalte:
+                return ToscaTypes.CapabilityTempalte;
+            case ToscaTypes.NodeTemplate:
+                return ToscaTypes.NodeTemplate;
+            case ToscaTypes.RequirementTemplate:
+                return ToscaTypes.RequirementTemplate;
             default:
                 return ToscaTypes.Admin;
         }
@@ -87,6 +95,14 @@ export class Utils {
                 return 'Policy Template';
             case ToscaTypes.Imports:
                 return 'XSD Imports';
+            case ToscaTypes.RequirementTemplate:
+                return 'Requirement Template';
+            case ToscaTypes.CapabilityTempalte:
+                return 'Capability Template';
+            case ToscaTypes.NodeTemplate:
+                return 'Node Templates';
+            case ToscaTypes.RelationshipTemplate:
+                return 'Relationship Template';
             default:
                 return 'Admin';
         }
@@ -98,6 +114,14 @@ export class Utils {
                 return ToscaTypes.ArtifactType;
             case ToscaTypes.NodeTypeImplementation:
                 return ToscaTypes.NodeType;
+            case ToscaTypes.NodeTemplate:
+                return ToscaTypes.NodeType;
+            case ToscaTypes.RelationshipTemplate:
+                return ToscaTypes.RelationshipType;
+            case ToscaTypes.CapabilityTempalte:
+                return ToscaTypes.CapabilityType;
+            case ToscaTypes.RequirementTemplate:
+                return ToscaTypes.RequirementType;
             case ToscaTypes.RelationshipTypeImplementation:
                 return ToscaTypes.RelationshipType;
             case ToscaTypes.PolicyTemplate:
@@ -116,5 +140,18 @@ export class Utils {
             case ToscaTypes.ArtifactType:
                 return ToscaTypes.ArtifactTemplate;
         }
+    }
+
+    public static getNameFromQname(qName: string) {
+        return qName.split('}').pop();
+    }
+
+    public static getNamespaceAndLocalNameFromQName(qname: string) {
+        const i = qname.indexOf('}');
+        const res = {
+            namespace: qname.substr(1, i - 1),
+            localname: qname.substr(i + 1)
+        };
+        return res;
     }
 }


### PR DESCRIPTION
Implement select boxes to select templates and target properties. Radio buttons are used to select the required template type.
The Service Template property has to be entered manually. Target template and property can be selected using the Dropdowns.
See screenshot below for UI changes:

- [ ] Change in CHANGELOG.md described
- [x] Screenshots added (for UI changes)

![addproperymapping](https://user-images.githubusercontent.com/23076947/30815297-10d66f42-a213-11e7-9617-aa83539516a7.PNG)