### PR TITLE
Add short notation support for operation definition

### DIFF
--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/reader/yaml/Builder.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/reader/yaml/Builder.java
@@ -145,6 +145,7 @@ public class Builder {
             switch (clazz.getSimpleName()) {
                 case "TAttributeAssignment":
                 case "TRequirementAssignment":
+                case "TOperationDefinition":
                     return true;
                 default:
                     return false;
@@ -560,22 +561,30 @@ public class Builder {
     @Nullable
     public TOperationDefinition buildOperationDefinition(Object object, Parameter<TOperationDefinition> parameter) {
         if (Objects.isNull(object) || !validate(TOperationDefinition.class, object, parameter)) return null;
-        @SuppressWarnings("unchecked")
-        Map<String, Object> map = (Map<String, Object>) object;
-        return new TOperationDefinition.Builder()
-            .setDescription(buildDescription(map.get("description")))
-            .setInputs(buildPropertyAssignmentOrDefinition(map.get("inputs"),
-                new Parameter<>(parameter.getContext()).addContext("Inputs")
-                    .setValue(parameter.getValue())
-            ))
-            .setOutputs(buildPropertyAssignmentOrDefinition(map.get("outputs"),
-                new Parameter<>(parameter.getContext()).addContext("outputs")
-                    .setValue(parameter.getValue())
-            ))
-            .setImplementation(buildImplementation(map.get("implementation"),
-                new Parameter<TImplementation>(parameter.getContext()).addContext("implementation")
-            ))
-            .build();
+        // short notation
+        if (object instanceof String) {
+            return new TOperationDefinition.Builder()
+                .setImplementation(new TImplementation.Builder(buildQName(stringValue(object))).build())
+                .build();
+        } else if (object instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = (Map<String, Object>) object;
+            return new TOperationDefinition.Builder()
+                .setDescription(buildDescription(map.get("description")))
+                .setInputs(buildPropertyAssignmentOrDefinition(map.get("inputs"),
+                    new Parameter<>(parameter.getContext()).addContext("Inputs")
+                        .setValue(parameter.getValue())
+                ))
+                .setOutputs(buildPropertyAssignmentOrDefinition(map.get("outputs"),
+                    new Parameter<>(parameter.getContext()).addContext("outputs")
+                        .setValue(parameter.getValue())
+                ))
+                .setImplementation(buildImplementation(map.get("implementation"),
+                    new Parameter<TImplementation>(parameter.getContext()).addContext("implementation")
+                ))
+                .build();
+        }
+        return null;
     }
 
     @Nullable

--- a/org.eclipse.winery.yaml.common/src/test/java/org/eclipse/winery/yaml/common/reader/ReflectionTests.java
+++ b/org.eclipse.winery.yaml.common/src/test/java/org/eclipse/winery/yaml/common/reader/ReflectionTests.java
@@ -210,7 +210,8 @@ public class ReflectionTests extends AbstractTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-        "constraints/valid-constraints-artifact_type-complete"
+        "operationDefinition/valid-operation_definition-short",
+        "operationDefinition/valid-operation_definition-topology_template"
     })
     public void testSingleServiceTemplates(String fileName) throws Exception {
         testServiceTemplates(getYamlFile(fileName));
@@ -236,7 +237,7 @@ public class ReflectionTests extends AbstractTest {
 
     @ParameterizedTest
     @CsvSource({
-        "invalid-yaml_syntax-missing_line_break, InvalidSyntax"
+        "invalid-yaml_syntax-missing_line_break, InvalidYamlSyntax"
     })
     public void testSingleServiceTemplatesException(String fileName,
                                                     String exception) throws Exception {

--- a/org.eclipse.winery.yaml.common/src/test/resources/builder/reflectionTests/operationDefinition/valid-operation_definition-short.yml
+++ b/org.eclipse.winery.yaml.common/src/test/resources/builder/reflectionTests/operationDefinition/valid-operation_definition-short.yml
@@ -1,0 +1,21 @@
+tosca_definitions_version: tosca_simple_yaml_1_1
+
+metadata:
+  description: Valid operation definition containing a short notation for an operation assignment.
+  targetNamespace: http://www.example.org/ns/simple/yaml/1.1/test
+  tosca.version: 1.1
+  reference: 3.5.13.2.1
+  exception: None
+  keyname: topology_template.node_templates.ndt1.interfaces.Standard.operations
+  assert-typeof: |
+    configure = TOperationDefinition
+  assert: |
+    configure.implementation.primary = testArtifact.sh
+
+topology_template:
+  node_templates:
+    ndt1:
+      type: tosca.nodes.Root
+      interfaces:      
+        Standard:
+          configure: testArtifact.sh

--- a/org.eclipse.winery.yaml.common/src/test/resources/builder/reflectionTests/operationDefinition/valid-operation_definition-topology_template.yml
+++ b/org.eclipse.winery.yaml.common/src/test/resources/builder/reflectionTests/operationDefinition/valid-operation_definition-topology_template.yml
@@ -1,0 +1,23 @@
+tosca_definitions_version: tosca_simple_yaml_1_1
+
+metadata:
+  description: Valid operation definition containing a short notation for an operation assignment.
+  targetNamespace: http://www.example.org/ns/simple/yaml/1.1/test
+  tosca.version: 1.1
+  reference: 3.5.13.2.1
+  exception: None
+  keyname: topology_template.node_templates.ndt1.interfaces.Standard.operations
+  assert-typeof: |
+    configure = TOperationDefinition
+  assert: |
+    configure.implementation.primary = testArtifact.sh
+
+topology_template:
+  node_templates:
+    ndt1:
+      type: tosca.nodes.Root
+      interfaces:      
+        Standard:
+          configure:  
+            implementation:
+              primary: testArtifact.sh


### PR DESCRIPTION
Add short notation support for operation definition
- Fix issue #215
- Fix minor issues for reflection tests

Signed-off-by: Christoph Kleine <kleinech.github@gmail.com>

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://chris.beams.io/posts/git-commit/)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for UI changes)
