### PR TITLE
Fix Inheritance Implementation

### DIFF
--- a/generate-stats.bat
+++ b/generate-stats.bat
@@ -7,9 +7,6 @@ GOTO EndOfLicense
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Philipp Meyer - initial API and implementation
  */
 :EndOfLicense
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/HasInheritance.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/HasInheritance.java
@@ -1,14 +1,11 @@
-/*******************************************************************************
+/**
  * Copyright (c) 2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Oliver Kopp - initial API and implementation
- *******************************************************************************/
+ */
 package org.eclipse.winery.model.tosca;
 
 /**
@@ -18,7 +15,13 @@ public interface HasInheritance {
 
     public TBoolean getAbstract();
 
+    public void setAbstract(TBoolean value);
+
     public TBoolean getFinal();
 
+    public void setFinal(TBoolean value);
+
     public HasType getDerivedFrom();
+
+    public void setDerivedFrom(HasType value);
 }

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/HasType.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/HasType.java
@@ -1,14 +1,11 @@
-/*******************************************************************************
- * Copyright (c) 2012-2013 University of Stuttgart.
+/**
+ * Copyright (c) 2012-2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Oliver Kopp - initial API and implementation
- *******************************************************************************/
+ */
 package org.eclipse.winery.model.tosca;
 
 import javax.xml.bind.annotation.XmlTransient;

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityType.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityType.java
@@ -176,8 +176,8 @@ public class TEntityType extends TExtensibleElements implements HasName, HasInhe
      *
      * @param value allowed object is {@link TEntityType.DerivedFrom }
      */
-    public void setDerivedFrom(TEntityType.DerivedFrom value) {
-        this.derivedFrom = value;
+    public void setDerivedFrom(HasType value) {
+        this.derivedFrom = (TEntityType.DerivedFrom) value;
     }
 
     /**

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTypeImplementation.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTypeImplementation.java
@@ -127,8 +127,8 @@ public class TNodeTypeImplementation extends TEntityTypeImplementation {
         return derivedFrom;
     }
 
-    public void setDerivedFrom(TNodeTypeImplementation.DerivedFrom value) {
-        this.derivedFrom = value;
+    public void setDerivedFrom(HasType value) {
+        this.derivedFrom = (TNodeTypeImplementation.DerivedFrom) value;
     }
 
     /**

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipTypeImplementation.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipTypeImplementation.java
@@ -104,8 +104,8 @@ public class TRelationshipTypeImplementation extends TEntityTypeImplementation {
         return derivedFrom;
     }
 
-    public void setDerivedFrom(TRelationshipTypeImplementation.DerivedFrom value) {
-        this.derivedFrom = value;
+    public void setDerivedFrom(HasType value) {
+        this.derivedFrom = (TRelationshipTypeImplementation.DerivedFrom) value;
     }
 
     @NonNull

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/EntityTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/EntityTypeResource.java
@@ -1,15 +1,11 @@
-/*******************************************************************************
- * Copyright (c) 2012-2013 University of Stuttgart.
+/**
+ * Copyright (c) 2012-2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Oliver Kopp - initial API and implementation
- *     Tino Stadelmaier, Philipp Meyer - rename for id/namespace
- *******************************************************************************/
+ */
 package org.eclipse.winery.repository.rest.resources;
 
 import java.util.Collection;
@@ -39,8 +35,7 @@ public abstract class EntityTypeResource extends AbstractComponentInstanceResour
 	}
 
 	/**
-	 * Convenience method to avoid casting. Required by
-	 * PropertiesDefinitionResource's jsp
+	 * Convenience method to avoid casting.
 	 */
 	public TEntityType getEntityType() {
 		return (TEntityType) this.element;
@@ -72,8 +67,7 @@ public abstract class EntityTypeResource extends AbstractComponentInstanceResour
 	}
 
 	/**
-	 * Returns an array suitable for processing in a {@code select2} field See
-	 * <a href="http://ivaynberg.github.io/select2">http://ivaynberg.github.io/select2</a>
+	 * Returns an array suitable for processing in a {@code select2} field See <a href="http://ivaynberg.github.io/select2">http://ivaynberg.github.io/select2</a>
 	 *
 	 * Each element: {id: "{ns}localname", text: "name/id"}
 	 */

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/InheritanceResourceApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/InheritanceResourceApiData.java
@@ -1,14 +1,11 @@
-/*******************************************************************************
+/**
  * Copyright (c) 2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzentter - initial API and implementation
- *******************************************************************************/
+ */
 
 package org.eclipse.winery.repository.rest.resources.apiData;
 

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/EntityTypeImplementationResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/EntityTypeImplementationResource.java
@@ -1,14 +1,11 @@
-/*******************************************************************************
- * Copyright (c) 2012-2013 University of Stuttgart.
+/**
+ * Copyright (c) 2012-2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Oliver Kopp - initial API and implementation
- *******************************************************************************/
+ */
 package org.eclipse.winery.repository.rest.resources.entitytypeimplementations;
 
 import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
