### PR TITLE
Fix Interfaces For Nodetypes in Boundary Definitions > Interfaces

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/interfaces/interfaces.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/interfaces/interfaces.service.ts
@@ -36,7 +36,7 @@ export class InterfacesService {
         } else if (relationshipInterfaces) {
             return this.getRelationshipInterfaces(url);
         } else {
-            return this.get(url + '/interfaces/')
+            return this.get(backendBaseURL + url + '/interfaces/')
                 .map(res => res.json());
         }
     }

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/interfaces/targetInterface/wineryTargetInterface.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/interfaces/targetInterface/wineryTargetInterface.component.html
@@ -6,9 +6,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter - initial API and implementation
  */
 -->
 <form *ngIf="operation">

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/interfaces/targetInterface/wineryTargetInterface.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/interfaces/targetInterface/wineryTargetInterface.component.ts
@@ -5,9 +5,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter - initial API and implementation
  */
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { InterfaceOperationApiData, InterfacesApiData } from '../interfacesApiData';


### PR DESCRIPTION
The back-end url wasn't set correctly for getting the interfaces of a specific nodetype.

Signed-off-by: Lukas Harzenetter <lharzenetter@gmx.de>
