### PR TITLE
Add markdown parser module and reamdme component for each tosca compo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ## [unreleased]
 
 ### Changed
-- Add ZIP-button for artifactemplate-files
+- Add ZIP-button for artifacttemplate-files
+- Add license and readme support for all components
 - Fix delete dialog message text
 - Fix popup text of upload message
 - Add Git Log View to track/discard changes and create commits

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/AbstractComponentInstanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/AbstractComponentInstanceResource.java
@@ -45,6 +45,7 @@ import javax.xml.parsers.DocumentBuilder;
 
 import org.eclipse.winery.common.RepositoryFileReference;
 import org.eclipse.winery.common.ToscaDocumentBuilderFactory;
+import org.eclipse.winery.common.Util;
 import org.eclipse.winery.common.constants.MimeTypes;
 import org.eclipse.winery.common.ids.Namespace;
 import org.eclipse.winery.common.ids.XmlId;
@@ -516,4 +517,37 @@ public abstract class AbstractComponentInstanceResource implements Comparable<Ab
 
 		return new TagsResource(this, tags.getTag());
 	}
+
+	@GET
+	@Path("LICENSE")
+	@Produces(MediaType.TEXT_PLAIN)
+	public Response getLicense() {
+		RepositoryFileReference ref = new RepositoryFileReference(this.id, Util.URLdecode("LICENSE"));
+		return RestUtils.returnRepoPath(ref, null);
+	}
+
+	@PUT
+	@Path("LICENSE")
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response putLicense(String data) {
+		RepositoryFileReference ref = new RepositoryFileReference(this.id, Util.URLdecode("LICENSE"));
+		return RestUtils.putContentToFile(ref, data, MediaType.TEXT_PLAIN_TYPE);
+	}
+
+	@GET
+	@Path("README.md")
+	@Produces(MediaType.TEXT_PLAIN)
+	public Response getReadme() {
+		RepositoryFileReference ref = new RepositoryFileReference(this.id, Util.URLdecode("README.md"));
+		return RestUtils.returnRepoPath(ref, null);
+	}
+
+	@PUT
+	@Path("README.md")
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response putFile(String data) {
+		RepositoryFileReference ref = new RepositoryFileReference(this.id, Util.URLdecode("README.md"));
+		return RestUtils.putContentToFile(ref, data, MediaType.TEXT_PLAIN_TYPE);
+	}
 }
