### PR TITLE
Add subtypes in inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is similar to [Angular's CHANGELOG.md](https://github.com/angular/angular/b
 ## [unreleased]
 
 ### Changed
+- Add a subtype in the inheritance view
 - Add consistency check in the UI
 - Add files in the self-service for Servicetemplates
 - Add error message if entered namespace contains a whitespace

--- a/org.eclipse.winery.bpmn4tosca.converter.tobpel/.gitignore
+++ b/org.eclipse.winery.bpmn4tosca.converter.tobpel/.gitignore
@@ -28,4 +28,6 @@ hs_err_pid*
 
 # Testgenerated files...
 /src/test/resources/bpmn4tosca/managementplan.exclusivegateway.zip
+/src/test/resources/bpmn4tosca/managementplan.noEndpoint.zip
 /src/test/resources/bpmn4tosca/managementplan.zip
+/src/test/resources/bpmn4tosca/managementplan.undefinedEndpoint.zip

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/QNameWithTypeApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/QNameWithTypeApiData.java
@@ -11,17 +11,7 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.apiData;
 
-public class QNameWithTypeApiData {
-
-	/**
-	 * The namespace of the element
-	 */
-	public String namespace;
-
-	/**
-	 * The local name (id) of the element
-	 */
-	public String localname;
+public class QNameWithTypeApiData extends QNameApiData {
 
 	/**
 	 * QName as string of the referenced type

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.component.html
@@ -13,6 +13,7 @@
 </div>
 <div *ngIf="!loading">
     <div class="right">
+        <button class="btn btn-info" (click)="onAddSubType()">Add a subtype</button>
         <button class="btn btn-primary" name="save" (click)="saveToServer()">Save</button>
     </div>
     <div class="form-group">
@@ -39,3 +40,9 @@
     <br>
     <button class="btn btn-info btn-sm" [disabled]="!enableButton" (click)="onButtonClick()">open</button>
 </div>
+
+<winery-add-component #addSubTypeModal
+                      [namespace]="sharedData.toscaComponent.namespace"
+                      [toscaType]="toscaType"
+                      [inheritFrom]="sharedData.toscaComponent.getQName()">
+</winery-add-component>

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.component.ts
@@ -17,6 +17,8 @@ import { ToscaTypes } from '../../../wineryInterfaces/enums';
 import { SelectData } from '../../../wineryInterfaces/selectData';
 import { SelectItem } from 'ng2-select';
 import { Router } from '@angular/router';
+import { ModalDirective } from 'ngx-bootstrap';
+import { WineryAddComponent } from '../../../wineryAddComponentModule/addComponent.component';
 
 @Component({
     selector: 'winery-instance-inheritance',
@@ -32,10 +34,11 @@ export class InheritanceComponent implements OnInit {
     toscaType: ToscaTypes;
     loading = true;
     enableButton = false;
-    @ViewChild('derivedFromSelector') aboutModal: any;
+    @ViewChild('derivedFromSelector') aboutModal: ModalDirective;
+    @ViewChild('addSubTypeModal') addSubTypeModal: WineryAddComponent;
     initialActiveItem: Array<SelectData>;
 
-    constructor(private sharedData: InstanceService,
+    constructor(public sharedData: InstanceService,
                 private service: InheritanceService,
                 private notify: WineryNotificationService, private router: Router) {
     }
@@ -79,6 +82,10 @@ export class InheritanceComponent implements OnInit {
         this.router.navigate([this.toscaType + '/' + encodeURIComponent(namespace) + '/' + name]);
     }
 
+    onAddSubType() {
+        this.addSubTypeModal.onAdd();
+    }
+
     private handleInheritanceData(inheritance: InheritanceApiData) {
         this.inheritanceApiData = inheritance;
         this.initialActiveItem = [{
@@ -108,5 +115,4 @@ export class InheritanceComponent implements OnInit {
         this.loading = false;
         this.notify.error(error.text(), 'Error');
     }
-
 }

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.module.ts
@@ -20,6 +20,7 @@ import { WineryQNameSelectorModule } from '../../../wineryQNameSelector/wineryQN
 import { SelectModule } from 'ng2-select';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
+import { WineryAddModule } from '../../../wineryAddComponentModule/addComponent.moudle';
 
 @NgModule({
     imports: [
@@ -32,6 +33,7 @@ import { RouterModule } from '@angular/router';
         WineryModalModule,
         WineryLoaderModule,
         WineryQNameSelectorModule,
+        WineryAddModule,
     ],
     exports: [InheritanceComponent],
     declarations: [InheritanceComponent],

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/inheritance/inheritance.service.ts
@@ -40,6 +40,17 @@ export class InheritanceService {
             .map(res => res.json());
     }
 
+    saveInheritanceFromString(url: string, inheritFrom: string): Observable<any> {
+        const inheritanceData = new InheritanceApiData();
+        inheritanceData.isAbstract = 'no';
+        inheritanceData.isFinal = 'no';
+        inheritanceData.derivedFrom = inheritFrom;
+
+        this.path = url;
+
+        return this.saveInheritanceData(inheritanceData);
+    }
+
     saveInheritanceData(inheritanceData: InheritanceApiData): Observable<any> {
         const headers = new Headers({ 'Content-Type': 'application/json', 'Accept': 'application/json' });
         const options = new RequestOptions({ headers: headers });

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.html
@@ -36,7 +36,8 @@
         <button class="btn btn-default sidebar-btn sectionBtn" id="sectionsAddNewBtn" (click)="onAdd();">Add new
         </button>
         <button class="btn btn-default sidebar-btn sectionBtn" id="sectionsImportCsarBtn"
-                (click)="addCsarModal.show();">Import CSAR
+                (click)="addCsarModal.show()">
+            Import CSAR
         </button>
         <button class="btn btn-default sidebar-btn sectionBtn" id="sectionsImportYamlBtn"
                 (click)="addYamlModal.show();">Import
@@ -63,54 +64,10 @@
     </div>
 </div>
 
-<winery-modal bsModal #addModal="bs-modal" [modalRef]="addModal">
-    <winery-modal-header [title]="'Add new ' + addModalType"></winery-modal-header>
-    <winery-modal-body>
-        <form #addComponentForm="ngForm">
-            <div class="form-group">
-                <label for="componentName" class="control-label">Name</label>
-                <input type="text"
-                       class="form-control"
-                       id="componentName"
-                       name="componentName"
-                       #newName="ngModel"
-                       [(ngModel)]="newComponentName"
-                       required
-                       [wineryDuplicateValidator]="validatorObject">
-                <div *ngIf="newName.errors && (newName.dirty || newName.touched)"
-                     class="alert alert-danger">
-                    <div [hidden]="!newName.errors.wineryDuplicateValidator">
-                        No duplicates allowed!
-                    </div>
-                    <div [hidden]="!newName.errors.required">
-                        Name is required!
-                    </div>
-                </div>
-            </div>
-            <!-- pattern parameter is required to enable form validation -->
-            <winery-namespace-selector #namespaceInput
-                                       name="namespace"
-                                       required
-                                       pattern="^\S*$"
-                                       [(ngModel)]="newComponentNamespace"
-                                       [isRequired]="true"
-                                       [useStartNamespace]="true"
-                                       [toscaType]="toscaType">
-            </winery-namespace-selector>
-            <div class="form-group" *ngIf="types">
-                <label for="typeSelect" class="control-label">Type</label>
-                <ng-select id="typeSelect" [items]="types" (selected)="typeSelected($event)"
-                           [active]="[newComponentSelectedType]"></ng-select>
-            </div>
-        </form>
-    </winery-modal-body>
-    <winery-modal-footer
-        (onOk)="addComponent()"
-        [closeButtonLabel]="'Cancel'"
-        [okButtonLabel]="'Add'"
-        [disableOkButton]="!addComponentForm.valid">
-    </winery-modal-footer>
-</winery-modal>
+<winery-add-component #addModal
+                      [componentData]="componentData"
+                      [toscaType]="toscaType">
+</winery-add-component>
 
 <winery-modal bsModal #addCsarModal="bs-modal" [modalRef]="addCsarModal">
     <winery-modal-header [title]="'Add CSAR'"></winery-modal-header>
@@ -118,8 +75,10 @@
         <winery-uploader [modalRef]="addCsarModal" [uploadUrl]="fileUploadUrl" #fileUploader
                          (onSuccess)="getSectionsData()"></winery-uploader>
         <div class="checkbox">
-            <label><input [(ngModel)]="overwriteValue" (change)="overwriteValueChanged()" type="checkbox" value="">Overwrite
-                existing content</label>
+            <label>
+                <input [(ngModel)]="overwriteValue" (change)="overwriteValueChanged()" type="checkbox" value="">
+                Overwrite existing content
+            </label>
         </div>
     </winery-modal-body>
     <winery-modal-footer [showDefaultButtons]="false">

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
@@ -10,20 +10,16 @@ import { ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild } from '@ang
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { SectionResolverData } from '../wineryInterfaces/resolverData';
-import { SelectData } from '../wineryInterfaces/selectData';
 import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
 import { WineryValidatorObject } from '../wineryValidators/wineryDuplicateValidator.directive';
 import { SectionService } from './section.service';
 import { SectionData } from './sectionData';
 import { backendBaseURL } from '../configuration';
-import { isNullOrUndefined } from 'util';
-import { NgForm } from '@angular/forms';
 import { ModalDirective } from 'ngx-bootstrap';
 import { Response } from '@angular/http';
 import { ToscaTypes } from '../wineryInterfaces/enums';
-import { Utils } from '../wineryUtils/utils';
 import { WineryUploaderComponent } from '../wineryUploader/wineryUploader.component';
-import { WineryNamespaceSelectorComponent } from '../wineryNamespaceSelector/wineryNamespaceSelector.component';
+import { WineryAddComponent } from '../wineryAddComponentModule/addComponent.component';
 
 const showAll = 'Show all Items';
 const showGrouped = 'Group by Namespace';
@@ -43,7 +39,6 @@ export class SectionComponent implements OnInit, OnDestroy {
     loading = true;
     toscaType: ToscaTypes;
     toscaTypes = ToscaTypes;
-    addModalType: string;
     routeSub: Subscription;
     filterString = '';
     itemsPerPage = 10;
@@ -52,28 +47,20 @@ export class SectionComponent implements OnInit, OnDestroy {
     changeViewButtonTitle = showGrouped;
     componentData: SectionData[];
     elementToRemove: SectionData;
-    types: SelectData[];
     overwriteValue = false;
 
     importXsdSchemaType: string;
-    formValid: boolean;
 
-    newComponentName: string;
     newComponentNamespace: string;
-    newComponentSelectedType: SelectData = new SelectData();
     validatorObject: WineryValidatorObject;
 
     fileUploadUrl = backendBaseURL + '/';
-    namespaceValid: boolean;
 
-    @ViewChild('addModal') addModal: ModalDirective;
-    @ViewChild('removeElementModal') removeElementModal: ModalDirective;
-    @ViewChild('addComponentForm') addComponentForm: NgForm;
+    @ViewChild('addModal') addModal: WineryAddComponent;
     @ViewChild('addCsarModal') addCsarModal: ModalDirective;
+    @ViewChild('removeElementModal') removeElementModal: ModalDirective;
     @ViewChild('addYamlModal') addYamlModal: ModalDirective;
     @ViewChild('fileUploader') fileUploader: WineryUploaderComponent;
-
-    @ViewChild('namespaceInput') namespaceInput: WineryNamespaceSelectorComponent;
 
     constructor(private route: ActivatedRoute,
                 private change: ChangeDetectorRef,
@@ -114,31 +101,8 @@ export class SectionComponent implements OnInit, OnDestroy {
     }
 
     onAdd() {
-        this.validatorObject = new WineryValidatorObject(this.componentData, 'id');
-
-        // This is needed for the modal to correctly display the selected namespace
-        this.newComponentNamespace = '';
-        this.change.detectChanges();
-        this.addComponentForm.reset();
-
-        this.newComponentSelectedType = this.types ? this.types[0].children[0] : null;
-        this.newComponentNamespace = (this.showNamespace !== 'all' && this.showNamespace !== 'group') ? this.showNamespace : '';
-        this.namespaceInput.writeValue(this.newComponentNamespace);
-
-        this.addModal.show();
-    }
-
-    typeSelected(event: SelectData) {
-        this.newComponentSelectedType = event;
-    }
-
-    addComponent() {
-        const compType = this.newComponentSelectedType ? this.newComponentSelectedType.id : null;
-        this.service.createComponent(this.newComponentName, this.newComponentNamespace, compType)
-            .subscribe(
-                data => this.handleSaveSuccess(),
-                error => this.handleError(error)
-            );
+        this.addModal.namespace = (this.showNamespace !== 'all' && this.showNamespace !== 'group') ? this.showNamespace : '';
+        this.addModal.onAdd();
     }
 
     showSpecificNamespaceOnly(): boolean {
@@ -182,12 +146,9 @@ export class SectionComponent implements OnInit, OnDestroy {
         this.toscaType = resolved.section;
         this.importXsdSchemaType = resolved.xsdSchemaType;
 
-        this.addModalType = Utils.getToscaTypeNameFromToscaType(this.toscaType);
-
         const storedNamespace = localStorage.getItem(this.toscaType + '_showNamespace') !== null ?
             localStorage.getItem(this.toscaType + '_showNamespace') : 'all';
         this.showNamespace = resolved.namespace ? resolved.namespace : storedNamespace;
-        this.types = null;
 
         this.service.setPath(resolved.path);
         this.getSectionsData();
@@ -208,31 +169,7 @@ export class SectionComponent implements OnInit, OnDestroy {
         } else {
             this.changeViewButtonTitle = showGrouped;
         }
-
-        const typesUrl = Utils.getTypeOfTemplateOrImplementation(this.toscaType);
-
-        if (!isNullOrUndefined(typesUrl)) {
-            this.service.getSectionData('/' + typesUrl + '?grouped=angularSelect')
-                .subscribe(
-                    data => this.handleTypes(data),
-                    error => this.handleError(error)
-                );
-        } else {
-            this.loading = false;
-        }
-    }
-
-    private handleTypes(types: SelectData[]): void {
         this.loading = false;
-        this.types = types.length > 0 ? types : null;
-    }
-
-    private handleSaveSuccess() {
-        this.newComponentName = this.newComponentName.replace(/\s/g, '_');
-        this.notify.success('Successfully saved component ' + this.newComponentName);
-        this.router.navigateByUrl('/' + this.toscaType + '/'
-            + encodeURIComponent(encodeURIComponent(this.newComponentNamespace)) + '/'
-            + this.newComponentName);
     }
 
     private handleError(error: Response): void {

--- a/org.eclipse.winery.repository.ui/src/app/section/section.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.module.ts
@@ -25,6 +25,7 @@ import { TooltipModule } from 'ngx-bootstrap';
 import { WineryPipesModule } from '../wineryPipes/wineryPipes.module';
 import { XaasPackagerComponent } from './xaasPackager/xaasPackager.component';
 import { TagInputModule } from 'ngx-chips';
+import { WineryAddModule } from '../wineryAddComponentModule/addComponent.moudle';
 
 @NgModule({
     imports: [
@@ -41,7 +42,8 @@ import { TagInputModule } from 'ngx-chips';
         WineryUploaderModule,
         TooltipModule,
         WineryPipesModule,
-        TagInputModule
+        TagInputModule,
+        WineryAddModule,
     ],
     exports: [SectionComponent],
     declarations: [
@@ -50,7 +52,6 @@ import { TagInputModule } from 'ngx-chips';
         SectionPipe,
         XaasPackagerComponent
     ],
-    providers: [],
 })
 export class SectionModule {
 }

--- a/org.eclipse.winery.repository.ui/src/app/section/section.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.service.ts
@@ -43,15 +43,14 @@ export class SectionService {
             .map(res => res.json());
     }
 
-    createComponent(newComponentName: string, newComponentNamespace: string, newComponentSelectedType?: string) {
+    createComponent(newComponentName: string, newComponentNamespace: string, newComponentSelectedType: string) {
         const headers = new Headers({ 'Content-Type': 'application/json' });
         const options = new RequestOptions({ headers: headers });
 
-        let saveObject: any;
-        if (!isNullOrUndefined(newComponentSelectedType)) {
-            saveObject = { localname: newComponentName, namespace: newComponentNamespace, type: newComponentSelectedType };
-        } else {
-            saveObject = { localname: newComponentName, namespace: newComponentNamespace };
+        const saveObject: any = { localname: newComponentName, namespace: newComponentNamespace };
+
+        if (!isNullOrUndefined(newComponentSelectedType) && newComponentSelectedType.length > 0) {
+            saveObject.type = newComponentSelectedType;
         }
 
         return this.http.post(backendBaseURL + this.path + '/', JSON.stringify(saveObject), options);

--- a/org.eclipse.winery.repository.ui/src/app/wineryAddComponentModule/addComponent.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryAddComponentModule/addComponent.component.html
@@ -1,0 +1,68 @@
+<!--
+/********************************************************************************
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ ********************************************************************************/
+-->
+<winery-modal bsModal #addModal="bs-modal" [modalRef]="addModal">
+    <div *ngIf="!loading; else showLoader">
+        <winery-modal-header [title]="'Add new ' + addModalType"></winery-modal-header>
+        <winery-modal-body>
+            <form #addComponentForm="ngForm">
+                <div class="form-group">
+                    <label for="componentName" class="control-label">Name</label>
+                    <input type="text"
+                           class="form-control"
+                           id="componentName"
+                           name="componentName"
+                           #newName="ngModel"
+                           [(ngModel)]="newComponentName"
+                           required
+                           [wineryDuplicateValidator]="validatorObject">
+                    <div *ngIf="newName.errors && (newName.dirty || newName.touched)"
+                         class="alert alert-danger">
+                        <div [hidden]="!newName.errors.wineryDuplicateValidator">
+                            No duplicates allowed!
+                        </div>
+                        <div [hidden]="!newName.errors.required">
+                            Name is required!
+                        </div>
+                    </div>
+                </div>
+                <!-- pattern parameter is required to enable form validation -->
+                <winery-namespace-selector #namespaceInput
+                                           name="namespace"
+                                           required
+                                           pattern="^\S*$"
+                                           [(ngModel)]="newComponentNamespace"
+                                           [isRequired]="true"
+                                           [useStartNamespace]="useStartNamespace"
+                                           [toscaType]="toscaType">
+                </winery-namespace-selector>
+                <div class="form-group" *ngIf="types">
+                    <label for="typeSelect" class="control-label">Type</label>
+                    <ng-select id="typeSelect" [items]="types" (selected)="typeSelected($event)"
+                               [active]="[newComponentSelectedType]"></ng-select>
+                </div>
+            </form>
+        </winery-modal-body>
+        <winery-modal-footer
+            (onOk)="addComponent()"
+            [closeButtonLabel]="'Cancel'"
+            [okButtonLabel]="'Add'"
+            [disableOkButton]="!addComponentForm?.valid">
+        </winery-modal-footer>
+    </div>
+    <ng-template #showLoader>
+        <winery-loader></winery-loader>
+    </ng-template>
+</winery-modal>

--- a/org.eclipse.winery.repository.ui/src/app/wineryAddComponentModule/addComponent.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryAddComponentModule/addComponent.component.ts
@@ -1,0 +1,142 @@
+/********************************************************************************
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ ********************************************************************************/
+import { ChangeDetectorRef, Component, Input, OnInit, ViewChild } from '@angular/core';
+import { SectionService } from '../section/section.service';
+import { SelectData } from '../wineryInterfaces/selectData';
+import { WineryValidatorObject } from '../wineryValidators/wineryDuplicateValidator.directive';
+import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
+import { ToscaTypes } from '../wineryInterfaces/enums';
+import { Router } from '@angular/router';
+import { Response } from '@angular/http';
+import { NgForm } from '@angular/forms';
+import { Utils } from '../wineryUtils/utils';
+import { isNullOrUndefined } from 'util';
+import { SectionData } from '../section/sectionData';
+import { ModalDirective } from 'ngx-bootstrap';
+import { WineryNamespaceSelectorComponent } from '../wineryNamespaceSelector/wineryNamespaceSelector.component';
+import { InheritanceService } from '../instance/sharedComponents/inheritance/inheritance.service';
+
+@Component({
+    selector: 'winery-add-component',
+    templateUrl: 'addComponent.component.html',
+    providers: [
+        SectionService,
+        InheritanceService,
+    ]
+})
+
+export class WineryAddComponent implements OnInit {
+
+    loading: boolean;
+
+    @Input() toscaType: ToscaTypes;
+    @Input() componentData: SectionData[];
+    @Input() namespace: string;
+    @Input() inheritFrom: string;
+
+    addModalType: string;
+    newComponentNamespace: string;
+    newComponentName: string;
+    newComponentSelectedType: SelectData = new SelectData();
+    validatorObject: WineryValidatorObject;
+    types: SelectData[];
+
+    @ViewChild('addComponentForm') addComponentForm: NgForm;
+    @ViewChild('addModal') addModal: ModalDirective;
+    @ViewChild('namespaceInput') namespaceInput: WineryNamespaceSelectorComponent;
+    useStartNamespace = true;
+
+    constructor(private sectionService: SectionService,
+                private inheritanceService: InheritanceService,
+                private change: ChangeDetectorRef,
+                private notify: WineryNotificationService,
+                private router: Router) {
+    }
+
+    ngOnInit() {
+    }
+
+    onAdd() {
+        const typesUrl = Utils.getTypeOfTemplateOrImplementation(this.toscaType);
+        this.addModalType = Utils.getToscaTypeNameFromToscaType(this.toscaType);
+        this.useStartNamespace = !(!isNullOrUndefined(this.namespace) && this.namespace.length > 0);
+
+        this.sectionService.setPath(this.toscaType);
+
+        if (!isNullOrUndefined(typesUrl)) {
+            this.loading = true;
+            this.sectionService.getSectionData('/' + typesUrl + '?grouped=angularSelect')
+                .subscribe(
+                    data => this.handleTypes(data),
+                    error => this.handleError(error)
+                );
+        }
+
+        this.validatorObject = new WineryValidatorObject(this.componentData, 'id');
+
+        // This is needed for the modal to correctly display the selected namespace
+        if (!this.useStartNamespace) {
+            this.newComponentNamespace = this.namespace;
+        } else {
+            this.newComponentNamespace = '';
+            this.addComponentForm.reset();
+        }
+        this.change.detectChanges();
+
+        this.newComponentSelectedType = this.types ? this.types[0].children[0] : null;
+        this.namespaceInput.writeValue(this.newComponentNamespace);
+
+        this.addModal.show();
+    }
+
+    addComponent() {
+        this.loading = true;
+        const compType = this.newComponentSelectedType ? this.newComponentSelectedType.id : null;
+        this.sectionService.createComponent(this.newComponentName, this.newComponentNamespace, compType)
+            .subscribe(
+                data => this.handleSaveSuccess(),
+                error => this.handleError(error)
+            );
+    }
+
+    typeSelected(event: SelectData) {
+        this.newComponentSelectedType = event;
+    }
+
+    private handleTypes(types: SelectData[]): void {
+        this.loading = false;
+        this.types = types.length > 0 ? types : null;
+    }
+
+    private handleSaveSuccess() {
+        this.newComponentName = this.newComponentName.replace(/\s/g, '-');
+        const url = '/' + this.toscaType + '/'
+            + encodeURIComponent(encodeURIComponent(this.newComponentNamespace)) + '/'
+            + this.newComponentName;
+
+        if (isNullOrUndefined(this.inheritFrom)) {
+            this.notify.success('Successfully saved component ' + this.newComponentName);
+            this.router.navigateByUrl(url);
+        } else {
+            this.inheritanceService.saveInheritanceFromString(url, this.inheritFrom)
+                .subscribe(() => this.handleSaveSuccess(), error => this.handleError(error));
+            this.inheritFrom = null;
+        }
+    }
+
+    private handleError(error: Response): void {
+        this.loading = false;
+        this.notify.error(error.toString());
+    }
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryAddComponentModule/addComponent.moudle.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryAddComponentModule/addComponent.moudle.ts
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ ********************************************************************************/
+import { NgModule } from '@angular/core';
+
+import { WineryAddComponent } from './addComponent.component';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+import { WineryModalModule } from '../wineryModalModule/winery.modal.module';
+import { WineryNotificationModule } from '../wineryNotificationModule/wineryNotification.module';
+import { WineryNamespaceSelectorModule } from '../wineryNamespaceSelector/wineryNamespaceSelector.module';
+import { WineryDuplicateValidatorModule } from '../wineryValidators/wineryDuplicateValidator.module';
+import { RouterModule } from '@angular/router';
+import { WineryLoaderModule } from '../wineryLoader/wineryLoader.module';
+import { SelectModule } from 'ng2-select';
+
+@NgModule({
+    imports: [
+        BrowserModule,
+        FormsModule,
+        RouterModule,
+        SelectModule,
+        WineryModalModule,
+        WineryLoaderModule,
+        WineryNotificationModule,
+        WineryNamespaceSelectorModule,
+        WineryDuplicateValidatorModule,
+    ],
+    exports: [WineryAddComponent],
+    declarations: [WineryAddComponent],
+})
+export class WineryAddModule {
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryInterfaces/toscaComponent.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryInterfaces/toscaComponent.ts
@@ -32,4 +32,8 @@ export class ToscaComponent {
             }
         }
     }
+
+    getQName(): string {
+        return '{' + this.namespace + '}' + this.localName;
+    }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Add support for adding subcomponents in the inheritance view.
Resolves https://github.com/OpenTOSCA/winery/issues/57

![grafik](https://user-images.githubusercontent.com/23058331/33989298-44e07196-e0c7-11e7-8f2c-717712b50978.png)

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://chris.beams.io/posts/git-commit/)
- [x] Ensure to use auto format in **all** files
- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
