### PR TITLE
Fix popup text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ## [unreleased]
 
 ### Changed
+- Fix popup text of upload message
 - Add Git Log View to track/discard changes and create commits
 - Add select boxes to select templates and target properties when adding a property mapping. Radio buttons are used to select the required template type.
 - Add grouping of Nodetypes by namespace at `Nodetype->Inheritance`. The Dropdown provides a search for the wanted Nodetype.

--- a/org.eclipse.winery.repository.ui/src/app/wineryUploader/wineryUploader.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryUploader/wineryUploader.component.ts
@@ -106,7 +106,7 @@ export class WineryUploaderComponent implements OnInit, OnChanges {
             this.loading = false;
 
             if (status >= 200 && status <= 204) {
-                this.notify.success('Successfully saved file ' + item.file.name);
+                this.notify.success('Successfully uploaded file ' + item.file.name);
                 if (!isNullOrUndefined(this.modalRef)) {
                     this.modalRef.hide();
                 }


### PR DESCRIPTION
Signed-off-by: Philipp Meyer <meyer.github@gmail.com>

Fix popup text of upload message, so that it corresponds to the action upload.

![grafik](https://user-images.githubusercontent.com/23094908/30859332-7cb6884a-a2c3-11e7-87e8-d608f73030ae.png)

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Change in CHANGELOG.md described
- [x] Screenshots added (for UI changes)