@@ -25,5 +22,4 @@ public abstract class EntityTypeImplementationResource extends AbstractComponent
 	protected EntityTypeImplementationResource(DefinitionsChildId id) {
 		super(id);
 	}
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/nodetypeimplementations/NodeTypeImplementationResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/nodetypeimplementations/NodeTypeImplementationResource.java
@@ -1,15 +1,11 @@
-/*******************************************************************************
- * Copyright (c) 2012-2013 University of Stuttgart.
+/**
+ * Copyright (c) 2012-2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Oliver Kopp - initial API and implementation
- *     Tino Stadelmaier, Philipp Meyer - rename for id/namespace
- *******************************************************************************/
+ */
 package org.eclipse.winery.repository.rest.resources.entitytypeimplementations.nodetypeimplementations;
 
 import javax.ws.rs.Path;
@@ -39,9 +35,8 @@ public class NodeTypeImplementationResource extends EntityTypeImplementationReso
 	}
 
 	/**
-	 * Even if both node type implementations and relationship type
-	 * implementations have implementation artifacts, there is no common
-	 * supertype. To avoid endless casts, we just implement the method here
+	 * Even if both node type implementations and relationship type implementations have implementation artifacts, there
+	 * is no common supertype. To avoid endless casts, we just implement the method here
 	 */
 	@Path("implementationartifacts/")
 	public ImplementationArtifactsResource getImplementationArtifacts() {
@@ -55,10 +50,8 @@ public class NodeTypeImplementationResource extends EntityTypeImplementationReso
 	}
 
 	/**
-	 * Only NodeTypes have deployment artifacts, not RelationshipType.
-	 * Therefore, this method is declared in
-	 * {@link NodeTypeImplementationResource} and not in
-	 * {@link EntityTypeImplementationResource}
+	 * Only NodeTypes have deployment artifacts, not RelationshipType. Therefore, this method is declared in {@link
+	 * NodeTypeImplementationResource} and not in {@link EntityTypeImplementationResource}
 	 */
 	@Path("deploymentartifacts/")
 	public DeploymentArtifactsResource getDeploymentArtifacts() {
@@ -75,5 +68,4 @@ public class NodeTypeImplementationResource extends EntityTypeImplementationReso
 	protected TExtensibleElements createNewElement() {
 		return new TNodeTypeImplementation();
 	}
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/relationshiptypeimplementations/RelationshipTypeImplementationResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/relationshiptypeimplementations/RelationshipTypeImplementationResource.java
@@ -1,15 +1,11 @@
-/*******************************************************************************
- * Copyright (c) 2012-2013 University of Stuttgart.
+/**
+ * Copyright (c) 2012-2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Oliver Kopp - initial API and implementation
- *     Tino Stadelmaier, Philipp Meyer - rename for id/namespace
- *******************************************************************************/
+ */
 package org.eclipse.winery.repository.rest.resources.entitytypeimplementations.relationshiptypeimplementations;
 
 import javax.ws.rs.Path;
@@ -52,5 +48,4 @@ public class RelationshipTypeImplementationResource extends EntityTypeImplementa
 	protected TExtensibleElements createNewElement() {
 		return new TRelationshipTypeImplementation();
 	}
-
 }

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/nodetypeimplementations/NodeTypeImplementationResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/nodetypeimplementations/NodeTypeImplementationResourceTest.java
@@ -5,11 +5,7 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- * Lukas Harzenetter - initial API and implementation
  */
