### PR TITLE
 Set focus to namespace input form after namespace has been selected

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.html
@@ -13,7 +13,8 @@
 </div>
 <div *ngIf="!loading" class="form-group">
     <label for="namespace">Namespace</label>
-    <input id="namespace"
+    <input #namespaceInput
+        id="namespace"
            class="form-control"
            name="namespace"
            autocomplete=off

--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
@@ -73,6 +73,7 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
     isValid: boolean;
 
     @ViewChild('namespace') input: any;
+    @ViewChild('namespaceInput') namespaceInput: ElementRef;
 
     loading = true;
     allNamespaces: NamespaceWithPrefix[] = [];
@@ -105,6 +106,7 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
             this.onChangeCallback(v);
             this.isValid = this.input.valid;
             this.onChange.emit(this.isValid);
+            this.namespaceInput.nativeElement.focus();
         }
     }
 


### PR DESCRIPTION
Fix issue where namespace input form was not focused after namespace was selected from typeahead-functionality.

- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [] Screenshots added (for UI changes)
