### PR TITLE
Fix minor YAML parser bugs

### DIFF
--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TCapabilityType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TCapabilityType.java
@@ -30,7 +30,7 @@ import org.eclipse.jdt.annotation.NonNull;
     "validSourceTypes"
 })
 public class TCapabilityType extends TEntityType {
-    @XmlAttribute(name = "valid_source_type")
+    @XmlAttribute(name = "valid_source_types")
     private List<QName> validSourceTypes;
 
     public TCapabilityType() {

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/support/ExceptionInterpreter.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/support/ExceptionInterpreter.java
@@ -38,7 +38,7 @@ public class ExceptionInterpreter {
 
     public YAMLParserException interpret(ScannerException e) {
         String scalarScanning = "while scanning a plain scalar";
-        if (e.getContext().matches(scalarScanning)) {
+        if (e.getContext() != null && e.getContext().matches(scalarScanning)) {
             String unexpected = "found unexpected ':'";
             if (e.getProblem().matches(unexpected)) {
                 String msg = "Using \":\" in values in flow context is invalid \n" +

--- a/org.eclipse.winery.yaml.common/src/test/java/org/eclipse/winery/yaml/common/reader/InvalidSyntaxTests.java
+++ b/org.eclipse.winery.yaml.common/src/test/java/org/eclipse/winery/yaml/common/reader/InvalidSyntaxTests.java
@@ -1,0 +1,20 @@
+package org.eclipse.winery.yaml.common.reader;
+
+import org.eclipse.winery.yaml.common.exception.MultiException;
+import org.eclipse.winery.yaml.common.reader.yaml.Reader;
+import org.junit.Test;
+
+/**
+ * Intention of this test class is to test the robustness of the parser
+ * Goal is to see no unexpected exceptions
+ */
+public class InvalidSyntaxTests {
+    
+    private static String PREFIX = "src/test/resources/builder/invalid_syntax";
+    
+    @Test(expected = MultiException.class)
+    public void missingLineBreakThrowsException() throws MultiException {
+       Reader reader = new Reader(); 
+       reader.parse(PREFIX, "missing_linebreak.yaml");
+    }
+}

--- a/org.eclipse.winery.yaml.common/src/test/resources/builder/3_9_3_12-capability_types-1_1.yml
+++ b/org.eclipse.winery.yaml.common/src/test/resources/builder/3_9_3_12-capability_types-1_1.yml
@@ -4,6 +4,7 @@ capability_types:
   DFEndpoint:
     derived_from: tosca.capabilities.Endpoint
     properties:
+    valid_source_types: [ Compute ]
     
   DFFeatures:
     derived_from: tosca.capabilities.Attachment

--- a/org.eclipse.winery.yaml.common/src/test/resources/builder/invalid_syntax/missing_linebreak.yaml
+++ b/org.eclipse.winery.yaml.common/src/test/resources/builder/invalid_syntax/missing_linebreak.yaml
@@ -1,0 +1,2 @@
+tosca_definitions_version: tosca_simple_yaml_1_0 description: test whether parser can handle a missing line break
+


### PR DESCRIPTION
some minor changes to the parser:
- fixed nullpointer exception
- fixed typo in xml mapping

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes


