### PR TITLE
Properties Definition

### DIFF
--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/ArtifactTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/ArtifactTypeResourceTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart. All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 and the Apache License 2.0 which both accompany this
+ * distribution, and are available at http://www.eclipse.org/legal/epl-v10.html and
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.eclipse.winery.repository.rest.resources.entitytypes.artifacttypes;
+
+import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
+
+import org.junit.Test;
+
+public class ArtifactTypeResourceTest extends AbstractResourceTest {
+
+	@Test
+	public void postPropertiesDefinitionFromElement() throws Exception {
+		this.setRevisionTo("85e157a2ebc512d760ce3def9fa1728ccef319b0");
+		this.assertNoContentPost("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/WAR/propertiesdefinition/",
+			"entitytypes/artifacttypes/propertiesDefinitionsElement.json");
+		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/WAR/",
+			"entitytypes/artifacttypes/war_with_properties_element.xml");
+	}
+
+	@Test
+	public void postPropertiesDefinitionFromType() throws Exception {
+		this.setRevisionTo("85e157a2ebc512d760ce3def9fa1728ccef319b0");
+		this.assertNoContentPost("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/WAR/propertiesdefinition/",
+			"entitytypes/artifacttypes/propertiesDefinitionsType.json");
+		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/WAR/",
+			"entitytypes/artifacttypes/war_with_properties_type.xml");
+	}
+
+	@Test
+	public void postPropertiesDefinitionFromCustomKeyValuePairs() throws Exception {
+		this.setRevisionTo("85e157a2ebc512d760ce3def9fa1728ccef319b0");
+		this.assertNoContentPost("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/WAR/propertiesdefinition/",
+			"entitytypes/artifacttypes/propertiesDefinitionsKV.json");
+		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/WAR/",
+			"entitytypes/artifacttypes/war_with_properties_kv.xml");
+	}
+
+	@Test
+	public void getPropertiesDefinitions() throws Exception {
+		this.setRevisionTo("5142e3f95295710778060479aac6c2099e68703c");
+		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/WAR/",
+			"entitytypes/artifacttypes/war_with_properties.xml");
+	}
+}

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/TemplatesOfOneArtifactTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/TemplatesOfOneArtifactTypeResourceTest.java
@@ -8,7 +8,6 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.artifacttypes;
 
-
 import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
 
 import org.junit.Test;
