### PR TITLE
implement editing of properties as xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ## [unreleased]
 
 ### Changed
+- Add edit properties as XML
 - Add available/not available indicator for LFS in git log component
 - Add ZIP-button for artifactemplate-files
 - Add license and readme support for all components

--- a/docs/adr/0006-wrap-properties-in-tosca-properties-element.md
+++ b/docs/adr/0006-wrap-properties-in-tosca-properties-element.md
@@ -1,0 +1,22 @@
+# Wrap properties in TOSCA properties element
+
+When GETting/PUTting the properties of an entitty template, the content has to be serialized somehow.
+
+## Considered Alternatives
+
+* Wrap properties in TOSCA properties element
+* Use nested XML element (`getAny()`)
+
+## Decision Outcome
+
+* Chosen Alternative: Wrap properties in TOSCA properties element
+* Receiving an XML element is not possible with JAX-B/JAX-RS as that setting relies on strong typing.
+
+## License
+
+Copyright (c) 2017 University of Stuttgart.
+
+All rights reserved. Made available under the terms of the [Eclipse Public License v2.0] and the [Apache License v2.0] which both accompany this distribution.
+
+ [Apache License v2.0]: http://www.apache.org/licenses/LICENSE-2.0.html
+ [Eclipse Public License v2.0]: http://www.eclipse.org/legal/epl-v20.html

--- a/org.eclipse.winery.repository.rest/pom.xml
+++ b/org.eclipse.winery.repository.rest/pom.xml
@@ -266,7 +266,11 @@
 			<artifactId>eclipse-collections</artifactId>
 			<version>8.2.0</version>
 		</dependency>
-
+		<dependency>
+			<groupId>io.github.adr</groupId>
+			<artifactId>e-adr</artifactId>
+			<version>1.0.0</version>
+		</dependency>
 
 		<!-- no review, but approval is required for test-only dependencies: http://wiki.eclipse.org/Development_Resources/IP/Test_and_Build_Dependencies -->
 		<dependency>

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/PropertiesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/PropertiesResource.java
@@ -18,6 +18,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -32,11 +33,11 @@ import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources.AbstractComponentInstanceResource;
 
