### PR TITLE
Add old topology modeler link

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/configuration.ts
+++ b/org.eclipse.winery.repository.ui/src/app/configuration.ts
@@ -23,4 +23,6 @@ export const workflowModelerURL = location.protocol + '//' + location.hostname +
     + (location.port === '4200' ? '9527' : location.port + '/winery-workflowmodeler');
 // similar to the workflowModeler, configure the topologyModelerURL
 export const topologyModelerURL = location.protocol + '//' + location.hostname + ':'
-    + (location.port === '4200' ? '4201' : location.port + '/winery-topologymodeler');
+    + (location.port === '4200' ? '4201' : location.port + '/winery-topologymodeler-ui');
+
+export const oldTopologyModelerURL = backendBaseURL + '-topologymodeler';

--- a/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/topologyTemplate/topologyTemplate.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/topologyTemplate/topologyTemplate.component.html
@@ -16,6 +16,9 @@
     <button [disabled]="!(sharedData?.versions?.length > 1)" class="btn btn-info" (click)="compareToModal.show()">
         Compare to...
     </button>
+    <div style="float: right">
+        <a [href]="oldEditorUrl" target="_blank" class="btn btn-light">Open Old Editor</a>
+    </div>
 </div>
 <div>
     <p class="help-block">

--- a/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/topologyTemplate/topologyTemplate.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/topologyTemplate/topologyTemplate.component.ts
@@ -11,12 +11,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-import {Component, OnInit, ViewChild} from '@angular/core';
-import {InstanceService} from '../../instance.service';
-import {backendBaseURL, topologyModelerURL} from '../../../configuration';
-import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
-import {WineryVersion} from '../../../wineryInterfaces/wineryVersion';
-import {ModalDirective} from 'ngx-bootstrap';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { InstanceService } from '../../instance.service';
+import { backendBaseURL, oldTopologyModelerURL, topologyModelerURL } from '../../../configuration';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { WineryVersion } from '../../../wineryInterfaces/wineryVersion';
+import { ModalDirective } from 'ngx-bootstrap';
 
 @Component({
     templateUrl: 'topologyTemplate.component.html'
@@ -26,6 +26,7 @@ export class TopologyTemplateComponent implements OnInit {
     loading = true;
     templateUrl: SafeResourceUrl;
     editorUrl: string;
+    oldEditorUrl: string;
 
     selectedVersion: WineryVersion;
 
@@ -35,16 +36,19 @@ export class TopologyTemplateComponent implements OnInit {
     }
 
     ngOnInit() {
-        const uiURL = encodeURIComponent(window.location.origin + window.location.pathname);
+        const uiURL = encodeURIComponent(window.location.origin + window.location.pathname + '#/');
 
         this.templateUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
             backendBaseURL + this.sharedData.path + '/topologytemplate/?view&uiURL=' + uiURL
         );
-        this.editorUrl = topologyModelerURL
-            + '?repositoryURL=' + encodeURIComponent(backendBaseURL)
+
+        const editorConfig = '?repositoryURL=' + encodeURIComponent(backendBaseURL)
             + '&uiURL=' + uiURL
             + '&ns=' + encodeURIComponent(this.sharedData.toscaComponent.namespace)
             + '&id=' + this.sharedData.toscaComponent.localName;
+
+        this.editorUrl = topologyModelerURL + editorConfig;
+        this.oldEditorUrl = oldTopologyModelerURL + editorConfig;
     }
 
     versionSelected(version: WineryVersion) {

--- a/org.eclipse.winery.topologymodeler.ui/pom.xml
+++ b/org.eclipse.winery.topologymodeler.ui/pom.xml
@@ -79,17 +79,6 @@
                 <executions>
                     <execution>
                         <phase>compile</phase>
-                        <id>install node and npm</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
-                        <configuration>
-                            <nodeVersion>v7.9.0</nodeVersion>
-                            <npmVersion>4.2.0</npmVersion>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <phase>compile</phase>
                         <id>install angular app</id>
                         <goals>
                             <goal>npm</goal>

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/entities-modal/entities-modal.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/entities-modal/entities-modal.component.ts
@@ -368,7 +368,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
         if (this.deploymentArtifactOrPolicyModalData.modalTemplateRef) {
             const artifactRef = this.deploymentArtifactOrPolicyModalData.modalTemplateRef;
             const url = hostURL
-                + '/#/artifacttemplates/'
+                + '/artifacttemplates/'
                 + encodeURIComponent(encodeURIComponent(this.getNamespace(artifactRef)))
                 + '/' + this.getLocalName(artifactRef);
             window.open(url, '_blank');

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/enums.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/enums.ts
@@ -28,7 +28,6 @@ export enum urlElement {
     CapabilityTypeURL = '/capabilitytypes/',
     RelationshipTypeURL = '/relationshiptypes/',
     ReadMe = '/readme',
-    Selector = '/#',
     ServiceTemplates = '/servicetemplates/',
     Winery = '/winery',
     TopologyTemplate = '/topologytemplate/'

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/toscatype-table/toscatype-table.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/toscatype-table/toscatype-table.component.ts
@@ -70,32 +70,32 @@ export class ToscatypeTableComponent implements OnInit, OnChanges {
     }
 
     clickArtifactRef(artifactRef: string) {
-        const url = hostURL
-            + '/#/artifacttemplates/'
+        const url = this.backendService.configuration.uiURL
+            + 'artifacttemplates/'
             + encodeURIComponent(encodeURIComponent(this.getNamespace(artifactRef)))
             + '/' + this.getLocalName(artifactRef);
         window.open(url, '_blank');
     }
 
     clickArtifactType(artifactType: string) {
-        const url = hostURL
-            + '/#/artifacttypes/'
+        const url = this.backendService.configuration.uiURL
+            + 'artifacttypes/'
             + encodeURIComponent(encodeURIComponent(this.getNamespace(artifactType)))
             + '/' + this.getLocalName(artifactType);
         window.open(url, '_blank');
     }
 
     clickPolicyRef(policyRef: string) {
-        const url = hostURL
-            + '/#/policytemplates/'
+        const url = this.backendService.configuration.uiURL
+            + 'policytemplates/'
             + encodeURIComponent(encodeURIComponent(this.getNamespace(policyRef)))
             + '/' + this.getLocalName(policyRef);
         window.open(url, '_blank');
     }
 
     clickPolicyType(policyType: string) {
-        const url = hostURL
-            + '/#/policytypes/'
+        const url = this.backendService.configuration.uiURL
+            + 'policytypes/'
             + encodeURIComponent(encodeURIComponent(this.getNamespace(policyType)))
             + '/' + this.getLocalName(policyType);
         window.open(url, '_blank');
@@ -163,7 +163,7 @@ export class ToscatypeTableComponent implements OnInit, OnChanges {
             clickedDefinition = definitionType.CapabilityDefinitions;
         }
         const url = this.backendService.configuration.uiURL
-            + urlElement.Selector + urlElement.NodeTypeURL
+            + urlElement.NodeTypeURL
             + encodeURIComponent(encodeURIComponent(this.getNamespace(this.currentNodeData.nodeTemplate.type)))
             + '/' + this.getLocalName(this.currentNodeData.nodeTemplate.type) + clickedDefinition;
         window.open(url, '_blank');


### PR DESCRIPTION
Add a link to the old TopologyModeler to support both simultaneously.

![grafik](https://user-images.githubusercontent.com/23058331/38801211-8c64f0d4-4169-11e8-95a4-706559548345.png)


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://chris.beams.io/posts/git-commit/)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
