### PR TITLE
Fix base link in the Topology Modeler

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/FilesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/FilesResource.java
@@ -146,6 +146,7 @@ public class FilesResource {
     @GET
     @Path("/{fileName}")
     public Response getFile(@PathParam("fileName") String fileName, @HeaderParam("If-Modified-Since") String modified, @QueryParam("path") String path) {
+        path = Objects.isNull(path) ? "" : path;
         RepositoryFileReference ref = this.fileName2fileRef(fileName, path, true);
         return RestUtils.returnRepoPath(ref, modified);
     }
@@ -153,6 +154,7 @@ public class FilesResource {
     @DELETE
     @Path("/{fileName}")
     public Response deleteFile(@PathParam("fileName") String fileName, @QueryParam("path") String path) {
+        path = Objects.isNull(path) ? "" : path;
         RepositoryFileReference ref = this.fileName2fileRef(fileName, path, true);
         return RestUtils.delete(ref);
     }

--- a/org.eclipse.winery.topologymodeler.ui/pom.xml
+++ b/org.eclipse.winery.topologymodeler.ui/pom.xml
@@ -75,7 +75,6 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
                 <executions>
                     <execution>
                         <phase>compile</phase>

--- a/org.eclipse.winery.topologymodeler.ui/src/index.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/index.html
@@ -17,7 +17,7 @@
 <head>
     <meta charset="utf-8">
     <title>Winery: Topologymodeler</title>
-    <base href="/">
+    <base href="./">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
If the TopologyModeler is deployed on a Tomcat, the files were not loaded correctly. This is now fixed.

Additionally, the path inside the FilesResource is no set to an empty string per default to avoid null pointer exceptions.


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://chris.beams.io/posts/git-commit/)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
