### PR TITLE
[WIP] Fix properties to be displayed in the same order as in the xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ## [unreleased]
 
 ### Changed
+- Fix properties are now displayed in the same order as in the xml
 - Add possibility to work with sub directories in artifact templates
 - Add overwrite option in dialog for importing CSARs
 - Add error notification in case of backend is not available

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/properties/properties.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/properties/properties.component.ts
@@ -5,9 +5,6 @@
  * and the Apache License 2.0 which both accompany this distribution,
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
- *
- * Contributors:
- *     Lukas Harzenetter - initial API and implementation
  */
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { PropertiesService } from './properties.service';
@@ -75,10 +72,11 @@ export class PropertiesComponent implements OnInit {
             this.properties = data.properties;
         } else {
             this.isXMLData = false;
-            if (!isNullOrUndefined(data.properies)) {
+            if (!isNullOrUndefined(data.properties)) {
                 this.propertyKeys = Object.keys(data.properties);
+                this.propertyKeys.sort();
             }
-            if (this.properties != null && this.propertyKeys.length > 0) {
+            if (this.propertyKeys.length > 0) {
                 this.properties = data.properties;
             }
         }


### PR DESCRIPTION
fix error where properties would not be displayed in the ui at all

Signed-off-by: Tino Stadelmaier <tstadelmaier.github@gmail.com>

- [x] Ensure to use auto format in **all** files
- [x] Change in CHANGELOG.md described
- [x] Screenshots added (for UI changes)

Screenshot xml:
![properties2](https://user-images.githubusercontent.com/23086006/31490646-f4e5a9ee-af44-11e7-89e4-a5e1387dcfdd.PNG)

Screenshot properties component:
![properties1](https://user-images.githubusercontent.com/23086006/31490668-00452314-af45-11e7-9a81-1e75da8b3c18.PNG)


