### PR TITLE
Add support for non-normative TOSCA types to yaml parser

### DIFF
--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/Defaults.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/Defaults.java
@@ -21,6 +21,7 @@ import javax.xml.namespace.QName;
 
 public class Defaults {
     public static final String TOSCA_NORMATIVE_TYPES = "tosca_simple_yaml_1_1.yml";
+    public static final String TOSCA_NONNORMATIVE_TYPES = "tosca_simple_yaml_non-normative_1_1.yml";
     public static final List<String> YAML_TYPES = new ArrayList<>(Arrays.asList("string", "integer", "float", "boolean", "timestamp", "null"));
     public static final List<String> TOSCA_TYPES = new ArrayList<>(Arrays.asList("list", "map"));
     public static final String TOSCA_DEFINITIONS_VERSION_PATTERN = "tosca_simple_yaml_\\d_\\d|http://docs\\.oasis-open\\.org/tosca/ns/simple/yaml/\\d\\.\\d";
@@ -79,8 +80,21 @@ public class Defaults {
         "tosca.policies.Placement",
         "tosca.policies.Scaling",
         "tosca.policies.Update",
-        "tosca.policies.Performance"
+        "tosca.policies.Performance"));
+    
+    public static final List<String> TOSCA_NONNORMATIVE_NAMES = new ArrayList<>(Arrays.asList(
+        "tosca.artifacts.Deployment.Image.Container.Docker", "Image.Container.Docker",
+        "tosca.artifacts.Deployment.Image.VM.ISO", "Image.VM.ISO",
+        "tosca.artifacts.Deployment.Image.VM.QCOW2", "Image.VM.QCOW2",
+        "tosca.capabilities.Container.Docker", "Container.Docker",
+        "tosca.nodes.Database.MySQL", "Database.MySQL",
+        "tosca.nodes.DBMS.MySQL", "DBMS.MySQL",
+        "tosca.nodes.WebServer.Apache", "Apache",
+        "tosca.nodes.WebApplication.WordPress", "WordPress",
+        "tosca.nodes.WebServer.Nodejs", "Nodejs",
+        "tosca.nodes.Container.Application.Docker", "Application.Docker"
     ));
+
     public static final QName IMPLEMENTATION_ARTIFACTS = new QName(Namespaces.TOSCA_NS, "tosca.artifacts.Implementation");
     public static final QName DEPLOYMENT_ARTIFACTS = new QName(Namespaces.TOSCA_NS, "tosca.artifacts.Deployment");
 }

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/reader/yaml/Builder.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/reader/yaml/Builder.java
@@ -284,7 +284,7 @@ public class Builder {
                 this.exceptionMessages.add("Prefix \"" + prefix + "\" for name \"" + localPart + "\" is not defined!");
             }
             return new QName(prefix2Namespace.get(prefix), localPart, prefix);
-        } else if (Defaults.TOSCA_NORMATIVE_NAMES.contains(name)) {
+        } else if (Defaults.TOSCA_NORMATIVE_NAMES.contains(name) || Defaults.TOSCA_NONNORMATIVE_NAMES.contains(name)) {
             return new QName(Namespaces.TOSCA_NS, name, "tosca");
         } else if (Defaults.YAML_TYPES.contains(name)) {
             return new QName(Namespaces.YAML_NS, name, "yaml");

--- a/org.eclipse.winery.yaml.common/src/main/resources/tosca_simple_yaml_non-normative_1_1.yml
+++ b/org.eclipse.winery.yaml.common/src/main/resources/tosca_simple_yaml_non-normative_1_1.yml
@@ -1,0 +1,168 @@
+tosca_definitions_version: tosca_simple_yaml_1_1
+
+description: >
+  Non-normative type definitions from Chapter 9 of TOSCA Simple Profile in
+  YAML Version 1.1 - Candidate OASIS Standard 01.
+
+#---------------------------------------------------------------------------------------------------------------------#
+#
+# Artifact Types
+#
+#---------------------------------------------------------------------------------------------------------------------#
+artifact_types:
+
+  tosca.artifacts.Deployment.Image.Container.Docker:
+    metadata:
+      shorthand_name: Image.Container.Docker
+      type_qualified_name: tosca:Image.Container.Docker
+      type_uri: tosca.artifacts.Deployment.Image.Container.Docker
+    derived_from: tosca.artifacts.Deployment.Image
+    description: Docker Container Image
+    
+  tosca.artifacts.Deployment.Image.VM.ISO:
+    metadata:
+      shorthand_name: Image.VM.ISO
+      type_qualified_name: tosca:Image.VM.ISO
+      type_uri: tosca.artifacts.Deployment.Image.VM.ISO
+    derived_from: tosca.artifacts.Deployment.Image.VM
+    description: Virtual Machine (VM) image in ISO disk format
+    mime_type: application/octet-stream
+    file_ext: [ iso ]
+
+  tosca.artifacts.Deployment.Image.VM.QCOW2:
+    metadata:
+      shorthand_name: Image.VM.QCOW2
+      type_qualified_name: tosca:Image.VM.QCOW2
+      type_uri: tosca.artifacts.Deployment.Image.VM.WCOW2
+    derived_from: tosca.artifacts.Deployment.Image.VM
+    description: Virtual Machine (VM) image in QCOW v2 standard disk format
+    mime_type: application/octet-stream
+    file_ext: [ qcow2 ]
+    
+#---------------------------------------------------------------------------------------------------------------------#
+#
+# Capability Types
+#
+#---------------------------------------------------------------------------------------------------------------------#
+
+capability_types:
+  tosca.capabilities.Container.Docker:
+    metadata:
+      shorthand_name: Container.Docker
+      type_qualified_name: tosca:Container.Docker
+      type_uri: tosca.capabilities.Container.Docker
+    derived_from: tosca.capabilities.Container
+    properties:
+      version:
+        type: list
+        required: false
+        entry_schema:
+         type: version
+      publish_all:
+        type: boolean
+        default: false
+        required: false
+      publish_ports:
+        type: list
+        entry_schema:
+          type: PortSpec
+        required: false
+      expose_ports:
+        type: list
+        entry_schema:
+          type: PortSpec
+        required: false
+      volumes:
+        type: list
+        entry_schema: 
+          type: string
+        required: false
+
+#---------------------------------------------------------------------------------------------------------------------#
+#
+# Node Types
+#
+#---------------------------------------------------------------------------------------------------------------------#
+
+node_types:
+  tosca.nodes.Database.MySQL:
+    metadata:
+      shorthand_name: Database.MySQL
+      type_qualified_name: tosca:Database.MySQL
+      type_uri: tosca.nodes.Database.MySQL
+    derived_from: tosca.nodes.Database
+    requirements:
+      - host:
+          node: tosca.nodes.DBMS.MySQL
+
+  tosca.nodes.DBMS.MySQL:
+    metadata:
+      shorthand_name: DBMS.MySQL
+      type_qualified_name: tosca:DBMS.MySQL
+      type_uri: tosca.nodes.DBMS.MySQL
+    derived_from: tosca.nodes.DBMS
+    properties:
+      port:
+        description: reflect the default MySQL server port
+        default: 3306
+      root_password:
+        required: true
+    capabilities:
+      host:
+        valid_source_types: [ tosca.nodes.Database.MySQL ]
+          
+  tosca.nodes.WebServer.Apache:
+    metadata:
+      shorthand_name: Apache
+      type_qualified_name: tosca:Apache
+      type_uri: tosca.nodes.WebServer.Apache
+    derived_from: tosca.nodes.WebServer
+  
+  tosca.nodes.WebApplication.WordPress:
+    metadata:
+      shorthand_name: WordPress
+      type_qualified_name: tosca:WordPress
+      type_uri: tosca.nodes.WebApplication.WordPress
+    derived_from: tosca.nodes.WebApplication
+    properties:
+      admin_user:
+        type: string
+      admin_password:
+        type: string
+      db_host:
+        type: string
+    requirements:
+      - database_endpoint:
+          capability: tosca.capabilities.Endpoint.Database
+          node: tosca.nodes.Database
+          relationship: tosca.relationships.ConnectsTo
+          
+  tosca.nodes.WebServer.Nodejs:
+    metadata:
+      shorthand_name: Nodejs
+      type_qualified_name: tosca:Nodejs
+      type_uri: tosca.nodes.WebServer.Nodejs
+    derived_from: tosca.nodes.WebServer
+    properties:
+      github_url:
+        required: no
+        type: string
+        description: location of the application on the github.
+        default: https://github.com/mmm/testnode.git
+    interfaces:
+      Standard:
+        inputs:
+          github_url:
+            type: string
+              
+  tosca.nodes.Container.Application.Docker:
+    metadata:
+      shorthand_name: Application.Docker
+      type_qualified_name: tosca:Application.Docker
+      type_uri: tosca.nodes.Container.Application.Docker
+    derived_from: tosca.nodes.Container.Application
+    requirements:
+      - host:
+          capability: tosca.capabilities.Container.Docker
+  
+

--- a/org.eclipse.winery.yaml.common/src/test/resources/builder/simpleTests/valid-non_normative_types.yml
+++ b/org.eclipse.winery.yaml.common/src/test/resources/builder/simpleTests/valid-non_normative_types.yml
@@ -1,0 +1,21 @@
+tosca_definitions_version: tosca_simple_yaml_1_1
+metadata:
+  description: Tests whether non-normative TOSCA types (TOSCA Simple Profile 1.1 cos01 ch. 9) are recognized by the parser
+  tosca.version: 1.1
+
+topology_template:
+  description: Template of several non-normative types from the tosca spec
+  
+  node_templates:
+    database:
+      type: tosca.nodes.Database.MySQL
+    dbms:
+      type: tosca.nodes.DBMS.MySQL
+    apache:
+      type: tosca.nodes.WebServer.Apache
+    wordpress:
+      type: tosca.nodes.WebApplication.WordPress
+    nodejs:
+      type: tosca.nodes.WebServer.Nodejs
+    docker:
+      type: tosca.nodes.Container.Application.Docker


### PR DESCRIPTION
Non-normative TOSCA Type Definitions declared in Ch. 9 of "TOSCA YAML Spec1.1
cos01" are now natively known to the parser and must not be manually
imported in a service template.

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://chris.beams.io/posts/git-commit/)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