-
 package org.eclipse.winery.repository.rest.resources.entitytypeimplementations.nodetypeimplementations;
 
 import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
@@ -24,20 +20,37 @@ public class NodeTypeImplementationResourceTest extends AbstractResourceTest {
 		this.assertPost("nodetypeimplementations/", "entityimplementations/nodetypeimplementations/baobab_create.json");
 		this.assertGetSize("nodetypeimplementations/", 1);
 		this.assertGet("nodetypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypeimplementations%252Ffruits/baobab_impl/",
-				"entityimplementations/nodetypeimplementations/baobab_initial.json");
+			"entityimplementations/nodetypeimplementations/baobab_initial.json");
 	}
 
 	@Test
 	public void nodeTypeImplementationResourceImplementationArtifactsCreation() throws Exception {
 		this.setRevisionTo("8d4abf7f7d79b99e27ec59e2421802c7e021f2a3");
 		this.assertPost("nodetypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypeimplementations%252Ffruits/baobab_impl/implementationartifacts/",
-				"entityimplementations/nodetypeimplementations/baobab_create_artifact.json");
+			"entityimplementations/nodetypeimplementations/baobab_create_artifact.json");
 		this.assertGet("artifacttemplates/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttemplates%252Ffruits/baobab_bananaInterface_IA/", "entityimplementations/nodetypeimplementations/initial_artifact_template.json");
 	}
 
 	@Test
 	public void getInterfacesOfAssociatedType() throws Exception {
 		this.setRevisionTo("9c486269f6280e0eb14730d01554e7e4553a3d60");
-		this.assertGet("nodetypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypeimplementations%252Ffruits/baobab_impl/implementationartifacts/interfaces/","entityimplementations/nodetypeimplementations/baobab_interfacesOfAssociatedType.json");
+		this.assertGet("nodetypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypeimplementations%252Ffruits/baobab_impl/implementationartifacts/interfaces/",
+			"entityimplementations/nodetypeimplementations/baobab_interfacesOfAssociatedType.json");
+	}
+
+	@Test
+	public void getInheritanceData() throws Exception {
+		this.setRevisionTo("410ec7b55bf7cf7daa5e18f4a8562d7b7c0efd1d");
+		this.assertGet("nodetypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypeimplementations%252Ffruits/baobab_impl/inheritance/",
+			"entityimplementations/nodetypeimplementations/baobab_initial_inheritance.json");
+	}
+
+	@Test
+	public void putInheritanceData() throws Exception {
+		this.setRevisionTo("1c7fbb0495c3ae07817ed7f44e60e8c275a79877");
+		this.assertPut("nodetypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypeimplementations%252Ffruits/grape_impl/inheritance/",
+			"entityimplementations/nodetypeimplementations/grape_inheritance.json");
+		this.assertGet("nodetypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypeimplementations%252Ffruits/grape_impl/xml",
+			"entityimplementations/nodetypeimplementations/grape_inheritance.xml");
 	}
 }

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/relationshiptypeimplementations/RelationshipTypeImplementationResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypeimplementations/relationshiptypeimplementations/RelationshipTypeImplementationResourceTest.java
@@ -5,9 +5,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- * Lukas Harzenetter - initial API and implementation
  */
 
 package org.eclipse.winery.repository.rest.resources.entitytypeimplementations.relationshiptypeimplementations;
