### PR TITLE
YAML Parser minor fixes

### DIFF
--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TCapabilityType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TCapabilityType.java
@@ -30,7 +30,7 @@ import org.eclipse.jdt.annotation.NonNull;
     "validSourceTypes"
 })
 public class TCapabilityType extends TEntityType {
-    @XmlAttribute(name = "valid_source_type")
+    @XmlAttribute(name = "valid_source_types")
     private List<QName> validSourceTypes;
 
     public TCapabilityType() {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/visitor/AbstractVisitor.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/visitor/AbstractVisitor.java
@@ -486,9 +486,11 @@ public abstract class AbstractVisitor<R extends AbstractResult<R>, P extends Abs
     private R visitRequirementDefinition(@NonNull List<TMapRequirementDefinition> requirements, P parameter) {
         R result = null;
         for (TMapRequirementDefinition map : requirements) {
-            for (Map.Entry<String, TRequirementDefinition> entry : map.entrySet()) {
-                if (entry.getValue() != null) {
-                    result = addR(result, entry.getValue().accept(this, parameter.copy().addContext("requirements", entry.getKey())));
+            if (map != null) {
+                for (Map.Entry<String, TRequirementDefinition> entry : map.entrySet()) {
+                    if (entry.getValue() != null) {
+                        result = addR(result, entry.getValue().accept(this, parameter.copy().addContext("requirements", entry.getKey())));
+                    }
                 }
             }
         }

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/support/ExceptionInterpreter.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/support/ExceptionInterpreter.java
@@ -38,7 +38,7 @@ public class ExceptionInterpreter {
 
     public YAMLParserException interpret(ScannerException e) {
         String scalarScanning = "while scanning a plain scalar";
-        if (e.getContext().matches(scalarScanning)) {
+        if (e.getContext() != null && e.getContext().matches(scalarScanning)) {
             String unexpected = "found unexpected ':'";
             if (e.getProblem().matches(unexpected)) {
                 String msg = "Using \":\" in values in flow context is invalid \n" +


### PR DESCRIPTION
some minor changes to the parser:
- fixed nullpointer exception. not sure if this is just a workaround, but due to lack of any documentation / test coverage its hard for me to find this out without several hours of senseless investigation
- fixed typo in xml mapping

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
  - total test coverage of parser is approx. 0%, parser needs a serious test suite

