### PR TITLE
Zip4artifactfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ## [unreleased]
 
 ### Changed
+- Add ZIP-button for artifactemplate-files
 - Fix delete dialog message text
 - Fix popup text of upload message
 - Add Git Log View to track/discard changes and create commits

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/RestUtils.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/RestUtils.java
@@ -231,9 +231,22 @@ public class RestUtils {
 	}
 
 	/**
-	 * Zipps the folder reference given by the id. As filename the parent id is used.
+	 * Zips the folder reference given by the id. As filename the parent id is used.
+	 *
+	 * @param id the id of the folder
 	 */
 	public static Response getZippedContents(final GenericId id) {
+		final String name = id.getParent().getXmlId().getEncoded();
+		return getZippedContents(id, name + Constants.SUFFIX_ZIP);
+	}
+
+	/**
+	 * Zips the folder reference given by the id. As filename the parent id is used.
+	 *
+	 * @param id   the id of the folder
+	 * @param name the name of the result zip (including.zip)
+	 */
+	public static Response getZippedContents(final GenericId id, String name) {
 		StreamingOutput so = output -> {
 			try {
 				RepositoryFactory.getRepository().getZippedContents(id, output);
@@ -243,8 +256,7 @@ public class RestUtils {
 		};
 		StringBuilder sb = new StringBuilder();
 		sb.append("attachment;filename=\"");
-		sb.append(id.getParent().getXmlId().getEncoded());
-		sb.append(Constants.SUFFIX_ZIP);
+		sb.append(name);
 		sb.append("\"");
 		return Response.ok().header("Content-Disposition", sb.toString()).type(MimeTypes.MIMETYPE_ZIP).entity(so).build();
 	}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/ArtifactTemplateResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/ArtifactTemplateResource.java
@@ -92,6 +92,14 @@ public class ArtifactTemplateResource extends AbstractComponentInstanceWithRefer
 		return new FilesResource(fileDir);
 	}
 
+	@GET
+	@Path("files/zip")
+	@Produces(MimeTypes.MIMETYPE_ZIP)
+	public Response getFilesDefinitionsAsResponse() {
+		ArtifactTemplateDirectoryId fileDir = new ArtifactTemplateFilesDirectoryId((ArtifactTemplateId) this.id);
+		return RestUtils.getZippedContents(fileDir);
+	}
+
 	@Path("source/")
 	public FilesResource getSrcResource() {
 		ArtifactTemplateDirectoryId fileDir = new ArtifactTemplateSourceDirectoryId((ArtifactTemplateId) this.id);
@@ -101,9 +109,9 @@ public class ArtifactTemplateResource extends AbstractComponentInstanceWithRefer
 	@GET
 	@Path("source/zip")
 	@Produces(MimeTypes.MIMETYPE_ZIP)
-	public Response getDefinitionsAsResponse() {
+	public Response getSourceDefinitionsAsResponse() {
 		ArtifactTemplateDirectoryId fileDir = new ArtifactTemplateSourceDirectoryId((ArtifactTemplateId) this.id);
-		return RestUtils.getZippedContents(fileDir);
+		return RestUtils.getZippedContents(fileDir, fileDir.getParent().getXmlId().getEncoded() + "-source.zip");
 	}
 
 	@Override

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/ArtifactTemplateResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/ArtifactTemplateResourceTest.java
@@ -5,10 +5,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- * 	   Oliver Kopp - initial API and implementation
- *     Philipp Meyer - support for source directory
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytemplates.artifacttemplates;
 
@@ -20,6 +16,12 @@ import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.junit.Test;
 
 public class ArtifactTemplateResourceTest extends AbstractResourceTest {
+
+	@Test
+	public void getFilesZip() throws Exception {
+		this.setRevisionTo("88e5ccd6c35aeffdebc19c8dda9cd76f432538f8");
+		this.assertGet("artifacttemplates/http%253A%252F%252Fopentosca.org%252Fartifacttemplates/MyTinyTest/files/zip", "entitytemplates/artifacttemplates/MyTinyTest_src.zip");
+	}
 
 	@Test
 	public void getSourceZip() throws Exception {

--- a/org.eclipse.winery.repository.ui/src/app/instance/artifactTemplates/filesTag/files.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/artifactTemplates/filesTag/files.component.html
@@ -11,6 +11,12 @@
  *     Lukas Harzenetter - initial API and implementation
  */
 -->
+<div class="right">
+    <a href="{{filesPath}}">
+        <button class="btn btn-primary" name="zip">ZIP</button>
+    </a>
+</div>
+
 <div>
     <winery-uploader (onSuccess)="loadFiles()" [uploadUrl]="uploadUrl" [allowMultipleFiles]="true">
     </winery-uploader>

--- a/org.eclipse.winery.repository.ui/src/app/instance/artifactTemplates/filesTag/files.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/artifactTemplates/filesTag/files.component.ts
@@ -12,7 +12,8 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { FilesApiData, FilesService } from './files.service.';
 import { WineryNotificationService } from '../../../wineryNotificationModule/wineryNotification.service';
-import { hostURL } from '../../../configuration';
+import { backendBaseURL, hostURL } from '../../../configuration';
+import { InstanceService } from '../../instance.service';
 
 @Component({
     templateUrl: 'files.component.html',
@@ -29,11 +30,13 @@ export class FilesComponent implements OnInit {
     uploadUrl: string;
     filesList: FilesApiData[];
     baseUrl = hostURL;
+    filesPath: string;
 
     @ViewChild('removeElementModal') removeElementModal: any;
     fileToRemove: FilesApiData;
 
-    constructor(private service: FilesService, private notify: WineryNotificationService) {
+    constructor(private service: FilesService, private sharedData: InstanceService, private notify: WineryNotificationService) {
+        this.filesPath = backendBaseURL + this.sharedData.path + '/files/zip';
     }
 
     ngOnInit() {


### PR DESCRIPTION
Signed-off-by: Philipp Meyer <meyer.github@gmail.com>

Add ZIP button for files directory of artifact templates.
Change name of source-ZIP to [template-Name]-source.zip

![grafik](https://user-images.githubusercontent.com/23094908/30957177-cb1a2da8-a439-11e7-8836-6efe8cfa8c43.png)


- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added (for UI changes)
