### PR TITLE
Add hide when out of focus and fix open diffs after reset

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.html
@@ -11,10 +11,11 @@
 <div id="wineryGitLogFloat" *ngIf="show">
     <div id="wineryGitLogContainer">
         <div id="wineryGitLogExpander">
-            <span  (click)="onExpand()"></span>
+            <span (click)="onExpand()"></span>
             <h3>{{files?.length}}</h3>
         </div>
-        <textarea id="wineryGitLogDiffs" wrap="soft" *ngIf="selectedFile != null && isExpanded">{{selectedFile?.diffs}}</textarea>
+        <textarea id="wineryGitLogDiffs" wrap="soft"
+                  *ngIf="selectedFile != null && isExpanded">{{selectedFile?.diffs}}</textarea>
         <div id="wineryGitLogGui" *ngIf="isExpanded">
             <table role="presentation">
                 <tbody class="files">
@@ -32,10 +33,12 @@
         <div id="wineryGitLogCommit" *ngIf="isExpanded">
             <button class="btn btn-sm btn-toolbar btn-primary" (click)="commit()">Commit</button>
             <button class="btn btn-sm btn-toolbar" (click)="refreshLog()">Refresh</button>
-            <button class="btn btn-sm btn-toolbar btn-danger" (click)="confirmDiscardModal.show()">discard changes</button>
+            <button class="btn btn-sm btn-toolbar btn-danger" (click)="confirmDiscardModal.show()">discard changes
+            </button>
         </div>
 
-        <textarea *ngIf="isExpanded" (change)="doCommitMsgValueChange($event)" id="wineryGitLogCommitMsg" [(ngModel)]="commitMsg"></textarea>
+        <textarea *ngIf="isExpanded" (change)="doCommitMsgValueChange($event)" id="wineryGitLogCommitMsg"
+                  [(ngModel)]="commitMsg"></textarea>
     </div>
 </div>
 

--- a/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryGitLog/wineryGitLog.component.ts
@@ -99,5 +99,10 @@ export class WineryGitLogComponent implements OnInit {
 
     discardChanges() {
         this.webSocket.send('reset');
+        this.selectedFile = null;
+    }
+
+    hide() {
+        this.isExpanded = false;
     }
 }

--- a/org.eclipse.winery.repository.ui/src/app/wineryRepository.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryRepository.component.ts
@@ -6,8 +6,9 @@
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
  */
-import { Component, ViewContainerRef } from '@angular/core';
+import { Component, ViewChild, ViewContainerRef } from '@angular/core';
 import { WineryNotificationService } from './wineryNotificationModule/wineryNotification.service';
+import { WineryGitLogComponent } from './wineryGitLog/wineryGitLog.component';
 
 @Component({
     selector: 'winery-repository',
@@ -19,6 +20,9 @@ import { WineryNotificationService } from './wineryNotificationModule/wineryNoti
 export class WineryRepositoryComponent {
     // region variables
     name = 'Winery Repository';
+
+    @ViewChild('gitLog') gitLog: WineryGitLogComponent;
+
     // endregion
     options = {
         position: ['top', 'right'],
@@ -28,5 +32,9 @@ export class WineryRepositoryComponent {
 
     constructor(vcr: ViewContainerRef, private notify: WineryNotificationService) {
         this.notify.init(vcr);
+    }
+
+    onClick() {
+        this.gitLog.hide();
     }
 }

--- a/org.eclipse.winery.repository.ui/src/app/wineryRepository.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryRepository.html
@@ -9,10 +9,10 @@
  */
 -->
 
-<div id="mainContainer" class="notoverflown">
+<div id="mainContainer" class="notoverflown" (click)="onClick()">
     <winery-header></winery-header>
     <div id="mainContent">
         <router-outlet></router-outlet>
     </div>
 </div>
-<winery-gitlog></winery-gitlog>
+<winery-gitlog #gitLog></winery-gitlog>


### PR DESCRIPTION
Signed-off-by: Lukas Balzer <balzer814_dev@web.de>

Add click event to hide the git log view when the focus is shifted to the mainContent
![image](https://user-images.githubusercontent.com/23092994/30970520-a73e384e-a465-11e7-9407-3644f4de0d17.png)

Fix that the difference View of the git log is still shown after the changes where discarded
![image](https://user-images.githubusercontent.com/23092994/30970488-8b0a1846-a465-11e7-90d3-b83fad3789b4.png)

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added (for UI changes)
