### PR TITLE
Visit artifacts before interfaces in yaml visitor

### DIFF
--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/visitor/AbstractVisitor.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/visitor/AbstractVisitor.java
@@ -191,8 +191,8 @@ public abstract class AbstractVisitor<R extends AbstractResult<R>, P extends Abs
             visitElement(node.getAttributes(), parameter, "attributes"),
             visitMapElement(node.getRequirements(), parameter, "requirements"),
             visitElement(node.getCapabilities(), parameter, "capabilities"),
-            visitElement(node.getInterfaces(), parameter, "interfaces"),
             visitElement(node.getArtifacts(), parameter, "artifacts"),
+            visitElement(node.getInterfaces(), parameter, "interfaces"),
             visitElement(node.getNodeFilter(), parameter, "node_filter")
         ));
     }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
This PR changes to visit order of `TNodeTemplate`:
- Before: Node's Interfaces are visited before node's artifacts
- After:  Node's Artifacts are visited before node's interfaces

**Reason:** Interfaces can depend on artifacts - however, artifacts can not depend on interfaces.

The new behaviour is useful in the stupro TOSCAna, where I'm converting the whole TServiceTemplate into a different model.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://chris.beams.io/posts/git-commit/)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
