### PR TITLE
Fix warning that orion built-editor sourceMaps cannot be found

### DIFF
--- a/org.eclipse.winery.repository.ui/pom.xml
+++ b/org.eclipse.winery.repository.ui/pom.xml
@@ -41,14 +41,14 @@
                 <version>1.3.0</version>
                 <executions>
                     <execution>
-                        <phase>generate-resources</phase>
+                        <phase>generate-sources</phase>
                         <id>download-orion-editor</id>
                         <goals>
                             <goal>wget</goal>
                         </goals>
                         <configuration>
                             <!-- we have to use the mirror URL as
-                            (1) https://www.eclipse.org/downloads/download.php?file=/orion/drops/R-8.0-201502161823/built-editor.zip&amp;mirror_id=96 leads to an HTML page
+                            (1) https://www.eclipse.org/downloads/download.php?file=/orion/drops/R-16.0-201710030941/built-editor.zip&amp;mirror_id=96 leads to an HTML page
                             (2) downloads.eclipse.org suffers from DDoS attacks from time to time - see https://bugs.eclipse.org/bugs/show_bug.cgi?id=515596#c73
                             -->
                             <url>http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/orion/drops/R-16.0-201710030941/built-editor.zip</url>
@@ -56,6 +56,34 @@
                             <unpack>true</unpack>
                             <outputDirectory>orion/editor</outputDirectory>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-all</artifactId>
+                        <version>2.1.7</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <!-- this is required because the built-editor.js expects the source map files to be in the orion/editor directory-->
+                        <phase>process-sources</phase>
+                        <id>default-cli</id>
+                        <configuration>
+                            <target>
+                                <copy todir="${project.basedir}/orion/editor" overwrite="true">
+                                    <fileset dir="${project.basedir}/orion/editor/sourcemaps" />
+                                </copy>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Signed-off-by: Lukas Balzer <balzer814_dev@web.de>

Fix warning that occured when trying to run ng serve because the orion built-editor.js.map was located inside a sourcemaps folder instead of the root directory

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
