### PR TITLE
Set readme-component as entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 
 ### Changed
 - Add edit properties as XML
+- Fix serviceTemplate headers and set readme-component as entryPoint
 - Fix lifecycle interface is now selected after click on "generate lifecycle interface"
 - Add available/not available indicator for LFS in git log component
 - Add ZIP-button for artifactemplate-files

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artictTemplates/artifactTemplateRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artictTemplates/artifactTemplateRouter.module.ts
@@ -38,7 +38,7 @@ const artifactTemplateRoutes: Routes = [
             { path: 'properties', component: PropertiesComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'files', pathMatch: 'full'}
+            { path: '', redirectTo: 'readme', pathMatch: 'full'}
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artifactTypes/artifactTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/artifactTypes/artifactTypeRouter.module.ts
@@ -41,7 +41,7 @@ const artifactTypeRoutes: Routes = [
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
             { path: 'templates', component: ImplementationsComponent },
-            { path: '', redirectTo: 'propertiesdefinition', pathMatch: 'full' }
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/capabilityTypes/capabilityTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/capabilityTypes/capabilityTypeRouter.module.ts
@@ -50,7 +50,7 @@ const capabilityTypeRoutes: Routes = [
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'propertiesdefinition', pathMatch: 'full' }
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypeImplementations/nodeTypeImplementationRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypeImplementations/nodeTypeImplementationRouter.module.ts
@@ -37,7 +37,7 @@ const nodeTypeImplementationRoutes: Routes = [
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'implementationartifacts', pathMatch: 'full' }
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypes/nodeTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypes/nodeTypeRouter.module.ts
@@ -50,7 +50,7 @@ const nodeTypeRoutes: Routes = [
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'visualappearance', pathMatch: 'full'}
+            { path: '', redirectTo: 'readme', pathMatch: 'full'}
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTemplates/policyTemplateRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTemplates/policyTemplateRouter.module.ts
@@ -34,7 +34,7 @@ const policyTemplateRoutes: Routes = [
             { path: 'properties', component: PropertiesComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'properties', pathMatch: 'full' }
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyTypeRouter.module.ts
@@ -42,7 +42,7 @@ const policyTypeRoutes: Routes = [
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
             { path: 'templates', component: ImplementationsComponent },
-            { path: '', redirectTo: 'language', pathMatch: 'full' }
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
 
         ]
     }

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypeImplementations/relationshipTypeImplementationRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypeImplementations/relationshipTypeImplementationRouter.module.ts
@@ -36,7 +36,7 @@ const relationshipTypeImplementationRoutes: Routes = [
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'implementationartifacts', pathMatch: 'full' }
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypes/relationshipTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypes/relationshipTypeRouter.module.ts
@@ -47,7 +47,7 @@ const relationshipTypeRoutes: Routes = [
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'visualappearance', pathMatch: 'full' }
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/requirementTypes/requirementTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/requirementTypes/requirementTypeRouter.module.ts
@@ -38,7 +38,7 @@ const requirementTypeRoutes: Routes = [
             { path: 'inheritance', component: InheritanceComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'requiredcapabilitytype', pathMatch: 'full' }
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]
     }
 ];

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/serviceTemplates/serviceTemplateRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/serviceTemplates/serviceTemplateRouter.module.ts
@@ -56,7 +56,7 @@ const serviceTemplateRoutes: Routes = [
             { path: 'tags', component: TagComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
-            { path: '', redirectTo: 'topologytemplate', pathMatch: 'full' }
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]
     }
 ];


### PR DESCRIPTION
Set readme-submenu as entry point for each component

![grafik](https://user-images.githubusercontent.com/23094908/31308517-54e96536-ab78-11e7-8fa2-341f651a25b0.png)

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
