### PR TITLE
Add missing Apache commons-codec to the yaml reader

### DIFF
--- a/org.eclipse.winery.yaml.common/pom.xml
+++ b/org.eclipse.winery.yaml.common/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>org.eclipse.winery.repository</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.11</version>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Using the org.eclipse.winery.yaml.common module in another project
produces an error if the program is packaged with mvn package and
afterwards run from the command line. The error message tells that the
DigestUtils class laying in the Apache commons-codec package can not be
found.
This pull request adds the commons-codec dependency to the org.eclipse.winery.yaml.common
modules pom.xml, which resolves the error.

Stack trace (Only the relevant part): 
```
java.lang.NoClassDefFoundError: org/apache/commons/codec/digest/DigestUtils
        at org.eclipse.winery.yaml.common.Utils.getHashValueOfFile(Utils.java:121)
        at org.eclipse.winery.yaml.common.reader.yaml.Reader.fileChanged(Reader.java:179)
        at org.eclipse.winery.yaml.common.reader.yaml.Reader.readServiceTemplate(Reader.java:209)
        at org.eclipse.winery.yaml.common.reader.yaml.Reader.parse(Reader.java:74)
        at org.opentosca.toscana.core.parse.CsarParseServiceImpl.parse(CsarParseServiceImpl.java:45)
        at org.opentosca.toscana.core.parse.CsarParseServiceImpl.parse(CsarParseServiceImpl.java:32)
        at org.opentosca.toscana.core.csar.CsarServiceImpl.populateWithTemplate(CsarServiceImpl.java:46)
        at org.opentosca.toscana.core.csar.CsarServiceImpl.getCsar(CsarServiceImpl.java:75)
        at org.opentosca.toscana.core.api.TransformationController.findByCsarId(TransformationController.java:814)
        at org.opentosca.toscana.core.api.TransformationController.addTransformation(TransformationController.java:287)
```