### PR TITLE
Fix delete dialog of node type implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ## [unreleased]
 
 ### Changed
+- Fix delete dialog message text
 - Add Git Log View to track/discard changes and create commits
 - Add select boxes to select templates and target properties when adding a property mapping. Radio buttons are used to select the required template type.
 - Add grouping of Nodetypes by namespace at `Nodetype->Inheritance`. The Dropdown provides a search for the wanted Nodetype.

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/implementations/implementations.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/implementations/implementations.component.html
@@ -76,7 +76,7 @@ to get an overview on all implementations stored in this repository. </p>
     </winery-modal-header>
     <winery-modal-body>
         <p *ngIf="elementToRemove != null" id="diagyesnomsg">
-            Do you want to delete the Element <span style="font-weight:bold;">{{ elementToRemove.localname }}</span>?
+            Do you want to delete the Element <span style="font-weight:bold;">{{ nameOfElementToRemove}}</span>?
         </p>
     </winery-modal-body>
     <winery-modal-footer (onOk)="removeConfirmed();"

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/implementations/implementations.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/implementations/implementations.component.ts
@@ -34,6 +34,7 @@ export class ImplementationsComponent implements OnInit {
     selectedCell: any;
     newImplementation: ImplementationAPIData = new ImplementationAPIData('', '');
     elementToRemove: ImplementationAPIData;
+    nameOfElementToRemove = '';
     selectedNamespace = '';
     validatorObject: WineryValidatorObject;
     columns: Array<any> = [
@@ -85,6 +86,11 @@ export class ImplementationsComponent implements OnInit {
             return;
         } else {
             this.elementToRemove = new ImplementationAPIData(data.namespace, data.localname);
+
+            const regex = /.*>(.*)<+/g;
+            const match = regex.exec(data.localname);
+            this.nameOfElementToRemove = match[1];
+
             this.confirmDeleteModal.show();
         }
     }


### PR DESCRIPTION
Signed-off-by: Philipp Meyer <meyer.github@gmail.com>

Fix delete dialog message, so that only the name of the element is shown.

![grafik](https://user-images.githubusercontent.com/23094908/30859107-8e1e57d0-a2c2-11e7-8966-073b2a7de835.png)

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Change in CHANGELOG.md described
- [x] Screenshots added (for UI changes)