@@ -22,5 +19,22 @@ public class RelationshipTypeImplementationResourceTest extends AbstractResource
 	public void getComponentAsJson() throws Exception {
 		this.setRevisionTo("3fe0df76e98d46ead68295920e5d1cf1354bdea1");
 		this.assertGet("relationshiptypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypeimplementations%252Ffruits/kiwi_implementation/", "entityimplementations/relationshiptypeimplementations/initial.json");
+	}
+
+	@Test
+	public void getInheritanceData() throws Exception {
+		this.setRevisionTo("410ec7b55bf7cf7daa5e18f4a8562d7b7c0efd1d");
+		this.assertGet("relationshiptypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypeimplementations%252Ffruits/kiwi_implementation/inheritance",
+			"entityimplementations/relationshiptypeimplementations/kiwi_initial_inheritance.json");
+	}
+
+	@Test
+	public void putInheritanceData() throws Exception {
+		this.setRevisionTo("aae0a874dd18cfed6abf4e33cb06f78a5a22b861");
+		this.assertPut("relationshiptypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypeimplementations%252Ffruits/attendTo_implementation/inheritance/",
+			"entityimplementations/relationshiptypeimplementations/attendTo_inheritance.json");
+		this.assertGet("relationshiptypeimplementations/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypeimplementations%252Ffruits/attendTo_implementation/xml/",
+			"entityimplementations/relationshiptypeimplementations/attendTo_inheritance.xml");
+
 	}
 }

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/ArtifactTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/ArtifactTypeResourceTest.java
@@ -46,4 +46,21 @@ public class ArtifactTypeResourceTest extends AbstractResourceTest {
 		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/WAR/",
 			"entitytypes/artifacttypes/war_with_properties.xml");
 	}
