### PR TITLE
Add template for start of namespace for TOSCA components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 - Added initial CLI. Current funtionality: Consistency check of the repository.
 - Rewrote the Backend UI using Angular
 - org.eclipse.winery.model.tosca was extended with builders and some helper classes
+- Add template start of namespace for the creation of tosca components
 - Fixed wrong output of "CSAR Export mode. Putting XSD into CSAR" if in CSAR export mode
 - New project `org.eclipse.winery.repository.rest` for separating REST resources from the backend
 - Add support of [Splitting](http://eclipse.github.io/winery/user/Splitting)

--- a/org.eclipse.winery.repository.ui/src/app/instance/admin/namespaces/namespaces.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/admin/namespaces/namespaces.component.html
@@ -29,8 +29,8 @@
             </p>
         </winery-modal-body>
         <winery-modal-footer (onOk)="deleteNamespace();"
-                            [closeButtonLabel]="'No'"
-                            [okButtonLabel]="'Yes'">
+                             [closeButtonLabel]="'No'"
+                             [okButtonLabel]="'Yes'">
         </winery-modal-footer>
     </winery-modal>
 
@@ -70,15 +70,17 @@
                     [isRequired]="true"
                     [typeAheadListLimit]="20"
                     required
-                    pattern="^\S*$">
+                    pattern="^\S*$"
+                    [useStartNamespace]="false">
                 </winery-namespace-selector>
-
             </form>
+
         </winery-modal-body>
-        <winery-modal-footer (onOk)="addNamespace(namespace.selectedNamespace, prefixName.value); addNamespaceForm.reset();"
-                            [closeButtonLabel]="'Cancel'"
-                            [okButtonLabel]="'Add'"
-                            [disableOkButton]="!addNamespaceForm?.form.valid">
+        <winery-modal-footer
+            (onOk)="addNamespace(); addNamespaceForm.reset();"
+            [closeButtonLabel]="'Cancel'"
+            [okButtonLabel]="'Add'"
+            [disableOkButton]="!addNamespaceForm?.form.valid">
         </winery-modal-footer>
     </winery-modal>
 </div>

--- a/org.eclipse.winery.repository.ui/src/app/instance/admin/namespaces/namespaces.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/admin/namespaces/namespaces.component.ts
@@ -27,8 +27,8 @@ import { ModalDirective } from 'ngx-bootstrap';
 export class NamespacesComponent implements OnInit {
 
     loading = true;
-    adminNamespaces: Array<any> = [];
-    newNamespace: any = { namespace: '', prefix: '' };
+    adminNamespaces: Array<NamespaceWithPrefix> = [];
+    newNamespace: NamespaceWithPrefix = { prefix: '', namespace: '' };
     validatorObjectPrefix: WineryValidatorObject;
     validatorObjectNamespace: WineryValidatorObject;
 
@@ -61,11 +61,8 @@ export class NamespacesComponent implements OnInit {
         this.getNamespaces();
     }
 
-    addNamespace(namespace: string, prefix: string) {
-        this.adminNamespaces.push({
-            namespace: namespace,
-            prefix: prefix
-        });
+    addNamespace() {
+        this.adminNamespaces.push(this.newNamespace);
         this.save();
     }
 

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/implementations/implementations.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/implementations/implementations.component.html
@@ -58,7 +58,8 @@
                     pattern="^\S*$"
                     [isRequired]="true"
                     [typeAheadListLimit]="20"
-                    [(ngModel)]="selectedNamespace">
+                    [(ngModel)]="selectedNamespace"
+                    [toscaType]="implementationOrTemplate">
                 </winery-namespace-selector>
             </div>
         </form>
@@ -68,7 +69,6 @@
                          [okButtonLabel]="'Add'"
                          [disableOkButton]="!addImplForm?.form.valid">
     </winery-modal-footer>
-
 </winery-modal>
 
 <winery-modal bsModal #confirmDeleteModal="bs-modal" [modalRef]="confirmDeleteModal">

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
@@ -63,7 +63,9 @@
                     <div class="wrapperTabButtom">
                         <!-- pattern parameter is required to enable form validation -->
                         <winery-namespace-selector
-                            [(ngModel)]="resourceApiData.winerysPropertiesDefinition.namespace" pattern="^\S*$"></winery-namespace-selector>
+                            [(ngModel)]="resourceApiData.winerysPropertiesDefinition.namespace" pattern="^\S*$"
+                            [useStartNamespace]="false">
+                        </winery-namespace-selector>
                     </div>
                 </tab>
             </tabset>

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.html
@@ -88,13 +88,14 @@
                 </div>
             </div>
             <!-- pattern parameter is required to enable form validation -->
-            <winery-namespace-selector #ns
+            <winery-namespace-selector #namespaceInput
                                        name="namespace"
                                        required
                                        pattern="^\S*$"
                                        [(ngModel)]="newComponentNamespace"
-                                       (onChange)="namespaceChanged($event)"
-                                       [isRequired]="true">
+                                       [isRequired]="true"
+                                       [useStartNamespace]="true"
+                                       [toscaType]="toscaType">
             </winery-namespace-selector>
             <div class="form-group" *ngIf="types">
                 <label for="typeSelect" class="control-label">Type</label>
@@ -107,7 +108,7 @@
         (onOk)="addComponent()"
         [closeButtonLabel]="'Cancel'"
         [okButtonLabel]="'Add'"
-        [disableOkButton]="!formValid">
+        [disableOkButton]="!addComponentForm.valid">
     </winery-modal-footer>
 </winery-modal>
 

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
@@ -23,6 +23,7 @@ import { Response } from '@angular/http';
 import { ToscaTypes } from '../wineryInterfaces/enums';
 import { Utils } from '../wineryUtils/utils';
 import { WineryUploaderComponent } from '../wineryUploader/wineryUploader.component';
+import { WineryNamespaceSelectorComponent } from '../wineryNamespaceSelector/wineryNamespaceSelector.component';
 
 const showAll = 'Show all Items';
 const showGrouped = 'Group by Namespace';
@@ -72,6 +73,8 @@ export class SectionComponent implements OnInit, OnDestroy {
     @ViewChild('addYamlModal') addYamlModal: ModalDirective;
     @ViewChild('fileUploader') fileUploader: WineryUploaderComponent;
 
+    @ViewChild('namespaceInput') namespaceInput: WineryNamespaceSelectorComponent;
+
     constructor(private route: ActivatedRoute,
                 private change: ChangeDetectorRef,
                 private router: Router,
@@ -118,8 +121,10 @@ export class SectionComponent implements OnInit, OnDestroy {
         this.change.detectChanges();
         this.addComponentForm.reset();
 
-        this.newComponentNamespace = (this.showNamespace !== 'all' && this.showNamespace !== 'group') ? this.showNamespace : '';
         this.newComponentSelectedType = this.types ? this.types[0].children[0] : null;
+        this.newComponentNamespace = (this.showNamespace !== 'all' && this.showNamespace !== 'group') ? this.showNamespace : '';
+        this.namespaceInput.writeValue(this.newComponentNamespace);
+
         this.addModal.show();
     }
 
@@ -163,7 +168,7 @@ export class SectionComponent implements OnInit, OnDestroy {
 
         this.fileUploader.getUploader().setOptions({
             url: this.fileUploadUrl,
-            additionalParameter: {'overwrite': this.overwriteValue}
+            additionalParameter: { 'overwrite': this.overwriteValue }
         });
     }
 
@@ -235,8 +240,4 @@ export class SectionComponent implements OnInit, OnDestroy {
         this.notify.error(error.toString());
     }
 
-    namespaceChanged(event: any) {
-        this.namespaceValid = event;
-        this.formValid = this.namespaceValid && this.addComponentForm.valid;
-    }
 }

--- a/org.eclipse.winery.repository.ui/src/app/wineryComponentExists/wineryComponentExists.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryComponentExists/wineryComponentExists.component.html
@@ -27,6 +27,7 @@
             name="artifactNamespace"
             [(ngModel)]="generateData.namespace"
             (onChange)="checkImplementationExists();"
+            [useStartNamespace]="false"
             pattern="^\S*$">
         </winery-namespace-selector>
     </div>

--- a/org.eclipse.winery.repository.ui/src/app/wineryInterfaces/enums.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryInterfaces/enums.ts
@@ -9,7 +9,7 @@
 
 export enum YesNoEnum {
     YES = 'YES',
-    NO = 'NO'
+    NO  = 'NO'
 }
 
 /**
@@ -20,19 +20,19 @@ export enum YesNoEnum {
  * Default is assumed ToscaTypes.Admin.
  */
 export enum ToscaTypes {
-    ServiceTemplate = 'servicetemplates',
-    NodeType = 'nodetypes',
-    RelationshipType = 'relationshiptypes',
-    ArtifactType = 'artifacttypes',
-    ArtifactTemplate = 'artifacttemplates',
-    RequirementType = 'requirementtypes',
-    CapabilityType = 'capabilitytypes',
-    NodeTypeImplementation = 'nodetypeimplementations',
+    ServiceTemplate                = 'servicetemplates',
+    NodeType                       = 'nodetypes',
+    RelationshipType               = 'relationshiptypes',
+    ArtifactType                   = 'artifacttypes',
+    ArtifactTemplate               = 'artifacttemplates',
+    RequirementType                = 'requirementtypes',
+    CapabilityType                 = 'capabilitytypes',
+    NodeTypeImplementation         = 'nodetypeimplementations',
     RelationshipTypeImplementation = 'relationshiptypeimplementations',
-    PolicyType = 'policytypes',
-    PolicyTemplate = 'policytemplates',
-    Imports = 'imports',
-    Admin = 'admin'
+    PolicyType                     = 'policytypes',
+    PolicyTemplate                 = 'policytemplates',
+    Imports                        = 'imports',
+    Admin                          = 'admin'
 }
 
 /**
@@ -40,17 +40,22 @@ export enum ToscaTypes {
  * The types of these templates can be retrieved by using the {@link Utils.getTypeOfServiceTemplateTemplate} method.
  */
 export enum ServiceTemplateTemplateTypes {
-    CapabilityTemplate = 'capabilityTemplates',
-    NodeTemplate = 'nodeTemplates',
+    CapabilityTemplate   = 'capabilityTemplates',
+    NodeTemplate         = 'nodeTemplates',
     RelationshipTemplate = 'relationshipTemplates',
-    RequirementTemplate = 'requirementTemplates'
+    RequirementTemplate  = 'requirementTemplates'
+}
+
+export enum StartNamespaces {
+    LocalStorageEntry     = 'defaultNamespace',
+    DefaultStartNamespace = 'http://www.example.org/tosca'
 }
 
 /**
  * BackendAvailabilityStates defines the states for the availability of the backend.
  */
 export enum BackendAvailabilityStates {
-    Available = 1,
+    Available   = 1,
     Unavailable = 0,
-    Undefined = -1
+    Undefined   = -1
 }

--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.html
@@ -14,14 +14,14 @@
 <div *ngIf="!loading" class="form-group">
     <label for="namespace">Namespace</label>
     <input #namespaceInput
-        id="namespace"
+           id="namespace"
            class="form-control"
            name="namespace"
            autocomplete=off
            [typeahead]="allNamespaces"
            typeaheadOptionField="namespace"
            [typeaheadOptionsLimit]="typeAheadListLimit"
-           [(ngModel)]="selectedNamespace"
+           [(ngModel)]="namespaceValue"
            #namespace="ngModel"
            [required]="isRequired"
            pattern="^\S*$">
@@ -32,6 +32,30 @@
         </div>
         <div [hidden]="!namespace.errors.pattern">
             Namespace must not contain spaces!
+        </div>
+    </div>
+    <div *ngIf="useStartNamespace" style="margin-top: 20px">
+        <label for="initNamespace" class="control-label">Template: Start of namespace URI - used for automatic
+            namespace URI generation</label>
+        <div style="display: flex;">
+            <input #initNamespace
+                   type="text"
+                   class="form-control"
+                   id="initNamespace"
+                   name="initNamespace"
+                   #namespaceStart="ngModel"
+                   [(ngModel)]="initNamespaceString">
+            <button style="margin-left: 10px; width: 15%;" class="bnt btn-primary" (click)="applyNamespace()">Apply
+            </button>
+        </div>
+        <div *ngIf="namespaceStart.errors && (namespaceStart.dirty || namespaceStart.touched)"
+             class="alert alert-danger">
+            <div [hidden]="!namespaceStart.errors.required">
+                Namespace is required!
+            </div>
+            <div [hidden]="!namespaceStart.errors.pattern">
+                Namespace must not contain spaces!
+            </div>
         </div>
     </div>
 </div>

--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
@@ -6,11 +6,13 @@
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
  */
-import { Component, ElementRef, EventEmitter, forwardRef, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, forwardRef, Input, OnInit, ViewChild } from '@angular/core';
 import { WineryNamespaceSelectorService } from './wineryNamespaceSelector.service';
 import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NamespaceWithPrefix } from '../wineryInterfaces/namespaceWithPrefix';
+import { StartNamespaces, ToscaTypes } from '../wineryInterfaces/enums';
+import { isNullOrUndefined } from 'util';
 
 const noop = () => {
 };
@@ -69,23 +71,24 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
 
     @Input() isRequired = false;
     @Input() typeAheadListLimit = 50;
-    @Output() onChange = new EventEmitter<any>();
-    isValid: boolean;
-
-    @ViewChild('namespace') input: any;
-    @ViewChild('namespaceInput') namespaceInput: ElementRef;
+    @Input() toscaType: ToscaTypes;
+    @Input() useStartNamespace = true;
 
     loading = true;
     allNamespaces: NamespaceWithPrefix[] = [];
 
-    private innerValue = '';
+    @ViewChild('namespaceInput') namespaceInput: ElementRef;
+    private initNamespaceString = '';
+    private innerNamespaceValue = '';
+
     private onTouchedCallback: () => void = noop;
-    private onChangeCallback: (_: any) => void = noop;
+    private propagateChange: (_: any) => void = noop;
 
     constructor(private service: WineryNamespaceSelectorService, private notify: WineryNotificationService) {
     }
 
     ngOnInit() {
+        this.getDefaultNamespace();
         this.service.getNamespaces()
             .subscribe(
                 data => {
@@ -96,31 +99,59 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
             );
     }
 
-    get selectedNamespace(): string {
-        return this.innerValue;
+    get namespaceValue(): string {
+        return this.innerNamespaceValue;
     }
 
-    set selectedNamespace(v: string) {
-        if (v !== this.innerValue) {
-            this.innerValue = v;
-            this.onChangeCallback(v);
-            this.isValid = this.input.valid;
-            this.onChange.emit(this.isValid);
+    set namespaceValue(value: string) {
+        this.innerNamespaceValue = value;
+        this.propagateChange(this.innerNamespaceValue);
+        if (this.namespaceInput) {
             this.namespaceInput.nativeElement.focus();
         }
     }
 
+    applyNamespace() {
+        localStorage.setItem(StartNamespaces.LocalStorageEntry.toString(), this.initNamespaceString);
+        this.namespaceValue = this.initNamespaceString !== '' ? this.applyToscaTypeToNamespace(this.initNamespaceString) : '';
+    }
+
+    // region ########## ControlValueAccessor Interface ##########
     writeValue(value: string) {
-        if (value !== this.innerValue) {
-            this.innerValue = value;
+        if (value !== this.innerNamespaceValue) {
+            if ((isNullOrUndefined(value) || value.length === 0) && this.useStartNamespace) {
+                // In the case that the namespace is set from outside this component via ngModel, don't overwrite the value set by the parent component.
+                // Otherwise, use the default namespace.
+                if (this.innerNamespaceValue.length === 0) {
+                    this.getDefaultNamespace();
+                    this.namespaceValue = this.applyToscaTypeToNamespace(this.initNamespaceString);
+                } else {
+                    this.namespaceValue = this.innerNamespaceValue;
+                }
+            } else {
+                this.namespaceValue = value;
+            }
         }
     }
 
     registerOnChange(fn: any) {
-        this.onChangeCallback = fn;
+        this.propagateChange = fn;
     }
 
     registerOnTouched(fn: any) {
         this.onTouchedCallback = fn;
+    }
+
+    // endregion
+
+    private applyToscaTypeToNamespace(namespaceStart: string) {
+        return namespaceStart.endsWith('/') ? namespaceStart + this.toscaType :
+            namespaceStart + '/' + this.toscaType;
+    }
+
+    private getDefaultNamespace() {
+        const storageValue = localStorage.getItem(StartNamespaces.LocalStorageEntry.toString());
+        this.initNamespaceString = isNullOrUndefined(storageValue) || storageValue.length === 0 ?
+            StartNamespaces.DefaultStartNamespace.toString() : storageValue;
     }
 }


### PR DESCRIPTION
Add template functionality to the wineryNamespaceSelector. This part is optional and can be set via the useStartNamespace parameter (default = true). In addtion the toscaType parameter is added to specify the component type

![grafik](https://user-images.githubusercontent.com/23094908/31658057-442290fa-b330-11e7-8def-a9681f736f15.png)


- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] Ensure to use auto format in **all** files
- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
