### PR TITLE
Fix style in wineryGitLog and set default to collapsed

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/GitWebSocket.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/GitWebSocket.java
@@ -115,8 +115,7 @@ public class GitWebSocket {
 					if (entry.getChangeType().equals(DiffEntry.ChangeType.ADD)) {
 						namePath = entry.getNewPath();
 					}
-					int nameStart = namePath.lastIndexOf('/') + 1;
-					jg.writeStringField("name", namePath.substring(nameStart));
+					jg.writeStringField("name", namePath);
 					jg.writeStringField("type", entry.getChangeType().name());
 					jg.writeStringField("path", namePath);
 					jg.writeStringField("diffs", entryList.get(entry));

--- a/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.css
+++ b/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.css
@@ -8,8 +8,10 @@
  */
 
 #wineryGitLogFloat {
+    pointer-events: none;
     position: absolute;
     right: 0px;
+    z-index: 2;
 }
 
 #wineryGitLogContainer {
@@ -23,6 +25,7 @@
 }
 
 #wineryGitLogExpander span {
+    pointer-events: painted;
     position: absolute;
     top: 30px;
     width: 91px;
@@ -32,12 +35,14 @@
 }
 
 #wineryGitLogExpander h3 {
+    pointer-events: auto;
     position: absolute;
     top: 148px;
     left: 11px;
 }
 
 #wineryGitLogDiffs {
+    pointer-events: auto;
     white-space: pre;
     overflow-wrap: normal;
     overflow-x: scroll;
@@ -45,23 +50,24 @@
 }
 
 #wineryGitLogGui {
+    pointer-events: auto;
     grid-column: 3/ span 1;
-    width: 300px;
     background-color: #f3f3f3;
 }
 
 #wineryGitLogCommit {
+    pointer-events: auto;
     grid-column: 3/ span 1;
     display: inline-grid;
     grid-template-columns: 1fr 1fr 1fr;
     margin-left: 5px;
 }
 #wineryGitLogCommitMsg {
+    pointer-events: auto;
     grid-column: 3/ span 1;
 }
 
 table {
-    width: 90%;
     margin-bottom: 20px;
     background-color: transparent;
     border-spacing: 0;
@@ -70,7 +76,6 @@ table {
 }
 
 tbody {
-    width: 90%;
     display: table-row-group;
     vertical-align: middle;
     border-color: inherit;
@@ -83,7 +88,6 @@ tr {
     border-color: inherit;
     width: 100%;
     height: 20px;
-    min-width: 300px;
 }
 
 tr:hover {
@@ -98,6 +102,7 @@ td {
     padding: 8px;
     line-height: 0;
     vertical-align: center;
+    white-space: nowrap;
 }
 
 #srcNameCell {
@@ -105,7 +110,7 @@ td {
 }
 
 #filesList {
-    width: 300px;
+    width: 318px;
     height: 500px;
     overflow: auto;
 }

--- a/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.html
@@ -19,7 +19,7 @@
             <table role="presentation">
                 <tbody class="files">
                 <div id="filesList">
-                    <tr *ngFor="let file of files" [ngClass]="{selected: file.name === selectedFile?.name}"
+                    <tr *ngFor="let file of files" [ngClass]="{selected: file == selectedFile}"
                         (click)="select(file)">
                         <td>{{file.type}}:</td>
                         <td>{{file.name}}</td>

--- a/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.ts
@@ -6,11 +6,10 @@
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
  */
-import { Component, EventEmitter, NgZone, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { GitLogApiData } from './GitLogApiData';
 import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
 import { ModalDirective } from 'ngx-bootstrap';
-import { backendBaseURL } from '../configuration';
 import { Router } from '@angular/router';
 
 @Component({
@@ -23,7 +22,7 @@ import { Router } from '@angular/router';
 export class WineryGitLogComponent implements OnInit {
 
     webSocket: WebSocket;
-    isExpanded = true;
+    isExpanded = false;
     files: GitLogApiData[] = [];
     selectedFile: GitLogApiData;
     commitMsg = '';
@@ -49,13 +48,16 @@ export class WineryGitLogComponent implements OnInit {
                 this.selectedFile = null;
             } else if (event.data === 'commit failed') {
                 this.notify.error('commit failed');
-            }else if (event.data === 'reset failed') {
+            } else if (event.data === 'reset failed') {
                 this.notify.error('winery-repository reset to last commit failed!');
-            }else if (event.data === 'reset success') {
+            } else if (event.data === 'reset success') {
                 this.notify.success('winery-repository resetted to last commit');
                 this.router.navigate(['/']);
             } else {
                 this.files = JSON.parse(event.data);
+                for (let i = 0; i < this.files.length; i++) {
+                    this.files[i].name = decodeURIComponent(decodeURIComponent(this.files[i].name));
+                }
             }
         };
 


### PR DESCRIPTION
Signed-off-by: Lukas Balzer <balzer814_dev@web.de>

Fix style to allow to allow clicks trough transparent part
Set default state of component to collapsed 
Fixed selection to only select one entry at the time

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