+import io.github.adr.embedded.ADR;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Element;
 
 public class PropertiesResource {
 
@@ -57,7 +58,7 @@ public class PropertiesResource {
 
 	@PUT
 	@Consumes({MediaType.APPLICATION_XML, MediaType.TEXT_XML})
-	public Response setProperties(TEntityTemplate.Properties properties) {
+	public Response setProperties(@ADR(6) TEntityTemplate.Properties properties) {
 		this.template.setProperties(properties);
 		return RestUtils.persist(this.res);
 	}
@@ -95,7 +96,13 @@ public class PropertiesResource {
 					LOGGER.debug("XML properties expected, but none found. Returning empty JSON.");
 					return Response.ok().entity("{}").type(MediaType.APPLICATION_JSON).build();
 				}
-				return Response.ok().entity(Util.getXMLAsString((Element) any)).type(MediaType.TEXT_XML).build();
+				try {
+					@ADR(6)
+					Response response = Response.ok().entity(Util.getXMLAsString(TEntityTemplate.Properties.class, props)).type(MediaType.TEXT_XML).build();
+					return response;
+				} catch (Exception e) {
+					throw new WebApplicationException(e);
+				}
 			}
 		} else {
 			Properties properties;

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytemplates/PropertiesResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytemplates/PropertiesResourceTest.java
@@ -52,4 +52,11 @@ public class PropertiesResourceTest extends AbstractResourceTest {
 		this.assertGet("artifacttemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttemplates%252Ffruits/baobab-ArtifactTemplate-Peel/properties/",
 			"entitytemplates/updatedProperties.json");
 	}
+	
+	@Test
+	public void postXMLPropertiesToArtifact() throws Exception {
+		this.setRevisionTo("2025ac44d12f5814cc441ba2f8425cdc78c47bb4");
+		this.assertPut("artifacttemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttemplates/ShipOrderTemplate/properties/", "entitytemplates/artifacttemplates/updatedProperties.xml");
+		this.assertGet("artifacttemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttemplates/ShipOrderTemplate/properties/", "entitytemplates/artifacttemplates/updatedPropertiesAfterPut.xml");
+	}
 }

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/updatedProperties.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/updatedProperties.xml
@@ -3,7 +3,7 @@
 		<orderperson xmlns="" xmlns:ns7="http://docs.oasis-open.org/tosca/ns/2011/12">Marty McFly Jr.</orderperson>
 		<shipto xmlns="" xmlns:ns7="http://docs.oasis-open.org/tosca/ns/2011/12">
 			<name>name</name>
-			<address>address</address>
+			<address>new address</address>
 			<city>city</city>
 			<country>country</country>
 		</shipto>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/updatedPropertiesAfterPut.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/updatedPropertiesAfterPut.xml
@@ -3,7 +3,7 @@
 		<orderperson xmlns="" xmlns:ns7="http://docs.oasis-open.org/tosca/ns/2011/12">Marty McFly Jr.</orderperson>
 		<shipto xmlns="" xmlns:ns7="http://docs.oasis-open.org/tosca/ns/2011/12">
 			<name>name</name>
-			<address>address</address>
+			<address>new address</address>
 			<city>city</city>
 			<country>country</country>
 		</shipto>

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/properties/properties.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/properties/properties.component.html
@@ -9,10 +9,10 @@
  */
 -->
 <div *ngIf="!loading; else loadingIcon">
+    <div class="right">
+        <button [disabled]="properties === null" class="btn btn-primary" (click)="save()">Save</button>
+    </div>
     <div *ngIf="propertyKeys?.length > 0; else elseBlock">
-        <div class="right">
-            <button class="btn btn-primary" (click)="save()">Save</button>
-        </div>
         <table>
             <tr *ngFor="let prop of propertyKeys">
                 <td>
@@ -25,9 +25,10 @@
         </table>
     </div>
     <ng-template #elseBlock>
-        <div>
+        <div *ngIf="properties === null">
             The type does not have a “Properties Definition”.
         </div>
+        <winery-editor #propertiesEditor *ngIf="isXMLData" [ngModel]="properties"></winery-editor>
     </ng-template>
 </div>
 <ng-template #loadingIcon>

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/properties/properties.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/properties/properties.component.ts
@@ -9,9 +9,11 @@
  * Contributors:
  *     Lukas Harzenetter - initial API and implementation
  */
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { PropertiesService } from './properties.service';
 import { WineryNotificationService } from '../../../wineryNotificationModule/wineryNotification.service';
+import { isNullOrUndefined } from 'util';
+import { WineryEditorComponent } from '../../../wineryEditorModule/wineryEditor.component';
 
 @Component({
     selector: 'winery-properties',
@@ -29,8 +31,10 @@ export class PropertiesComponent implements OnInit {
      * Why `any`? => see {@link PropertiesService.getProperties()}
      */
     properties: any = null;
-    propertyKeys: string[];
+    propertyKeys: string[] = [];
+    isXMLData: boolean;
     loading = true;
+    @ViewChild('propertiesEditor') propertiesEditor: WineryEditorComponent;
 
     constructor(private service: PropertiesService, private notify: WineryNotificationService) {
     }
@@ -41,7 +45,10 @@ export class PropertiesComponent implements OnInit {
 
     save() {
         this.loading = true;
-        this.service.saveProperties(this.properties)
+        if (this.isXMLData) {
+            this.properties = this.propertiesEditor.getData();
+        }
+        this.service.saveProperties(this.properties, this.isXMLData)
             .subscribe(
                 data => this.handleSave(),
                 error => this.handleError(error)
@@ -63,9 +70,17 @@ export class PropertiesComponent implements OnInit {
 
     private handleProperties(data: any) {
         this.loading = false;
-        this.propertyKeys = Object.keys(data);
-        if (this.properties != null && this.propertyKeys.length > 0) {
-            this.properties = data;
+        if (data.isXML) {
+            this.isXMLData = true;
+            this.properties = data.properties;
+        } else {
+            this.isXMLData = false;
+            if (!isNullOrUndefined(data.properies)) {
+                this.propertyKeys = Object.keys(data.properties);
+            }
+            if (this.properties != null && this.propertyKeys.length > 0) {
+                this.properties = data.properties;
+            }
         }
     }
 

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/properties/properties.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/properties/properties.service.ts
@@ -7,7 +7,7 @@
  * and http://www.apache.org/licenses/LICENSE-2.0
  */
 import { Injectable } from '@angular/core';
-import { Headers, Http, Response, RequestOptions } from '@angular/http';
+import { Headers, Http, RequestOptions, Response } from '@angular/http';
 import { InstanceService } from '../../instance.service';
 import { Observable } from 'rxjs/Observable';
 import { backendBaseURL } from '../../../configuration';
@@ -28,11 +28,24 @@ export class PropertiesService {
      */
     public getProperties(): Observable<any> {
         return this.http.get(this.path)
-            .map(res => res.json());
+                   .map(res => {
+                       if (res.headers.get('Content-Type') === 'application/json') {
+                           return {
+                               isXML: false, properties: res.json()
+                           };
+                       } else {
+                           return {isXML: true, properties: res.text()};
+                       }
+                   });
     }
 
-    public saveProperties(properties: any): Observable<Response> {
-        const headers = new Headers({'Content-Type': 'application/json'});
+    public saveProperties(properties: any, isXML: boolean): Observable<Response> {
+        let headers: Headers;
+        if (isXML) {
+            headers = new Headers({'Content-Type': 'application/xml'});
+        } else {
+            headers = new Headers({'Content-Type': 'application/json'});
+        }
         const options = new RequestOptions({headers: headers});
         return this.http.put(this.path, properties, options);
     }


### PR DESCRIPTION
Implement editing of properties as XML. The XML-Editor is available if the user chose "XML element" at the "properties definition" of the corresponding type.
See screenshot for UI changes.
- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added (for UI changes)
![propertiesasxml](https://user-images.githubusercontent.com/23076947/31139637-7a267496-a872-11e7-88b6-1eb1c4cd4d37.PNG)