### PR TITLE
Implement namespace filtering and forbid spaces in namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ## [unreleased]
 
 ### Changed
+- Add error message if entered namespace contains a whitespace
+- Add filtering to namespaces to filter non allowed namespaces 
 - Add possibility to work with sub directories in artifact templates
 - Add overwrite option in dialog for importing CSARs
 - Add error notification in case of backend is not available

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TDocumentation.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TDocumentation.java
@@ -25,6 +25,8 @@ import javax.xml.bind.annotation.XmlMixed;
 import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
+import org.eclipse.winery.model.tosca.constants.Namespaces;
+
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.w3c.dom.Element;
@@ -61,7 +63,7 @@ public class TDocumentation {
     @XmlAttribute(name = "source")
     @XmlSchemaType(name = "anyURI")
     protected String source;
-    @XmlAttribute(name = "lang", namespace = "http://www.w3.org/XML/1998/namespace")
+    @XmlAttribute(name = "lang", namespace = Namespaces.W3C_NAMESPACE_URI)
     protected String lang;
 
     @Override

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/constants/Namespaces.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/constants/Namespaces.java
@@ -11,18 +11,32 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.constants;
 
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.XMLConstants;
+
 /**
  * Defines namespace constants not available in Java7's XMLConstants
  */
 public class Namespaces {
 
-	public static final String TOSCA_NAMESPACE = "http://docs.oasis-open.org/tosca/ns/2011/12";
-	public static final String TOSCA_WINERY_EXTENSIONS_NAMESPACE = "http://www.opentosca.org/winery/extensions/tosca/2013/02/12";
+    public static final String EXAMPLE_NAMESPACE_URI = "http://www.example.org";
+    
+    public static final String TOSCA_NAMESPACE = "http://docs.oasis-open.org/tosca/ns/2011/12";
+    public static final String TOSCA_WINERY_EXTENSIONS_NAMESPACE = "http://www.opentosca.org/winery/extensions/tosca/2013/02/12";
+    
+    public static final String URI_BPMN20_MODEL = "http://www.omg.org/spec/BPMN/20100524/MODEL";
+    public static final String URI_BPMN4TOSCA_20 = "http://www.opentosca.org/bpmn4tosca";
+    public static final String URI_BPEL20_ABSTRACT = "http://docs.oasis-open.org/wsbpel/2.0/process/abstract";
+    public static final String URI_BPEL20_EXECUTABLE = "http://docs.oasis-open.org/wsbpel/2.0/process/executable";
+    public static final String URI_OPENTOSCA_NODETYPE = "http://www.opentosca.org/nodetypes";
+    
+    // XML Schema namespace is defined at Java7's XMLConstants.W3C_XML_SCHEMA_NS_URI
+    public static final String W3C_XML_SCHEMA_NS_URI = XMLConstants.W3C_XML_SCHEMA_NS_URI;
+    public static final String W3C_NAMESPACE_URI = "http://www.w3.org/XML/1998/namespace";
 
-	// XML Schema namespace is defined at Java7's XMLConstants.W3C_XML_SCHEMA_NS_URI
-
-	public static final String URI_BPMN20_MODEL = "http://www.omg.org/spec/BPMN/20100524/MODEL";
-	public static final String URI_BPMN4TOSCA_20 = "http://www.opentosca.org/bpmn4tosca";
-	public static final String URI_BPEL20_ABSTRACT = "http://docs.oasis-open.org/wsbpel/2.0/process/abstract";
-	public static final String URI_BPEL20_EXECUTABLE = "http://docs.oasis-open.org/wsbpel/2.0/process/executable";
+    public static List<String> getDisallowedNamespaces() {
+        return Arrays.asList(TOSCA_NAMESPACE, TOSCA_WINERY_EXTENSIONS_NAMESPACE, W3C_NAMESPACE_URI, W3C_XML_SCHEMA_NS_URI, URI_BPEL20_ABSTRACT, URI_BPEL20_EXECUTABLE);
+    }
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/NamespacesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/NamespacesResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -36,11 +37,13 @@ import javax.ws.rs.core.Response.Status;
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.common.ids.Namespace;
 import org.eclipse.winery.common.ids.admin.NamespacesId;
+import org.eclipse.winery.model.tosca.constants.Namespaces;
 import org.eclipse.winery.repository.backend.NamespaceManager;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.backend.filebased.ConfigurationBasedNamespaceManager;
 import org.eclipse.winery.repository.rest.resources.apiData.NamespaceWithPrefix;
 
+import io.swagger.annotations.ApiParam;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,15 +153,23 @@ public class NamespacesResource extends AbstractAdminResource {
 	 */
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
-	public List<NamespaceWithPrefix> getNamespacesAsJSONlist() {
+	public List<NamespaceWithPrefix> getNamespacesAsJSONlist(
+		@ApiParam(value = "if set all namespaces are returned otherwise the list will be filtered by disallowed namespaces", required = false) @QueryParam("all") String allNamespaces) {
 		Collection<Namespace> namespaces = this.getNamespaces();
 
 		// We now have all namespaces
+		// We need to check if the "all" parameter has been set and filter accordingly
 		// We need to convert from Namespace to String
 
 		List<NamespaceWithPrefix> namespacesList = new ArrayList<>();
 		for (Namespace ns : namespaces) {
-			namespacesList.add(new NamespaceWithPrefix(ns, this.namespaceManager.getPrefix(ns.getDecoded())));
+			if (allNamespaces == null) {
+				if (!Namespaces.getDisallowedNamespaces().contains(ns.getDecoded())) {
+					namespacesList.add(new NamespaceWithPrefix(ns, this.namespaceManager.getPrefix(ns.getDecoded())));
+				}
+			} else {
+				namespacesList.add(new NamespaceWithPrefix(ns, this.namespaceManager.getPrefix(ns.getDecoded())));
+			}
 		}
 		Collections.sort(namespacesList);
 		return namespacesList;

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/admin/NamespaceResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/admin/NamespaceResourceTest.java
@@ -21,8 +21,8 @@ public class NamespaceResourceTest extends AbstractResourceTest {
 	@Test
 	public void getNamespaceList() throws Exception {
 		this.setRevisionTo("8b57ea031ea0786a46ef8338ed322db886a77cd6");
-		this.assertGet("admin/namespaces/", "entitytypes/admin/namspacesList.json");
-		this.assertGetSize("admin/namespaces/", 13);
+		this.assertGet("admin/namespaces/?all", "entitytypes/admin/namspacesList.json");
+		this.assertGetSize("admin/namespaces/?all", 13);
 	}
 
 }

--- a/org.eclipse.winery.repository.ui/src/app/instance/admin/namespaces/namespaces.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/admin/namespaces/namespaces.component.html
@@ -6,9 +6,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Niko Stadelmaier - initial API and implementation
  */
 -->
 <div [class.hidden]="!loading">
@@ -65,14 +62,15 @@
                         </div>
                     </div>
                 </div>
-
+                <!-- pattern parameter is required to enable form validation -->
                 <winery-namespace-selector
                     #namespace
                     name="namespaceSelector"
                     [(ngModel)]="newNamespace.namespace"
                     [isRequired]="true"
                     [typeAheadListLimit]="20"
-                    required>
+                    required
+                    pattern="^\S*$">
                 </winery-namespace-selector>
 
             </form>

--- a/org.eclipse.winery.repository.ui/src/app/instance/admin/namespaces/namespaces.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/admin/namespaces/namespaces.service.ts
@@ -26,7 +26,7 @@ export class NamespacesService {
     }
 
     getAllNamespaces(): Observable<NamespaceWithPrefix[]> {
-        return this.namespaceService.getAllNamespaces();
+        return this.namespaceService.getNamespaces(true);
     }
 
     postNamespaces(namespaces: NamespaceWithPrefix[]): Observable<Response> {

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/implementations/implementations.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/implementations/implementations.component.html
@@ -51,9 +51,11 @@
                 </div>
             </div>
             <div class="form-group">
+                <!-- pattern parameter is required to enable form validation -->
                 <winery-namespace-selector
                     name="namespaceSelector"
                     required
+                    pattern="^\S*$"
                     [isRequired]="true"
                     [typeAheadListLimit]="20"
                     [(ngModel)]="selectedNamespace">

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
@@ -61,8 +61,9 @@
                                [(ngModel)]="resourceApiData.winerysPropertiesDefinition.elementName">
                     </div>
                     <div class="wrapperTabButtom">
+                        <!-- pattern parameter is required to enable form validation -->
                         <winery-namespace-selector
-                            [(ngModel)]="resourceApiData.winerysPropertiesDefinition.namespace"></winery-namespace-selector>
+                            [(ngModel)]="resourceApiData.winerysPropertiesDefinition.namespace" pattern="^\S*$"></winery-namespace-selector>
                     </div>
                 </tab>
             </tabset>

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.html
@@ -78,11 +78,14 @@
                     </div>
                 </div>
             </div>
-            <winery-namespace-selector
-                name="namespace"
-                required
-                [(ngModel)]="newComponentNamespace"
-                [isRequired]="true">
+            <!-- pattern parameter is required to enable form validation -->
+            <winery-namespace-selector #ns
+                                       name="namespace"
+                                       required
+                                       pattern="^\S*$"
+                                       [(ngModel)]="newComponentNamespace"
+                                       (onChange)="namespaceChanged($event)"
+                                       [isRequired]="true">
             </winery-namespace-selector>
             <div class="form-group" *ngIf="types">
                 <label for="typeSelect" class="control-label">Type</label>
@@ -95,7 +98,7 @@
         (onOk)="addComponent()"
         [closeButtonLabel]="'Cancel'"
         [okButtonLabel]="'Add'"
-        [disableOkButton]="!(addComponentForm?.form.valid && newComponentNamespace?.length > 0)">
+        [disableOkButton]="!formValid">
     </winery-modal-footer>
 </winery-modal>
 

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
@@ -55,6 +55,7 @@ export class SectionComponent implements OnInit, OnDestroy {
     overwriteValue = false;
 
     importXsdSchemaType: string;
+    formValid: boolean;
 
     newComponentName: string;
     newComponentNamespace: string;
@@ -62,6 +63,7 @@ export class SectionComponent implements OnInit, OnDestroy {
     validatorObject: WineryValidatorObject;
 
     fileUploadUrl = backendBaseURL + '/';
+    namespaceValid: boolean;
 
     @ViewChild('addModal') addModal: ModalDirective;
     @ViewChild('removeElementModal') removeElementModal: ModalDirective;
@@ -230,5 +232,10 @@ export class SectionComponent implements OnInit, OnDestroy {
     private handleError(error: Response): void {
         this.loading = false;
         this.notify.error(error.toString());
+    }
+
+    namespaceChanged(event: any) {
+        this.namespaceValid = event;
+        this.formValid = this.namespaceValid && this.addComponentForm.valid;
     }
 }

--- a/org.eclipse.winery.repository.ui/src/app/wineryComponentExists/wineryComponentExists.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryComponentExists/wineryComponentExists.component.html
@@ -6,9 +6,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter - initial API and implementation
  */
 -->
 <div class="form-group-grouping typeimplementation">
@@ -25,10 +22,12 @@
         <ng-template #reuseArtifact>
             <div class="alert alert-info">Will be reused.</div>
         </ng-template>
+        <!-- pattern parameter is required to enable form validation -->
         <winery-namespace-selector
             name="artifactNamespace"
             [(ngModel)]="generateData.namespace"
-            (onChange)="checkImplementationExists();">
+            (onChange)="checkImplementationExists();"
+            pattern="^\S*$">
         </winery-namespace-selector>
     </div>
 </div>

--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.html
@@ -6,10 +6,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter - initial API and implementation
- *     Niko Stadelmaier - add namespace filed option
  */
 -->
 <div [class.hidden]="!loading">
@@ -26,11 +22,15 @@
            [typeaheadOptionsLimit]="typeAheadListLimit"
            [(ngModel)]="selectedNamespace"
            #namespace="ngModel"
-           [required]="isRequired">
-    <div *ngIf="isRequired && namespace.errors && (namespace.dirty || namespace.touched)"
+           [required]="isRequired"
+           pattern="^\S*$">
+    <div *ngIf="namespace.errors && (namespace.dirty || namespace.touched)"
          class="alert alert-danger">
         <div [hidden]="!namespace.errors.required">
             Namespace is required!
+        </div>
+        <div [hidden]="!namespace.errors.pattern">
+            Namespace must not contain spaces!
         </div>
     </div>
 </div>

--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
@@ -6,7 +6,7 @@
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
  */
-import { Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, forwardRef, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { WineryNamespaceSelectorService } from './wineryNamespaceSelector.service';
 import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -70,6 +70,9 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
     @Input() isRequired = false;
     @Input() typeAheadListLimit = 50;
     @Output() onChange = new EventEmitter<any>();
+    isValid: boolean;
+
+    @ViewChild('namespace') input: any;
 
     loading = true;
     allNamespaces: NamespaceWithPrefix[] = [];
@@ -82,7 +85,7 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
     }
 
     ngOnInit() {
-        this.service.getAllNamespaces()
+        this.service.getNamespaces()
             .subscribe(
                 data => {
                     this.allNamespaces = data;
@@ -100,7 +103,8 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
         if (v !== this.innerValue) {
             this.innerValue = v;
             this.onChangeCallback(v);
-            this.onChange.emit();
+            this.isValid = this.input.valid;
+            this.onChange.emit(this.isValid);
         }
     }
 

--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.service.ts
@@ -18,11 +18,16 @@ export class WineryNamespaceSelectorService {
     constructor(private http: Http) {
     }
 
-    getAllNamespaces(): Observable<NamespaceWithPrefix[]> {
+    getNamespaces(all: boolean = false): Observable<NamespaceWithPrefix[]> {
         const headers = new Headers({'Accept': 'application/json'});
         const options = new RequestOptions({headers: headers});
-
-        return this.http.get(backendBaseURL + '/admin/namespaces/', options)
+        let URL: string;
+        if (all) {
+            URL = backendBaseURL + '/admin/namespaces/?all';
+        } else {
+            URL = backendBaseURL + '/admin/namespaces/';
+        }
+        return this.http.get(URL, options)
             .map(res => res.json());
     }
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
@@ -32,14 +32,14 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
 		// globally set prefixes
 
 		// if that behavior is not desired, the code has to be moved to "generatePrefix" which checks for existence, ...
-		this.configuration.setProperty("http://www.w3.org/2001/XMLSchema", "xsd");
-		this.configuration.setProperty("http://www.w3.org/XML/1998/namespace", "xmlns");
 		this.configuration.setProperty(Namespaces.TOSCA_NAMESPACE, "tosca");
 		this.configuration.setProperty(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "winery");
+		this.configuration.setProperty(Namespaces.W3C_XML_SCHEMA_NS_URI, "xsd");
+		this.configuration.setProperty(Namespaces.W3C_NAMESPACE_URI, "xmlns");
 
 		// example namespaces opened for users to create new types
-		this.configuration.setProperty("http://www.example.org", "ex");
-		this.configuration.setProperty("http://www.opentosca.org/nodetypes", "otnt");
+		this.configuration.setProperty(Namespaces.EXAMPLE_NAMESPACE_URI, "ex");
+		this.configuration.setProperty(Namespaces.URI_OPENTOSCA_NODETYPE, "otnt");
 	}
 
 	@Override


### PR DESCRIPTION
Implemented namespace filtering. Some default namespaces should not be provided in the auto-completion therefore they are filtered out in the backend. 
Further, the namespace-selector will not allow namespaces that contain whitespaces and display an error message.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added (for UI changes)
![namespacewitherror](https://user-images.githubusercontent.com/23076947/31472723-a2e3d412-aef0-11e7-8cf4-c2beca7939ae.PNG)
