### PR TITLE
Group export buttons

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/instance/instance.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instance.module.ts
@@ -20,6 +20,7 @@ import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { PropertyRenameComponent } from './instanceHeader/propertyRename/propertyRename.component';
 import { FormsModule } from '@angular/forms';
+import { BsDropdownModule } from 'ngx-bootstrap';
 
 @NgModule({
     imports: [
@@ -28,7 +29,8 @@ import { FormsModule } from '@angular/forms';
         WineryLoaderModule,
         WineryModalModule,
         WineryPipesModule,
-        FormsModule
+        FormsModule,
+        BsDropdownModule.forRoot()
     ],
     exports: [InstanceComponent],
     declarations: [

--- a/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/instanceHeader.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instanceHeader/instanceHeader.component.html
@@ -15,13 +15,31 @@
         <winery-property-rename [toscaComponent]="toscaComponent" [propertyName]="'namespace'"></winery-property-rename>
     </div>
     <div class="managementButtons" *ngIf="showManagementButtons">
-        <button class="btn btn-danger" (click)="confirmDeleteModal.show()">Delete</button>
-        <a class="btn btn-info" target="_blank" href="{{ toscaComponent.xmlPath }}">XML</a>
-        <a class="btn btn-info" target="_blank" href="{{ toscaComponent.yamlPath }}">YAML</a>
-        <a class="btn btn-info" target="_blank" href="{{ toscaComponent.yamlCsarPath }}">CSAR (YAML)</a>
-        <a class="btn btn-info" target="_blank" href="{{ toscaComponent.xmlCsarPath }}">CSAR (XML)</a>
+        <div style="float:right;">
+            <div class="btn-group" dropdown>
+                <button dropdownToggle type="button" class="btn btn-info dropdown-toggle dropdown-toggle-split">
+                    Export <span class="caret"></span>
+                </button>
+                <ul *dropdownMenu class="dropdown-menu dropdown-menu-right" role="menu">
+                    <li>
+                        <a target="_blank" href="{{ toscaComponent.xmlPath }}">XML</a>
+                    </li>
+                    <li>
+                        <a target="_blank" href="{{ toscaComponent.yamlPath }}">YAML</a>
+                    </li>
+                    <li class="divider dropdown-divider"></li>
+                    <li>
+                        <a target="_blank" href="{{ toscaComponent.yamlCsarPath }}">CSAR (YAML)</a>
+                    </li>
+                    <li>
+                        <a target="_blank" href="{{ toscaComponent.xmlCsarPath }}">CSAR (XML)</a>
+                    </li>
+                </ul>
+            </div>
+            <button class="btn btn-danger" (click)="confirmDeleteModal.show()">Delete</button>
+        </div>
         <div *ngIf="typeUrl">
-            {{ typeOf }} <a [routerLink]="typeUrl">{{ typeId }}</a>
+            <span style="white-space: pre">{{ typeOf }} <a [routerLink]="typeUrl">{{ typeId }}</a></span>
         </div>
     </div>
     <div class="subMenu">


### PR DESCRIPTION
Gropus the export buttons into a dropdown because it overlays names and namespaces in the case of long names as shown in the first screenshot.

![grafik](https://user-images.githubusercontent.com/23058331/35768957-03d5943c-0904-11e8-88d8-93ce9df25bdf.png)

The new UI groups this now:

![grafik](https://user-images.githubusercontent.com/23058331/35768934-939f0400-0903-11e8-9f29-4e5e40ca2065.png)


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://chris.beams.io/posts/git-commit/)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