@@ -18,6 +17,7 @@ public class TemplatesOfOneArtifactTypeResourceTest extends AbstractResourceTest
 	@Test
 	public void getTemplatesOfArtifactType() throws Exception {
 		this.setRevisionTo("6aabc1c52ad74ab2692e7d59dbe22a263667e2c9");
-		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/JAR/templates/", "entitytypes/artifacttypes/templates_of_jar_artifact_type.json");
+		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/JAR/templates/",
+			"entitytypes/artifacttypes/templates_of_jar_artifact_type.json");
 	}
 }

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/propertiesDefinitionsElement.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/propertiesDefinitionsElement.json
@@ -1,0 +1,8 @@
+{
+	"propertiesDefinition": {
+		"element": "{http://opentosca.org/nodetypes}CloudProviderProperties",
+		"type": null
+	},
+	"winerysPropertiesDefinition": null,
+	"selectedValue": "Element"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/propertiesDefinitionsKV.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/propertiesDefinitionsKV.json
@@ -1,0 +1,18 @@
+{
+	"propertiesDefinition": {
+		"element": null,
+		"type": null
+	},
+	"winerysPropertiesDefinition": {
+		"namespace": "http://winery.opentosca.org/test/artifacttypes/fruits/propertiesdefinition/winery",
+		"elementName": "properties",
+		"propertyDefinitionKVList": [
+			{
+				"key": "contextPath",
+				"type": "xsd:string"
+			}
+		],
+		"isDerivedFromXSD": null
+	},
+	"selectedValue": "Custom"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/propertiesDefinitionsType.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/propertiesDefinitionsType.json
@@ -1,0 +1,8 @@
+{
+	"propertiesDefinition": {
+		"element": null,
+		"type": "{https://www.w3schools.com/xml/schema_example.asp}shipordertype"
+	},
+	"winerysPropertiesDefinition": null,
+	"selectedValue": "Type"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits" id="winery-defs-for_wfa-WAR" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12">
+	<tosca:ArtifactType name="WAR" targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits">
+		<winery:PropertiesDefinition elementname="CloudProviderProperties" winery:derivedFromXSD="true" namespace="http://opentosca.org/nodetypes">
+			<winery:properties>
+				<winery:key>APIEndpoint</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>APILoginName</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>APILoginPassword</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+		</winery:PropertiesDefinition>
+		<tosca:PropertiesDefinition element="nodetypes1:CloudProviderProperties" xmlns:nodetypes1="http://opentosca.org/nodetypes"/>
+	</tosca:ArtifactType>
+</tosca:Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_element.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_element.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits" id="winery-defs-for_wfa-WAR" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12">
+	<tosca:ArtifactType name="WAR" targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits">
+		<winery:PropertiesDefinition elementname="CloudProviderProperties" winery:derivedFromXSD="true" namespace="http://opentosca.org/nodetypes">
+			<winery:properties>
+				<winery:key>APIEndpoint</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>APILoginName</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>APILoginPassword</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+		</winery:PropertiesDefinition>
+		<tosca:PropertiesDefinition element="nodetypes:CloudProviderProperties" xmlns:nodetypes="http://opentosca.org/nodetypes"/>
+	</tosca:ArtifactType>
+</tosca:Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_kv.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_kv.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" id="winery-defs-for_wfa-WAR" targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits">
+	<tosca:Import importType="http://www.w3.org/2001/XMLSchema" location="http://localhost:9080/winery/artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/WAR/propertiesdefinition/xsd" namespace="http://winery.opentosca.org/test/artifacttypes/fruits/propertiesdefinition/winery" winery:wpd="true"/>
+	<tosca:ArtifactType name="WAR" targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits">
+		<winery:PropertiesDefinition elementname="properties" namespace="http://winery.opentosca.org/test/artifacttypes/fruits/propertiesdefinition/winery">
+			<winery:properties>
+				<winery:key>contextPath</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+		</winery:PropertiesDefinition>
+		<tosca:PropertiesDefinition xmlns:winery2="http://winery.opentosca.org/test/artifacttypes/fruits/propertiesdefinition/winery" type="winery2:properties"/>
+	</tosca:ArtifactType>
+</tosca:Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_type.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits" id="winery-defs-for_wfa-WAR" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12">
+	<tosca:ArtifactType name="WAR" targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12">
+		<tosca:PropertiesDefinition xmlns:schemaexampleasp="https://www.w3schools.com/xml/schema_example.asp" type="schemaexampleasp:shipordertype"/>
+	</tosca:ArtifactType>
+</tosca:Definitions>

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
@@ -6,9 +6,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter, Niko Stadelmaier - initial API and implementation
  */
 -->
 <div class="localLoader" [class.hidden]="!loading">

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
@@ -5,18 +5,12 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter, Niko Stadelmaier - initial API and implementation
  */
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { InstanceService } from '../../instance.service';
 import { PropertiesDefinitionService } from './propertiesDefinition.service';
 import {
-    PropertiesDefinition,
-    PropertiesDefinitionEnum,
-    PropertiesDefinitionKVList,
-    PropertiesDefinitionsResourceApiData,
+    PropertiesDefinition, PropertiesDefinitionEnum, PropertiesDefinitionKVElement, PropertiesDefinitionsResourceApiData,
     WinerysPropertiesDefinition
 } from './propertiesDefinitionsResourceApiData';
 import { SelectData } from '../../../wineryInterfaces/selectData';
@@ -24,8 +18,9 @@ import { isNullOrUndefined } from 'util';
 import { Response } from '@angular/http';
 import { WineryNotificationService } from '../../../wineryNotificationModule/wineryNotification.service';
 import { WineryValidatorObject } from '../../../wineryValidators/wineryDuplicateValidator.directive';
-import { WineryTableColumn } from '../../../wineryTableModule/wineryTable.component';
+import { WineryRowData, WineryTableColumn } from '../../../wineryTableModule/wineryTable.component';
 import { ModalDirective } from 'ngx-bootstrap';
+import { BreakException } from '../../../wineryUtils/breakException';
 
 @Component({
     templateUrl: 'propertiesDefinition.component.html',
@@ -43,14 +38,14 @@ export class PropertiesDefinitionComponent implements OnInit {
 
     resourceApiData: PropertiesDefinitionsResourceApiData;
     selectItems: SelectData[];
-    activeElement: SelectData;
-    selectedCell: any;
+    activeElement = new SelectData();
+    selectedCell: WineryRowData;
     elementToRemove: any = null;
     columns: Array<WineryTableColumn> = [
-        {title: 'Name', name: 'key', sort: true},
-        {title: 'Type', name: 'type', sort: true},
+        { title: 'Name', name: 'key', sort: true },
+        { title: 'Type', name: 'type', sort: true },
     ];
-    newProperty: PropertiesDefinitionKVList = new PropertiesDefinitionKVList();
+    newProperty: PropertiesDefinitionKVElement = new PropertiesDefinitionKVElement();
 
     validatorObject: WineryValidatorObject;
     @ViewChild('confirmDeleteModal') confirmDeleteModal: ModalDirective;
@@ -82,11 +77,6 @@ export class PropertiesDefinitionComponent implements OnInit {
      */
     onXmlElementSelected(): void {
         this.resourceApiData.selectedValue = PropertiesDefinitionEnum.Element;
-        this.service.getXsdElementDefinitions()
-            .subscribe(
-                data => this.selectItems = data,
-                error => this.handleError(error)
-            );
 
         if (isNullOrUndefined(this.resourceApiData.propertiesDefinition)) {
             this.resourceApiData.propertiesDefinition = new PropertiesDefinition();
@@ -95,8 +85,11 @@ export class PropertiesDefinitionComponent implements OnInit {
         this.resourceApiData.propertiesDefinition.type = null;
         this.resourceApiData.winerysPropertiesDefinition = null;
 
-        this.activeElement = new SelectData();
-        this.activeElement.text = this.resourceApiData.propertiesDefinition.element;
+        this.service.getXsdElementDefinitions()
+            .subscribe(
+                data => this.handleSelectData(data, false),
+                error => this.handleError(error)
+            );
     }
 
     /**
@@ -105,11 +98,6 @@ export class PropertiesDefinitionComponent implements OnInit {
      */
     onXmlTypeSelected(): void {
         this.resourceApiData.selectedValue = PropertiesDefinitionEnum.Type;
-        this.service.getXsdTypeDefinitions()
-            .subscribe(
-                data => this.selectItems = data,
-                error => this.handleError(error)
-            );
 
         if (isNullOrUndefined(this.resourceApiData.propertiesDefinition)) {
             this.resourceApiData.propertiesDefinition = new PropertiesDefinition();
@@ -118,8 +106,11 @@ export class PropertiesDefinitionComponent implements OnInit {
         this.resourceApiData.propertiesDefinition.element = null;
         this.resourceApiData.winerysPropertiesDefinition = null;
 
-        this.activeElement = new SelectData();
-        this.activeElement.text = this.resourceApiData.propertiesDefinition.type;
+        this.service.getXsdTypeDefinitions()
+            .subscribe(
+                data => this.handleSelectData(data, true),
+                error => this.handleError(error)
+            );
     }
 
     /**
@@ -184,7 +175,7 @@ export class PropertiesDefinitionComponent implements OnInit {
      * handler for clicks on remove button
      * @param data
      */
-    onRemoveClick(data: any) {
+    onRemoveClick(data: PropertiesDefinitionKVElement) {
         if (isNullOrUndefined(data)) {
             return;
         } else {
@@ -197,7 +188,7 @@ export class PropertiesDefinitionComponent implements OnInit {
      * handler for clicks on the add button
      */
     onAddClick() {
-        this.newProperty = new PropertiesDefinitionKVList();
+        this.newProperty = new PropertiesDefinitionKVElement();
         this.validatorObject = new WineryValidatorObject(this.resourceApiData.winerysPropertiesDefinition.propertyDefinitionKVList, 'key');
         this.addModal.show();
     }
@@ -210,13 +201,13 @@ export class PropertiesDefinitionComponent implements OnInit {
      */
     xmlValueSelected(event: SelectData): void {
         if (this.resourceApiData.selectedValue === PropertiesDefinitionEnum.Element) {
-            this.resourceApiData.propertiesDefinition.element = event.text;
+            this.resourceApiData.propertiesDefinition.element = event.id;
         } else if (this.resourceApiData.selectedValue === PropertiesDefinitionEnum.Type) {
-            this.resourceApiData.propertiesDefinition.type = event.text;
+            this.resourceApiData.propertiesDefinition.type = event.id;
         }
     }
 
-    onCellSelected(data: any) {
+    onCellSelected(data: WineryRowData) {
         if (isNullOrUndefined(data)) {
             this.selectedCell = data;
         }
@@ -256,6 +247,33 @@ export class PropertiesDefinitionComponent implements OnInit {
             );
     }
 
+    private handleSelectData(data: SelectData[], isType: boolean) {
+        this.selectItems = data;
+
+        try {
+            this.selectItems.forEach(nsList => {
+                this.activeElement = nsList.children.find(item => {
+                    if (isType) {
+                        return item.id === this.resourceApiData.propertiesDefinition.type;
+                    }
+                    return item.id === this.resourceApiData.propertiesDefinition.element;
+                });
+
+                if (!isNullOrUndefined(this.activeElement)) {
+                    throw new BreakException();
+                }
+            });
+        } catch (e) {
+            if (e ! instanceof BreakException) {
+                throw e;
+            }
+        }
+
+        if (isNullOrUndefined(this.activeElement)) {
+            this.activeElement = new SelectData();
+        }
+    }
+
     /**
      * Set loading to false and show success notification.
      *
@@ -291,13 +309,13 @@ export class PropertiesDefinitionComponent implements OnInit {
 
         // because the selectedValue doesn't get set correctly do it here
         switch (isNullOrUndefined(this.resourceApiData.selectedValue) ? '' : this.resourceApiData.selectedValue.toString()) {
-            case 'Element':
+            case PropertiesDefinitionEnum.Element:
                 this.onXmlElementSelected();
                 break;
-            case 'Type':
+            case PropertiesDefinitionEnum.Type:
                 this.onXmlTypeSelected();
                 break;
-            case 'Custom':
+            case PropertiesDefinitionEnum.Custom:
                 this.onCustomKeyValuePairSelected();
                 break;
             default:

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinitionsResourceApiData.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinitionsResourceApiData.ts
@@ -17,7 +17,7 @@ export enum PropertiesDefinitionEnum {
     None = 'None'
 }
 
-export class PropertiesDefinitionKVList {
+export class PropertiesDefinitionKVElement {
     key: string = null;
     type: string = null;
 }
@@ -30,7 +30,7 @@ export class PropertiesDefinition {
 export class WinerysPropertiesDefinition {
     namespace: string = null;
     elementName: string = null;
-    propertyDefinitionKVList: PropertiesDefinitionKVList[] = [];
+    propertyDefinitionKVList: PropertiesDefinitionKVElement[] = [];
     isDerivedFromXSD = false;
 }
 

--- a/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.ts
@@ -23,7 +23,7 @@ import { Router } from '@angular/router';
 export class WineryGitLogComponent implements OnInit {
 
     webSocket: WebSocket;
-    isExpanded = true;
+    isExpanded = false;
     files: GitLogApiData[] = [];
     selectedFile: GitLogApiData;
     commitMsg = '';

--- a/org.eclipse.winery.repository.ui/src/app/wineryQNameSelector/wineryQNameSelector.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryQNameSelector/wineryQNameSelector.component.ts
@@ -5,9 +5,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter - initial API and implementation
  */
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { isNullOrUndefined } from 'util';

--- a/org.eclipse.winery.repository.ui/src/app/wineryUtils/breakException.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryUtils/breakException.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v10.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+export class BreakException extends Error {
+
+}


### PR DESCRIPTION
The properties definitions component sends now the QName to the backend. This fixes missing prefixes in the `<tosca:propertiesDefinition element=""/>` and `<tosca:propertiesDefinition type=""/>`

Signed-off-by: Lukas Harzenetter <lharzenetter@gmx.de>