+

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/FilesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/FilesResource.java
@@ -22,6 +22,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -142,6 +143,17 @@ public class FilesResource {
 	@Path("/{fileName}")
 	@Consumes(MediaType.APPLICATION_JSON)
 	public Response postFile(@PathParam("fileName") String fileName, ArtifactResourceApiData data) {
+		if (StringUtils.isEmpty(fileName)) {
+			return Response.status(Status.BAD_REQUEST).build();
+		}
+		RepositoryFileReference ref = this.fileName2fileRef(fileName, false);
+		return RestUtils.putContentToFile(ref, data.content, MediaType.TEXT_PLAIN_TYPE);
+	}
+
+	@PUT
+	@Path("/{fileName}")
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response putFile(@PathParam("fileName") String fileName, ArtifactResourceApiData data) {
 		if (StringUtils.isEmpty(fileName)) {
 			return Response.status(Status.BAD_REQUEST).build();
 		}

--- a/org.eclipse.winery.repository.ui/src/app/instance/instance.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instance.module.ts
@@ -20,7 +20,6 @@ import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { PropertyRenameComponent } from './instanceHeader/propertyRename/propertyRename.component';
 import { FormsModule } from '@angular/forms';
-import { WineryDuplicateValidatorModule } from '../wineryValidators/wineryDuplicateValidator.module';
 
 @NgModule({
     imports: [

--- a/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
@@ -35,42 +35,42 @@ export class InstanceService {
 
         switch (this.toscaComponent.toscaType) {
             case ToscaTypes.NodeType:
-                subMenu = ['Visual Appearance', 'Instance States', 'Interfaces', 'Implementations',
+                subMenu = ['README', 'LICENSE', 'Visual Appearance', 'Instance States', 'Interfaces', 'Implementations',
                     'Requirement Definitions', 'Capability Definitions', 'Properties Definition',
                     'Inheritance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.ServiceTemplate:
-                subMenu = ['Topology Template', 'Plans', 'Selfservice Portal',
+                subMenu = ['README', 'LICENSE', 'Topology Template', 'Plans', 'Selfservice Portal',
                     'Boundary Definitions', 'Tags', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.RelationshipType:
-                subMenu = ['Visual Appearance', 'Instance States', 'Source Interfaces', 'Target Interfaces',
+                subMenu = ['README', 'LICENSE', 'Visual Appearance', 'Instance States', 'Source Interfaces', 'Target Interfaces',
                     'Valid Sources and Targets', 'Implementations', 'Properties Definition',
                     'Inheritance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.ArtifactType:
-                subMenu = ['Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.ArtifactTemplate:
-                subMenu = ['Files', 'Source', 'Properties', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Files', 'Source', 'Properties', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.RequirementType:
-                subMenu = ['Required Capability Type', 'Properties Definition', 'Inheritance', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Required Capability Type', 'Properties Definition', 'Inheritance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.CapabilityType:
-                subMenu = ['Properties Definition', 'Inheritance', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Properties Definition', 'Inheritance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.NodeTypeImplementation:
-                subMenu = ['Implementation Artifacts', 'Deployment Artifacts', 'Inheritance', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Implementation Artifacts', 'Deployment Artifacts', 'Inheritance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.RelationshipTypeImplementation:
-                subMenu = ['Implementation Artifacts', 'Inheritance', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Implementation Artifacts', 'Inheritance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.PolicyType:
-                subMenu = ['Language', 'Applies To', 'Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Language', 'Applies To', 'Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.PolicyTemplate:
-                subMenu = ['Properties', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Properties', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.Imports:
                 subMenu = ['All Declared Elements Local Names', 'All Defined Types Local Names'];

--- a/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/boundaryDefinitions/propertyMappings/propertyMappings.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/boundaryDefinitions/propertyMappings/propertyMappings.component.ts
@@ -62,10 +62,10 @@ export class PropertyMappingsComponent implements OnInit {
     ngOnInit() {
         this.getMappings();
         this.getProperties();
-        this.getTopologyTempalte();
+        this.getTopologyTemplate();
     }
 
-    getTopologyTempalte() {
+    getTopologyTemplate() {
         this.instanceService.getTopologyTemplate().subscribe(
             data => this.topologyTemplate = data,
             error => this.notify.error('could not get topology data')

--- a/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.component.css
+++ b/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.component.css
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+.flash{
+    background-color: #dbedff;
+    padding: 16px;
+    display: inline-block;
+    border: 1px solid rgba(27,31,35,0.15);
+    border-radius: 3px;
+    font-size: larger;
+}
+
+.flash-action {
+    background-image: linear-gradient(#79d858, #569e3d);
+    border-color: #569e3d;
+}
+
+.license-label {
+    font-size: 13px;
+    font-weight: bold;
+    line-height: 20px;
+    color: #333;
+    white-space: nowrap;
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.component.html
@@ -1,0 +1,52 @@
+<!--
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+-->
+<div *ngIf="!licenseAvailable">
+    <div class="flash">
+        This {{ toscaType | toscaTypeToReadableName }} has no license.
+        <button class="btn btn-sm btn-primary flash-action" (click)="licenseAvailable=true;isEditable=true;">Add a
+            LICENSE
+        </button>
+    </div>
+</div>
+
+<div *ngIf="!isEditable && licenseAvailable">
+    <div class="right" style="width: 100%; margin-bottom: 11px; ">
+        <button class="btn fa fa-pencil" aria-hidden="true" name="edit" style="float: right;"
+                (click)="isEditable = true;"></button>
+    </div>
+    <textarea readonly tabIndex="-1" style="width: 95%;height: 500px; resize: none;">{{licenseText}}</textarea>
+</div>
+
+<div *ngIf="isEditable">
+    <div class="btn-group" dropdown style="margin-bottom: 2px;">
+        <button type="button" class="btn btn-default" >Choose a license: <span class="license-label">{{licenseType
+            }}</span></button>
+        <button type="button" dropdownToggle class="btn btn-default dropdown-toggle dropdown-toggle-split">
+            <span class="caret"></span>
+            <span class="sr-only">Split button!</span>
+        </button>
+        <ul *dropdownMenu class="dropdown-menu" role="menu">
+            <li *ngFor="let item of options" role="presentation">
+                <button role="menuitem" class=" btn btn-link dropdown-item" (click)="dropdownAction(item)">{{ item }}</button>
+            </li>
+        </ul>
+    </div>
+
+    <div class="right">
+        <button class="btn fa fa-floppy-o" aria-hidden="true" name="save" (click)="saveLicenseFile()"> Save</button>
+        <button class="btn fa fa-ban" name="cancel" aria-hidden="true" (click)="cancelEdit()"> Cancel</button>
+    </div>
+    <textarea style="width: 95%; height: 500px; resize: none; font-family: monospace" [(ngModel)]="licenseText"></textarea>
+
+</div>
+
+
+

--- a/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.component.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { Component, OnInit } from '@angular/core';
+import { WineryLicenseService } from './wineryLicense.service';
+import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
+import { InstanceService } from '../instance/instance.service';
+import { ToscaTypes } from '../wineryInterfaces/enums';
+import { LicenseEnum, WineryLicense } from './wineryLicense.enum';
+
+@Component({
+    templateUrl: 'wineryLicense.component.html',
+    styleUrls: ['wineryLicense.component.css'],
+    providers: [WineryLicenseService]
+})
+
+export class WineryLicenseComponent implements OnInit {
+
+    licenseText = '';
+    intialLicenseText = '';
+    licenseAvailable = true;
+    licenseType = '';
+
+    loading = true;
+    options: any;
+    isEditable = false;
+
+    toscaType: ToscaTypes;
+
+    constructor(private service: WineryLicenseService, private notify: WineryNotificationService, private sharedData: InstanceService) {
+        this.toscaType = this.sharedData.toscaComponent.toscaType;
+        this.options = Object.keys(LicenseEnum).map(key => LicenseEnum[key]);
+    }
+
+    ngOnInit() {
+        this.service.getData().subscribe(
+            data => {
+                this.licenseText = data;
+                this.intialLicenseText = data;
+            },
+            error => this.handleMissingLicense()
+        );
+    }
+
+    saveLicenseFile() {
+        this.service.save(this.licenseText).subscribe(
+            data => this.handleSave(),
+            error => this.handleError(error)
+        );
+    }
+
+    dropdownAction(item: string) {
+        this.licenseType = item;
+        this.licenseText = WineryLicense.getLicense(this.licenseType);
+    }
+
+    cancelEdit() {
+        this.licenseText = this.intialLicenseText;
+        this.isEditable = false;
+    }
+
+    private handleError(error: any) {
+        this.loading = false;
+        this.notify.error(error);
+    }
+
+    private handleMissingLicense() {
+        this.loading = false;
+        this.licenseAvailable = false;
+    }
+
+    private handleSave() {
+        this.notify.success('Successfully saved LICENSE');
+    }
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.enum.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.enum.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+export enum LicenseEnum {
+    None      = 'None',
+    APL2      = 'Apache License 2.0',
+    GPL3      = 'GNU General Public License v3.0',
+    MIT       = 'MIT License',
+    BSD2      = 'BSD 2-clause "Simplified" License',
+    BSD3      = 'BSD 3-clause "New" or "Revised" License',
+    EPL1      = 'Eclipse Public License 1.0',
+    EPL2      = 'Eclipse Public License 2.0',
+    AGPL3     = 'GNU Affero General Public License v3.0',
+    GPL2      = 'GNU General Public License v2.0',
+    LGPL21    = 'GNU Lesser General Public License v2.1',
+    LGPL3     = 'GNU Lesser General Public License v3.0',
+    MPL2      = 'Mozilla Public License 2.0',
+    Unlicense = 'The Unlicense',
+}
+
+export class WineryLicense {
+
+    public static getLicense(license: any) {
+        let licenseText = '';
+
+        switch (license) {
+            case LicenseEnum.None:
+                licenseText = '';
+                break;
+            case LicenseEnum.APL2:
+                licenseText = 'SPDX:Apache-2.0';
+                break;
+            case LicenseEnum.GPL3:
+                licenseText = 'SPDX:GPL-3.0';
+                break;
+            case LicenseEnum.MIT:
+                licenseText = 'SPDX:MIT';
+                break;
+            case LicenseEnum.BSD2:
+                licenseText = 'SPDX:BSD-2-Clause';
+                break;
+            case LicenseEnum.BSD3:
+                licenseText = 'SPDX:BSD-3-Clause';
+                break;
+            case LicenseEnum.EPL1:
+                licenseText = 'SPDX:EPL-1.0';
+                break;
+            case LicenseEnum.EPL2:
+                licenseText = 'SPDX:EPL-2.0';
+                break;
+            case LicenseEnum.AGPL3:
+                licenseText = 'SPDX:AGPL-3.0';
+                break;
+            case LicenseEnum.GPL2:
+                licenseText = 'SPDX:GPL-2.0';
+                break;
+            case LicenseEnum.LGPL21:
+                licenseText = 'SPDX:LGPL-2.1';
+                break;
+            case LicenseEnum.LGPL3:
+                licenseText = 'SPDX:LGPL-3.0';
+                break;
+            case LicenseEnum.MPL2:
+                licenseText = 'SPDX:MPL-2.0';
+                break;
+            case LicenseEnum.Unlicense:
+                licenseText = 'SPDX:Unlicense';
+                break;
+            default:
+                licenseText = 'error no valid license type';
+                break;
+        }
+        return licenseText;
+    }
+
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.module.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { WineryLicenseComponent } from './wineryLicense.component';
+import { WineryPipesModule } from '../wineryPipes/wineryPipes.module';
+import { CommonModule } from '@angular/common';
+import { BrowserModule } from '@angular/platform-browser';
+import { BsDropdownModule } from 'ngx-bootstrap';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        FormsModule,
+        BrowserModule,
+        WineryPipesModule,
+        BsDropdownModule.forRoot()
+    ],
+    exports: [
+        WineryLicenseComponent
+    ],
+    declarations: [WineryLicenseComponent],
+    providers: [],
+})
+export class WineryLicenseModule {
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryLicenseModule/wineryLicense.service.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { Injectable } from '@angular/core';
+import { Headers, Http, RequestOptions } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import { InstanceService } from '../instance/instance.service';
+import { backendBaseURL } from '../configuration';
+
+@Injectable()
+export class WineryLicenseService {
+
+    constructor(private http: Http,
+                private sharedData: InstanceService) {
+    }
+
+    getData(): Observable<string> {
+        const headers = new Headers({ 'Accept': 'text/plain' });
+        const options = new RequestOptions({ headers: headers });
+        return this.http.get(backendBaseURL + this.sharedData.path + '/LICENSE', options)
+            .map(res => res.text());
+    }
+
+    save(licenseFile: String) {
+        const headers = new Headers({ 'Content-Type': 'application/json' });
+        const options = new RequestOptions({ headers: headers });
+
+        return this.http.put(backendBaseURL + this.sharedData.path + '/LICENSE', licenseFile, options)
+            .map(res => res.json());
+    }
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artictTemplates/artifactTemplate.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artictTemplates/artifactTemplate.module.ts
@@ -21,6 +21,8 @@ import { ArtifactSourceComponent } from '../../instance/artifactTemplates/artifa
 import { TabsModule } from 'ngx-bootstrap';
 import { WineryEditorModule } from '../../wineryEditorModule/wineryEditor.module';
 import { WineryDuplicateValidatorModule } from '../../wineryValidators/wineryDuplicateValidator.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
@@ -35,6 +37,8 @@ import { WineryDuplicateValidatorModule } from '../../wineryValidators/wineryDup
         WineryEditorModule,
         WineryDuplicateValidatorModule,
         ArtifactTemplateRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ],
     declarations: [
         FilesComponent,

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artictTemplates/artifactTemplateRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artictTemplates/artifactTemplateRouter.module.ts
@@ -18,6 +18,8 @@ import { ToscaTypes } from '../../wineryInterfaces/enums';
 import { PropertiesComponent } from '../../instance/sharedComponents/properties/properties.component';
 import { FilesComponent } from '../../instance/artifactTemplates/filesTag/files.component';
 import { ArtifactSourceComponent } from '../../instance/artifactTemplates/artifactSource/artifactSource.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.ArtifactTemplate;
 
@@ -29,6 +31,8 @@ const artifactTemplateRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'files', component: FilesComponent },
             { path: 'source', component: ArtifactSourceComponent },
             { path: 'properties', component: PropertiesComponent },

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artifactTypes/artifactType.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artifactTypes/artifactType.module.ts
@@ -12,11 +12,15 @@
 import { NgModule } from '@angular/core';
 import { ArtifactTypeRouterModule } from './artifactTypeRouter.module';
 import { CommonModule } from '@angular/common';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
 
 @NgModule({
     imports: [
         CommonModule,
         ArtifactTypeRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ],
 })
 export class ArtifactTypeModule {

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artifactTypes/artifactTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artifactTypes/artifactTypeRouter.module.ts
@@ -21,6 +21,8 @@ import { ToscaTypes } from '../../wineryInterfaces/enums';
 import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
 import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
 import { TemplatesOfTypeComponent } from '../../instance/sharedComponents/templatesOfTypes/templatesOfTypes.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.ArtifactType;
 
@@ -32,6 +34,8 @@ const artifactTypeRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent},
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'propertiesdefinition', component: PropertiesDefinitionComponent },
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/capabilityTypes/capabilityType.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/capabilityTypes/capabilityType.module.ts
@@ -12,11 +12,15 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CapabilityTypeRouterModule } from './capabilityTypeRouter.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
         CommonModule,
-        CapabilityTypeRouterModule
+        CapabilityTypeRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ],
 })
 export class CapabilityTypeModule {

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/capabilityTypes/capabilityTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/capabilityTypes/capabilityTypeRouter.module.ts
@@ -31,7 +31,8 @@ import { DocumentationComponent } from '../../instance/sharedComponents/document
 import { ToscaTypes } from '../../wineryInterfaces/enums';
 import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
 import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
-import { RequiredCapabilityTypeComponent } from '../../instance/requirementTypes/requiredCapabilityType/requiredCapabilityType.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.CapabilityType;
 
@@ -43,11 +44,13 @@ const capabilityTypeRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'propertiesdefinition', component: PropertiesDefinitionComponent },
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'propertiesdefinition', pathMatch: 'full'}
+            { path: '', redirectTo: 'propertiesdefinition', pathMatch: 'full' }
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypeImplementations/nodeTypeImplementation.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypeImplementations/nodeTypeImplementation.module.ts
@@ -13,12 +13,16 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NodeTypeImplementationRouterModule } from './nodeTypeImplementationRouter.module';
 import { WineryArtifactModule } from '../../instance/sharedComponents/wineryArtifacts/artifact.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
         CommonModule,
         WineryArtifactModule,
         NodeTypeImplementationRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ]
 })
 export class NodeTypeImplementationModule {

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypeImplementations/nodeTypeImplementationRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypeImplementations/nodeTypeImplementationRouter.module.ts
@@ -17,6 +17,8 @@ import { DocumentationComponent } from '../../instance/sharedComponents/document
 import { ToscaTypes } from '../../wineryInterfaces/enums';
 import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
 import { WineryArtifactComponent } from '../../instance/sharedComponents/wineryArtifacts/artifact.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.NodeTypeImplementation;
 
@@ -28,6 +30,8 @@ const nodeTypeImplementationRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'implementationartifacts', component: WineryArtifactComponent },
             { path: 'deploymentartifacts', component: WineryArtifactComponent },
             { path: 'inheritance', component: InheritanceComponent },

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypes/nodeType.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypes/nodeType.module.ts
@@ -26,6 +26,8 @@ import { VisualAppearanceModule } from '../../instance/sharedComponents/visualAp
 import { InstanceStatesModule } from '../../instance/sharedComponents/instanceStates/instanceStates.module';
 import { PropertiesDefinitionModule } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.module';
 import { InheritanceModule } from '../../instance/sharedComponents/inheritance/inheritance.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
@@ -43,7 +45,9 @@ import { InheritanceModule } from '../../instance/sharedComponents/inheritance/i
         WineryTableModule,
         WineryModalModule,
         WineryEditorModule,
-        NodeTypeRouterModule
+        NodeTypeRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ],
     exports: [],
     declarations: [CapOrReqDefComponent],

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypes/nodeTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypes/nodeTypeRouter.module.ts
@@ -25,6 +25,8 @@ import { ImplementationsComponent } from '../../instance/sharedComponents/implem
 import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
 import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
 import { CapOrReqDefComponent } from '../../instance/nodeTypes/capabilityOrRequirementDefinitions/capOrReqDef.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.NodeType;
 
@@ -36,6 +38,8 @@ const nodeTypeRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'visualappearance', component: VisualAppearanceComponent },
             { path: 'instancestates', component: InstanceStatesComponent },
             { path: 'interfaces', component: InterfacesComponent },

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTemplates/policyTemplate.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTemplates/policyTemplate.module.ts
@@ -11,10 +11,14 @@
  */
 import { NgModule } from '@angular/core';
 import { PolicyTemplateRouterModule } from './policyTemplateRouter.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
-        PolicyTemplateRouterModule
+        PolicyTemplateRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ],
 })
 export class PolicyTemplateModule {

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTemplates/policyTemplateRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTemplates/policyTemplateRouter.module.ts
@@ -15,11 +15,9 @@ import { InstanceResolver } from '../../instance/instance.resolver';
 import { EditXMLComponent } from '../../instance/sharedComponents/editXML/editXML.component';
 import { DocumentationComponent } from '../../instance/sharedComponents/documentation/documentation.component';
 import { ToscaTypes } from '../../wineryInterfaces/enums';
-import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
-import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
-import { LanguageComponent } from '../../instance/policyTypes/language/language.component';
-import { AppliesToComponent } from '../../instance/policyTypes/appliesTo/appliesTo.component';
 import { PropertiesComponent } from '../../instance/sharedComponents/properties/properties.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.PolicyTemplate;
 
@@ -31,6 +29,8 @@ const policyTemplateRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent },
             { path: 'properties', component: PropertiesComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyType.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyType.module.ts
@@ -13,10 +13,14 @@ import { NgModule } from '@angular/core';
 import { LanguageComponent } from '../../instance/policyTypes/language/language.component';
 import { AppliesToComponent } from '../../instance/policyTypes/appliesTo/appliesTo.component';
 import { PolicyTypeRouterModule } from './policyTypeRouter.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
         PolicyTypeRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ],
     declarations: [
         LanguageComponent,

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyTypeRouter.module.ts
@@ -20,6 +20,8 @@ import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/p
 import { LanguageComponent } from '../../instance/policyTypes/language/language.component';
 import { AppliesToComponent } from '../../instance/policyTypes/appliesTo/appliesTo.component';
 import { TemplatesOfTypeComponent } from '../../instance/sharedComponents/templatesOfTypes/templatesOfTypes.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.PolicyType;
 
@@ -31,13 +33,15 @@ const policyTypeRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'language', component: LanguageComponent },
             { path: 'appliesto', component: AppliesToComponent },
             { path: 'propertiesdefinition', component: PropertiesDefinitionComponent },
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: 'templates', component:  TemplatesOfTypeComponent},
+            { path: 'templates', component: TemplatesOfTypeComponent },
             { path: '', redirectTo: 'language', pathMatch: 'full' }
 
         ]

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypeImplementations/relationshipTypeImplementation.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypeImplementations/relationshipTypeImplementation.module.ts
@@ -12,11 +12,15 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RelationshipTypeImplementationRouterModule } from './relationshipTypeImplementationRouter.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
         CommonModule,
         RelationshipTypeImplementationRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ]
 })
 export class RelationshipTypeImplementationModule {

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypeImplementations/relationshipTypeImplementationRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypeImplementations/relationshipTypeImplementationRouter.module.ts
@@ -16,9 +16,9 @@ import { EditXMLComponent } from '../../instance/sharedComponents/editXML/editXM
 import { DocumentationComponent } from '../../instance/sharedComponents/documentation/documentation.component';
 import { ToscaTypes } from '../../wineryInterfaces/enums';
 import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
-import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
-import { RequiredCapabilityTypeComponent } from '../../instance/requirementTypes/requiredCapabilityType/requiredCapabilityType.component';
 import { WineryArtifactComponent } from '../../instance/sharedComponents/wineryArtifacts/artifact.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.RelationshipTypeImplementation;
 
@@ -30,6 +30,8 @@ const relationshipTypeImplementationRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'implementationartifacts', component: WineryArtifactComponent },
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypes/relationshipType.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypes/relationshipType.module.ts
@@ -15,13 +15,17 @@ import { CommonModule } from '@angular/common';
 import { ValidSourcesAndTargetsComponent } from '../../instance/relationshipTypes/validSourcesAndTargets/validSourcesAndTargets.component';
 import { SelectModule } from 'ng2-select';
 import { WineryLoaderModule } from '../../wineryLoader/wineryLoader.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
         CommonModule,
         SelectModule,
         WineryLoaderModule,
-        RelationshipTypeRouterModule
+        RelationshipTypeRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ],
     declarations: [
         ValidSourcesAndTargetsComponent,

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypes/relationshipTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypes/relationshipTypeRouter.module.ts
@@ -21,8 +21,9 @@ import { InterfacesComponent } from '../../instance/sharedComponents/interfaces/
 import { ImplementationsComponent } from '../../instance/sharedComponents/implementations/implementations.component';
 import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
 import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
-import { CapOrReqDefComponent } from '../../instance/nodeTypes/capabilityOrRequirementDefinitions/capOrReqDef.component';
 import { ValidSourcesAndTargetsComponent } from '../../instance/relationshipTypes/validSourcesAndTargets/validSourcesAndTargets.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.RelationshipType;
 
@@ -34,6 +35,8 @@ const relationshipTypeRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'visualappearance', component: VisualAppearanceComponent },
             { path: 'instancestates', component: InstanceStatesComponent },
             { path: 'sourceinterfaces', component: InterfacesComponent },

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/requirementTypes/requirementType.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/requirementTypes/requirementType.module.ts
@@ -15,6 +15,8 @@ import { RequiredCapabilityTypeComponent } from '../../instance/requirementTypes
 import { CommonModule } from '@angular/common';
 import { WineryLoaderModule } from '../../wineryLoader/wineryLoader.module';
 import { WineryQNameSelectorModule } from '../../wineryQNameSelector/wineryQNameSelector.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
@@ -22,6 +24,8 @@ import { WineryQNameSelectorModule } from '../../wineryQNameSelector/wineryQName
         WineryLoaderModule,
         WineryQNameSelectorModule,
         RequirementTypeRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ],
     declarations: [
         RequiredCapabilityTypeComponent

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/requirementTypes/requirementTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/requirementTypes/requirementTypeRouter.module.ts
@@ -18,6 +18,8 @@ import { ToscaTypes } from '../../wineryInterfaces/enums';
 import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
 import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
 import { RequiredCapabilityTypeComponent } from '../../instance/requirementTypes/requiredCapabilityType/requiredCapabilityType.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.RequirementType;
 
@@ -29,6 +31,8 @@ const requirementTypeRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'requiredcapabilitytype', component: RequiredCapabilityTypeComponent },
             { path: 'propertiesdefinition', component: PropertiesDefinitionComponent },
             { path: 'inheritance', component: InheritanceComponent },

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/serviceTemplates/serviceTemplate.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/serviceTemplates/serviceTemplate.module.ts
@@ -27,6 +27,8 @@ import { SelfServicePortalModule } from '../../instance/serviceTemplates/selfSer
 import { BoundaryDefinitionsModule } from '../../instance/serviceTemplates/boundaryDefinitions/boundaryDefinitions.module';
 import { TagModule } from '../../instance/serviceTemplates/tag/tag.module';
 import { DocumentationModule } from '../../instance/sharedComponents/documentation/documentation.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 
 @NgModule({
     imports: [
@@ -44,6 +46,8 @@ import { DocumentationModule } from '../../instance/sharedComponents/documentati
         WineryUploaderModule,
         WineryTableModule,
         ServiceTemplateRouterModule,
+        WineryReadmeModule,
+        WineryLicenseModule
     ],
     declarations: [
         TopologyTemplateComponent,

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/serviceTemplates/serviceTemplateRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/serviceTemplates/serviceTemplateRouter.module.ts
@@ -22,6 +22,8 @@ import { selfServiceRoutes } from '../../instance/serviceTemplates/selfServicePo
 import { TagComponent } from '../../instance/serviceTemplates/tag/tag.component';
 import { DocumentationComponent } from '../../instance/sharedComponents/documentation/documentation.component';
 import { ToscaTypes } from '../../wineryInterfaces/enums';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 
 const toscaType = ToscaTypes.ServiceTemplate;
 
@@ -33,6 +35,8 @@ const serviceTemplateRoutes: Routes = [
         component: InstanceComponent,
         resolve: { resolveData: InstanceResolver },
         children: [
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent},
             { path: 'topologytemplate', component: TopologyTemplateComponent },
             { path: 'plans', component: PlansComponent },
             {

--- a/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.component.css
+++ b/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.component.css
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+.flash{
+    background-color: #dbedff;
+    padding: 16px;
+    display: inline-block;
+    border: 1px solid rgba(27,31,35,0.15);
+    border-radius: 3px;
+    font-size: larger;
+}
+
+.flash-action {
+    background-image: linear-gradient(#79d858, #569e3d);
+    border-color: #569e3d;
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.component.html
@@ -1,0 +1,39 @@
+<!--
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+-->
+<div *ngIf="!readmeAvailable">
+    <div class="flash">
+        Help people interested in this {{ toscaType | toscaTypeToReadableName }} understand this {{ toscaType |
+        toscaTypeToReadableName }} by adding a README.
+        <button class="btn btn-sm btn-primary flash-action" (click)="readmeAvailable=true;isEditable=true;">Add a
+            README
+        </button>
+    </div>
+</div>
+
+<div *ngIf="!isEditable && readmeAvailable">
+    <div class="right" style="width: 100%; margin-bottom: 2px; ">
+        <button class="btn fa fa-pencil" aria-hidden="true" name="edit" style="float: right;"
+                (click)="isEditable = true;"></button>
+    </div>
+    <textarea readonly tabIndex="-1" style="width: 95%;height: 500px; resize: none;">{{readmeContent}}</textarea>
+</div>
+
+<div *ngIf="isEditable">
+    <div class="right" style="margin-bottom: 2px;">
+        <button class="btn fa fa-floppy-o" aria-hidden="true" name="save" (click)="saveReadmeFile()"> Save</button>
+        <button class="btn fa fa-ban" name="cancel" aria-hidden="true" (click)="cancelEdit()"> Cancel</button>
+    </div>
+
+    <textarea style="width: 95%; height: 500px; resize: none; font-family: monospace" [(ngModel)]="readmeContent"></textarea>
+</div>
+
+
+

--- a/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.component.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { Component, OnInit } from '@angular/core';
+import { ReadmeService } from './wineryReadme.service';
+import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
+import { InstanceService } from '../instance/instance.service';
+import { ToscaTypes } from '../wineryInterfaces/enums';
+
+@Component({
+    templateUrl: 'wineryReadme.component.html',
+    styleUrls: ['wineryReadme.component.css'],
+    providers: [ReadmeService]
+})
+
+export class WineryReadmeComponent implements OnInit {
+
+    loading = true;
+    readmeContent = '';
+    initialReadmeContent = '';
+
+    isEditable = false;
+    readmeAvailable = true;
+    toscaType: ToscaTypes;
+
+    constructor(private service: ReadmeService, private notify: WineryNotificationService, private sharedData: InstanceService) {
+        this.toscaType = this.sharedData.toscaComponent.toscaType;
+
+    }
+
+    ngOnInit() {
+        this.service.getData().subscribe(
+            data => {
+                this.readmeContent = data;
+                this.initialReadmeContent = data;
+            },
+            error => this.handleMissingReadme()
+        );
+    }
+
+    saveReadmeFile() {
+        this.service.save(this.readmeContent).subscribe(
+            data => this.handleSave(),
+            error => this.handleError(error)
+        );
+    }
+
+    cancelEdit() {
+        this.isEditable = false;
+        this.readmeContent = this.initialReadmeContent;
+    }
+
+    private handleError(error: any) {
+        this.loading = false;
+        this.notify.error(error);
+    }
+
+    private handleMissingReadme() {
+        this.loading = false;
+        this.readmeAvailable = false;
+    }
+
+    private handleSave() {
+        this.notify.success('Successfully saved README.md');
+    }
+
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.module.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+import { NgModule } from '@angular/core';
+import { WineryReadmeComponent } from './wineryReadme.component';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { WineryLoaderModule } from '../wineryLoader/wineryLoader.module';
+import { TabsModule } from 'ngx-bootstrap';
+import { WineryPipesModule } from '../wineryPipes/wineryPipes.module';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        WineryLoaderModule,
+        FormsModule,
+        TabsModule,
+        WineryPipesModule
+    ],
+    exports: [
+        WineryReadmeComponent
+    ],
+    declarations: [WineryReadmeComponent],
+    providers: [],
+})
+export class WineryReadmeModule {
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.service.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { Injectable } from '@angular/core';
+import { Headers, Http, RequestOptions } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import { InstanceService } from '../instance/instance.service';
+import { backendBaseURL } from '../configuration';
+
+@Injectable()
+export class ReadmeService {
+
+    constructor(private http: Http,
+                private sharedData: InstanceService) {
+    }
+
+    getData(): Observable<string> {
+        const headers = new Headers({ 'Accept': 'text/plain' });
+        const options = new RequestOptions({ headers: headers });
+        return this.http.get(backendBaseURL + this.sharedData.path + '/README.md', options)
+            .map(res => res.text());
+    }
+
+    save(readmeFile: String) {
+        const headers = new Headers({ 'Content-Type': 'application/json' });
+        const options = new RequestOptions({ headers: headers });
+
+        return this.http.put(backendBaseURL + this.sharedData.path + '/README.md', readmeFile, options)
+            .map(res => res.json());
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Philipp Meyer <meyer.github@gmail.com>

Add a license module and a Readme module that is used in each Tosca-Type to display README.md and LICENSE  files. 

![grafik](https://user-images.githubusercontent.com/23094908/30969935-22762fbe-a464-11e7-807f-b1771339c4ec.png)

![grafik](https://user-images.githubusercontent.com/23094908/31025590-6968472e-a543-11e7-8752-8ead7602a35a.png)

![grafik](https://user-images.githubusercontent.com/23094908/31025510-2ff28cb6-a543-11e7-90ff-b98a862fa3ca.png)


- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