+
+	@Test
+	public void getInheritanceData() throws Exception {
+		this.setRevisionTo("410ec7b55bf7cf7daa5e18f4a8562d7b7c0efd1d");
+		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/JAR/inheritance",
+			"entitytypes/artifacttypes/jar_initial_inheritance.json");
+	}
+
+	@Test
+	public void putInheritanceData() throws Exception {
+		this.setRevisionTo("aae0a874dd18cfed6abf4e33cb06f78a5a22b861");
+		this.assertPut("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/JAR/inheritance/",
+			"entitytypes/artifacttypes/jar_inheritance.json");
+		this.assertGet("artifacttypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fartifacttypes%252Ffruits/JAR/xml",
+			"entitytypes/artifacttypes/jar_inheritance.xml");
+
+	}
 }

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/requirementtypes/RequirementTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/requirementtypes/RequirementTypeResourceTest.java
@@ -5,9 +5,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- * Lukas Harzenetter - initial API and implementation
  */
 
 package org.eclipse.winery.repository.rest.resources.entitytypes.requirementtypes;

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/baobab_initial_inheritance.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/baobab_initial_inheritance.json
@@ -1,0 +1,5 @@
+{
+	"isAbstract": "no",
+	"isFinal": "no",
+	"derivedFrom": "(none)"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/grape_inheritance.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/grape_inheritance.json
@@ -1,0 +1,5 @@
+{
+	"derivedFrom": "{http://winery.opentosca.org/test/nodetypeimplementations/fruits}baobab_impl",
+	"isAbstract": "no",
+	"isFinal": "yes"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/grape_inheritance.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/grape_inheritance.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Definitions targetNamespace="http://winery.opentosca.org/test/nodetypeimplementations/fruits" id="winery-defs-for_fruits3-grape_impl" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:testwineryopentoscaorg="http://test.winery.opentosca.org">
+	<NodeTypeImplementation targetNamespace="http://winery.opentosca.org/test/nodetypeimplementations/fruits" name="grape_impl" abstract="no" final="yes" nodeType="fruits4:grape" xmlns:fruits4="http://winery.opentosca.org/test/nodetypes/fruits">
+		<DerivedFrom nodeTypeImplementationRef="fruits3:baobab_impl" xmlns:fruits3="http://winery.opentosca.org/test/nodetypeimplementations/fruits"/>
+	</NodeTypeImplementation>
+</Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/relationshiptypeimplementations/attendTo_inheritance.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/relationshiptypeimplementations/attendTo_inheritance.json
@@ -1,0 +1,5 @@
+{
+	"derivedFrom": "{http://winery.opentosca.org/test/relationshiptypeimplementations/fruits}kiwi_implementation",
+	"isAbstract": "yes",
+	"isFinal": "no"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/relationshiptypeimplementations/attendTo_inheritance.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/relationshiptypeimplementations/attendTo_inheritance.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Definitions targetNamespace="http://winery.opentosca.org/test/relationshiptypeimplementations/fruits" id="winery-defs-for_fruits7-attendTo_implementation" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:testwineryopentoscaorg="http://test.winery.opentosca.org">
+	<RelationshipTypeImplementation targetNamespace="http://winery.opentosca.org/test/relationshiptypeimplementations/fruits" name="attendTo_implementation" abstract="yes" final="no" relationshipType="ponyuniverse:attendTo" xmlns:ponyuniverse="http://winery.opentosca.org/test/ponyuniverse">
+		<DerivedFrom relationshipTypeImplementationRef="fruits7:kiwi_implementation" xmlns:fruits7="http://winery.opentosca.org/test/relationshiptypeimplementations/fruits"/>
+	</RelationshipTypeImplementation>
+</Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/relationshiptypeimplementations/kiwi_initial_inheritance.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/relationshiptypeimplementations/kiwi_initial_inheritance.json
@@ -1,0 +1,5 @@
+{
+	"isAbstract": "no",
+	"isFinal": "no",
+	"derivedFrom": "(none)"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/jar_inheritance.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/jar_inheritance.json
@@ -1,0 +1,5 @@
+{
+	"derivedFrom": "{http://winery.opentosca.org/test/artifacttypes/fruits}WAR",
+	"isAbstract": "no",
+	"isFinal": "no"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/jar_inheritance.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/jar_inheritance.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Definitions targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits" id="winery-defs-for_wfa-JAR" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:testwineryopentoscaorg="http://test.winery.opentosca.org">
+	<ArtifactType name="JAR" abstract="no" final="no" targetNamespace="http://winery.opentosca.org/test/artifacttypes/fruits">
+		<winery:PropertiesDefinition elementname="properties" namespace="http://winery.opentosca.org/test/artifacttypes/fruits/properties">
+			<winery:properties>
+				<winery:key>Input</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>Configuration</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+		</winery:PropertiesDefinition>
+		<DerivedFrom typeRef="fruits1:WAR" xmlns:fruits1="http://winery.opentosca.org/test/artifacttypes/fruits"/>
+	</ArtifactType>
+</Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/jar_initial_inheritance.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/jar_initial_inheritance.json
@@ -1,0 +1,5 @@
+{
+	"isAbstract": "no",
+	"isFinal": "no",
+	"derivedFrom": "(none)"
+}

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.component.html
@@ -6,9 +6,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter - initial API and implementation
  */
 -->
 <div [class.hidden]="!loading">
@@ -37,11 +34,8 @@
     <ng-select #derivedFromSelector
                [items]="availableSuperClasses"
                (selected)="onSelectedValueChanged($event)"
-               [active]="initialActiveItem"
-    ></ng-select>
+               [active]="initialActiveItem">
+    </ng-select>
     <br>
-    <button class="btn btn-info btn-sm"
-            [routerLink]="openSuperClassLink">
-            open
-    </button>
+    <button class="btn btn-info btn-sm" [disabled]="!enableButton" (click)="onButtonClick()">open</button>
 </div>

--- a/org.eclipse.winery.repository.ui/src/app/wineryInterfaces/selectData.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryInterfaces/selectData.ts
@@ -5,9 +5,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter - initial API and implementation
  */
 export class SelectData {
     id: string = null;


### PR DESCRIPTION
This patch fixes the issue of saving Inheritance data. Because of new type enforcement strategies, saving inheritance in other components than Nodetypes wasn't working anymore.
Further the UI is now able to also "remove" the inheritance again.

Signed-off-by: Lukas Harzenetter <lharzenetter@gmx.de>