### PR TITLE
Focus name inputForm when Add modal of propertydefinitions is shown

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
@@ -37,7 +37,8 @@
     <div>
         <div *ngIf="(resourceApiData.selectedValue === propertiesEnum.Element
             || resourceApiData.selectedValue === propertiesEnum.Type)">
-            <ng-select [items]="selectItems" (selected)="xmlValueSelected($event)" [active]="[activeElement]"></ng-select>
+            <ng-select [items]="selectItems" (selected)="xmlValueSelected($event)"
+                       [active]="[activeElement]"></ng-select>
         </div>
 
         <div *ngIf="resourceApiData.selectedValue === propertiesEnum.Custom">
@@ -60,7 +61,8 @@
                                [(ngModel)]="resourceApiData.winerysPropertiesDefinition.elementName">
                     </div>
                     <div class="wrapperTabButtom">
-                        <winery-namespace-selector [(ngModel)]="resourceApiData.winerysPropertiesDefinition.namespace"></winery-namespace-selector>
+                        <winery-namespace-selector
+                            [(ngModel)]="resourceApiData.winerysPropertiesDefinition.namespace"></winery-namespace-selector>
                     </div>
                 </tab>
             </tabset>
@@ -68,14 +70,16 @@
     </div>
 </div>
 
-<winery-modal bsModal #addModal="bs-modal" [modalRef]="addModal">
+<winery-modal bsModal #addModal="bs-modal" [modalRef]="addModal"
+              (onShown)="onAddModalShown();" (onHide)="addPropertyFrom.reset();">
     <winery-modal-header [title]="'Add Property'">
     </winery-modal-header>
     <winery-modal-body>
         <form #addPropertyFrom="ngForm" id="addPropertyForm">
             <div class="form-group">
                 <label class="control-label" for="key">Name</label>
-                <input #propName="ngModel"
+                <input #nameInputForm
+                       #propName="ngModel"
                        id="key"
                        class="form-control"
                        type="text"

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
@@ -6,7 +6,7 @@
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
  */
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { InstanceService } from '../../instance.service';
 import { PropertiesDefinitionService } from './propertiesDefinition.service';
 import {
@@ -49,6 +49,7 @@ export class PropertiesDefinitionComponent implements OnInit {
     validatorObject: WineryValidatorObject;
     @ViewChild('confirmDeleteModal') confirmDeleteModal: ModalDirective;
     @ViewChild('addModal') addModal: ModalDirective;
+    @ViewChild('nameInputForm') nameInputForm: ElementRef;
 
     constructor(private sharedData: InstanceService, private service: PropertiesDefinitionService,
                 private notify: WineryNotificationService) {
@@ -232,6 +233,10 @@ export class PropertiesDefinitionComponent implements OnInit {
         this.confirmDeleteModal.hide();
         this.deleteItemFromPropertyDefinitionKvList(this.elementToRemove);
         this.elementToRemove = null;
+    }
+
+    onAddModalShown() {
+        this.nameInputForm.nativeElement.focus();
     }
 
     // endregion


### PR DESCRIPTION
Focus name inputForm when Add-modal of propertydefinitions is shown.

![grafik](https://user-images.githubusercontent.com/23094908/31315613-1caef7fe-ac1c-11e7-870d-8be3a7540124.png)

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
