### PR TITLE
A get at the NamespaceManager does not persist the result anymore

### DIFF
--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/constants/Namespaces.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/constants/Namespaces.java
@@ -13,9 +13,10 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.constants;
 
-import javax.xml.XMLConstants;
 import java.util.Arrays;
 import java.util.List;
+
+import javax.xml.XMLConstants;
 
 /**
  * Defines namespace constants not available in Java7's XMLConstants
@@ -34,7 +35,7 @@ public class Namespaces {
     public static final String URI_BPMN4TOSCA_20 = "http://www.opentosca.org/bpmn4tosca";
     public static final String URI_BPEL20_ABSTRACT = "http://docs.oasis-open.org/wsbpel/2.0/process/abstract";
     public static final String URI_BPEL20_EXECUTABLE = "http://docs.oasis-open.org/wsbpel/2.0/process/executable";
-    public static final String URI_OPENTOSCA_NODETYPE = "http://www.opentosca.org/nodetypes";
+    public static final String URI_START_OPENTOSCA = "http://opentosca.org/";
 
     // XML Schema namespace is defined at Java7's XMLConstants.W3C_XML_SCHEMA_NS_URI
     public static final String W3C_XML_SCHEMA_NS_URI = XMLConstants.W3C_XML_SCHEMA_NS_URI;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/VisualAppearanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/VisualAppearanceResource.java
@@ -13,8 +13,20 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.nodetypes;
 
-import com.sun.jersey.multipart.FormDataBodyPart;
-import com.sun.jersey.multipart.FormDataParam;
+import java.io.InputStream;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.ids.definitions.NodeTypeId;
 import org.eclipse.winery.model.tosca.constants.QNames;
 import org.eclipse.winery.repository.backend.constants.Filename;
@@ -22,15 +34,11 @@ import org.eclipse.winery.repository.datatypes.ids.elements.VisualAppearanceId;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.GenericVisualAppearanceResource;
 import org.eclipse.winery.repository.rest.resources.apiData.NodeTypesVisualsApiData;
+
+import com.sun.jersey.multipart.FormDataBodyPart;
+import com.sun.jersey.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.xml.namespace.QName;
-import java.io.InputStream;
-import java.util.Map;
 
 public class VisualAppearanceResource extends GenericVisualAppearanceResource {
 
@@ -57,7 +65,7 @@ public class VisualAppearanceResource extends GenericVisualAppearanceResource {
     @GET
     @Path("bordercolor")
     public String getBorderColor() {
-        return RestUtils.getColorAndSetDefaultIfNotExisting(this.getId().getParent().getXmlId().getDecoded(), QNames.QNAME_BORDER_COLOR, this.otherAttributes, this.res);
+        return RestUtils.getColor(this.getId().getParent().getXmlId().getDecoded(), QNames.QNAME_BORDER_COLOR, this.otherAttributes, this.res);
     }
 
     @PUT

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/properties/PropertiesDefinitionResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/properties/PropertiesDefinitionResource.java
@@ -138,8 +138,8 @@ public class PropertiesDefinitionResource {
             ModelUtilities.replaceWinerysPropertiesDefinition(et, data.winerysPropertiesDefinition);
             String namespace = data.winerysPropertiesDefinition.getNamespace();
             NamespaceManager namespaceManager = RepositoryFactory.getRepository().getNamespaceManager();
-            if (!namespaceManager.hasPrefix(namespace)) {
-                namespaceManager.addNamespace(namespace);
+            if (!namespaceManager.hasPermanentPrefix(namespace)) {
+                namespaceManager.addPermanentNamespace(namespace);
             }
             return RestUtils.persist(this.parentRes);
         }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/VisualAppearanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/VisualAppearanceResource.java
@@ -234,7 +234,7 @@ public class VisualAppearanceResource extends GenericVisualAppearanceResource {
     /* * * color * * */
 
     public String getColor() {
-        return RestUtils.getColorAndSetDefaultIfNotExisting(this.getId().getParent().getXmlId().getDecoded(), QNames.QNAME_COLOR, this.otherAttributes, this.res);
+        return RestUtils.getColor(this.getId().getParent().getXmlId().getDecoded(), QNames.QNAME_COLOR, this.otherAttributes, this.res);
     }
 
     public String getHoverColor() {

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/admin/NamespaceResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/admin/NamespaceResourceTest.java
@@ -23,7 +23,6 @@ public class NamespaceResourceTest extends AbstractResourceTest {
     public void getNamespaceList() throws Exception {
         this.setRevisionTo("8b57ea031ea0786a46ef8338ed322db886a77cd6");
         this.assertGet("admin/namespaces/?all", "entitytypes/admin/namspacesList.json");
-        this.assertGetSize("admin/namespaces/?all", 13);
     }
 
 }

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypeResourceTest.java
@@ -26,7 +26,7 @@ public class PolicyTypeResourceTest extends AbstractResourceTest {
 
     @Test
     public void getInstanceXml() throws Exception {
-        this.setRevisionTo("c25aa724201824fce6eddcc7c35a666c6e015880");
+        this.setRevisionTo("origin/fruits");
         this.assertGet(replacePathStringEncoding(INSTANCE_URL), INSTANCE_XML_PATH);
     }
 

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResourceTest.java
@@ -38,7 +38,7 @@ public class RelationshipTypeResourceTest extends AbstractResourceTest {
 
     @Test
     public void createRelationshipType() throws Exception {
-        this.setRevisionTo("9c486269f6280e0eb14730d01554e7e4553a3d60");
+        this.setRevisionTo("15cd64e30770ca7986660a34e1a4a7e0cf332f19"); // empty repository
         this.assertPost("relationshiptypes/", "entitytypes/relationshiptypes/kiwi_create.json");
         this.assertGet("relationshiptypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypes%252Ffruits/kiwi/", "entitytypes/relationshiptypes/kiwi_initial.json");
     }

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/baobab_bananaInterface_IA-at-c25aa724201824fce6eddcc7c35a666c6e015880.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/baobab_bananaInterface_IA-at-c25aa724201824fce6eddcc7c35a666c6e015880.xml
@@ -11,9 +11,9 @@
                             nodeType="ns6:baobab"
                             targetNamespace="http://winery.opentosca.org/test/nodetypeimplementations/fruits">
         <ImplementationArtifacts>
-            <ImplementationArtifact xmlns:fruits="http://winery.opentosca.org/test/artifacttypes/fruits"
-                                    xmlns:fruits1="http://winery.opentosca.org/test/artifacttemplates/fruits"
-                                    artifactRef="fruits1:baobab_bananaInterface_IA" artifactType="fruits:WAR"
+            <ImplementationArtifact xmlns:atyfruits="http://winery.opentosca.org/test/artifacttypes/fruits"
+                                    xmlns:atefruits="http://winery.opentosca.org/test/artifacttemplates/fruits"
+                                    artifactRef="atefruits:baobab_bananaInterface_IA" artifactType="atyfruits:WAR"
                                     interfaceName="bananaInterface" name="baobab_bananaInterface_IA"/>
         </ImplementationArtifacts>
     </NodeTypeImplementation>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/baobab_initial.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/baobab_initial.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_fruits-baobab_impl",
+    "id": "winery-defs-for_ntyifruits-baobab_impl",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/relationshiptypeimplementations/kiwi-at-c25aa724201824fce6eddcc7c35a666c6e015880.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/relationshiptypeimplementations/kiwi-at-c25aa724201824fce6eddcc7c35a666c6e015880.xml
@@ -1,7 +1,7 @@
 <Definitions xmlns="http://docs.oasis-open.org/tosca/ns/2011/12"
              id="winery-defs-for_wfri-kiwi_implementation"
              targetNamespace="http://winery.opentosca.org/test/relationshiptypeimplementations/fruits">
-    <RelationshipTypeImplementation xmlns:fruits="http://winery.opentosca.org/test/relationshiptypes/fruits"
-                                    name="kiwi_implementation" relationshipType="fruits:kiwi"
+    <RelationshipTypeImplementation xmlns:ntyfruits="http://winery.opentosca.org/test/relationshiptypes/fruits"
+                                    name="kiwi_implementation" relationshipType="ntyfruits:kiwi"
                                     targetNamespace="http://winery.opentosca.org/test/relationshiptypeimplementations/fruits"/>
 </Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/MyTinyTest.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/MyTinyTest.json
@@ -38,7 +38,7 @@
             "otherAttributes": {
             },
             "namespace": "http://opentosca.org/artifacttypes",
-            "location": "artifacttypes__MiniArtifactType.tosca",
+            "location": "otartifacttypes__MiniArtifactType.tosca",
             "importType": "http://docs.oasis-open.org/tosca/ns/2011/12"
         }
     ]

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/MyTinyTest.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/MyTinyTest.xml
@@ -4,8 +4,8 @@
     <Import importType="http://docs.oasis-open.org/tosca/ns/2011/12"
             location="http://localhost:9080/winery/artifacttypes/http%253A%252F%252Fopentosca.org%252Fartifacttypes/MiniArtifactType/?definitions"
             namespace="http://opentosca.org/artifacttypes"/>
-    <ArtifactTemplate xmlns:artifacttypes="http://opentosca.org/artifacttypes" id="MyTinyTest" name="MyTinyTest"
-                      type="artifacttypes:MiniArtifactType" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12">
+    <ArtifactTemplate xmlns:otartifacttypes="http://opentosca.org/artifacttypes" id="MyTinyTest" name="MyTinyTest"
+                      type="otartifacttypes:MiniArtifactType" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12">
         <ArtifactReferences>
             <ArtifactReference
                 reference="artifacttemplates/http%253A%252F%252Fopentosca.org%252Fartifacttemplates/MyTinyTest/files/blub.zip"/>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/artifactTemplateContainsUpdatedFileReferenceInJson-withFile.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/artifactTemplateContainsUpdatedFileReferenceInJson-withFile.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_artifacttemplates-artifactTemplateContainsUpdatedFileReferenceInJson",
+    "id": "winery-defs-for_otartifacttemplates-artifactTemplateContainsUpdatedFileReferenceInJson",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/artifactTemplateContainsUpdatedFileReferenceInJson-withoutFile.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/artifactTemplateContainsUpdatedFileReferenceInJson-withoutFile.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_artifacttemplates-artifactTemplateContainsUpdatedFileReferenceInJson",
+    "id": "winery-defs-for_otartifacttemplates-artifactTemplateContainsUpdatedFileReferenceInJson",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/admin/namspacesList.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/admin/namspacesList.json
@@ -36,10 +36,6 @@
         "namespace": "http://www.example.org"
     },
     {
-        "prefix": "otnt",
-        "namespace": "http://www.opentosca.org/nodetypes"
-    },
-    {
         "prefix": "winery",
         "namespace": "http://www.opentosca.org/winery/extensions/tosca/2013/02/12"
     },

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war.xml
@@ -1,4 +1,4 @@
-<Definitions xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" id="winery-defs-for_artifacttypes-WAR"
+<Definitions xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" id="winery-defs-for_otartifacttypes-WAR"
              targetNamespace="http://opentosca.org/artifacttypes">
     <ArtifactType name="WAR" targetNamespace="http://opentosca.org/artifacttypes"/>
 </Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_element.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_element.xml
@@ -18,7 +18,7 @@
                 <winery:type>xsd:string</winery:type>
             </winery:properties>
         </winery:PropertiesDefinition>
-        <PropertiesDefinition xmlns:nodetypes="http://opentosca.org/nodetypes"
-                              element="nodetypes:CloudProviderProperties"/>
+        <PropertiesDefinition xmlns:otnodetypes="http://opentosca.org/nodetypes"
+                              element="otnodetypes:CloudProviderProperties"/>
     </ArtifactType>
 </Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_kv.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war_with_properties_kv.xml
@@ -15,7 +15,7 @@
             </winery:properties>
         </winery:PropertiesDefinition>
         <PropertiesDefinition
-            xmlns:winery2="http://winery.opentosca.org/test/artifacttypes/fruits/propertiesdefinition/winery"
-            type="winery2:properties"/>
+            xmlns:atypd="http://winery.opentosca.org/test/artifacttypes/fruits/propertiesdefinition/winery"
+            type="atypd:properties"/>
     </ArtifactType>
 </Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/baobab_initial_with_definitions_expected.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/baobab_initial_with_definitions_expected.xml
@@ -29,7 +29,7 @@
                 <winery:type>xsd:anyURI</winery:type>
             </winery:properties>
         </winery:PropertiesDefinition>
-        <PropertiesDefinition xmlns:fruits="http://winery.opentosca.org/test/nodetypes/fruits"
-                              type="fruits:BaobabProperties"/>
+        <PropertiesDefinition xmlns:ntyfruits="http://winery.opentosca.org/test/nodetypes/fruits"
+                              type="ntyfruits:BaobabProperties"/>
     </NodeType>
 </Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/baobab_updated_expected.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/baobab_updated_expected.xml
@@ -29,7 +29,7 @@
                 <winery:type>xsd:anyURI</winery:type>
             </winery:properties>
         </winery:PropertiesDefinition>
-        <PropertiesDefinition xmlns:fruits="http://winery.opentosca.org/test/nodetypes/fruits"
-                              type="fruits:BaobabProperties"/>
+        <PropertiesDefinition xmlns:ntyfruits="http://winery.opentosca.org/test/nodetypes/fruits"
+                              type="ntyfruits:BaobabProperties"/>
     </NodeType>
 </Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/policytypes/fruits-at-c25aa724201824fce6eddcc7c35a666c6e015880.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/policytypes/fruits-at-c25aa724201824fce6eddcc7c35a666c6e015880.xml
@@ -5,6 +5,6 @@
             namespace="http://winery.opentosca.org/test/policytypes/fruits"/>
     <PolicyType abstract="no" final="yes" name="european"
                 targetNamespace="http://winery.opentosca.org/test/policytypes/fruits">
-        <DerivedFrom xmlns:fruits="http://winery.opentosca.org/test/policytypes/fruits" typeRef="fruits:organic"/>
+        <DerivedFrom xmlns:wfp="http://winery.opentosca.org/test/policytypes/fruits" typeRef="wfp:organic"/>
     </PolicyType>
 </Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/relationshiptypes/kiwi_initial.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/relationshiptypes/kiwi_initial.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_fruits-kiwi",
+    "id": "winery-defs-for_ntyfruits-kiwi",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/JAXBSupport.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/JAXBSupport.java
@@ -13,21 +13,22 @@
  *******************************************************************************/
 package org.eclipse.winery.repository;
 
-import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
-import org.apache.commons.lang3.StringUtils;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+
 import org.eclipse.winery.model.selfservice.Application;
 import org.eclipse.winery.model.tosca.TDefinitions;
 import org.eclipse.winery.model.tosca.constants.Namespaces;
 import org.eclipse.winery.model.tosca.kvproperties.WinerysPropertiesDefinition;
 import org.eclipse.winery.repository.backend.MockXMLElement;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
+
+import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 
 // if com.sun.xml.bind.marshaller.NamespacePrefixMapper cannot be resolved,
 // possibly
@@ -67,7 +68,7 @@ public class JAXBSupport {
             }
 
             if (!requirePrefix && namespaceUri.equals(Namespaces.TOSCA_NAMESPACE)) {
-                // in case no prefix is required and the namespace is the TOCSA namespace, there should be no prefix added at all to increase human-readability of the XML
+                // in case no prefix is required and the namespace is the TOSCA namespace, there should be no prefix added at all to increase human-readability of the XML
                 LOGGER.trace("No prefix required: returning null.");
                 return null;
             }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/NamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/NamespaceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,44 +13,47 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend;
 
-import org.eclipse.winery.common.ids.Namespace;
-
 import java.util.Collection;
+
+import org.eclipse.winery.common.ids.Namespace;
 
 public interface NamespaceManager {
 
-    /**
-     * SIDEFFECT: URI is added to list of known namespaces if it did not exist
-     * before
-     */
     default String getPrefix(Namespace namespace) {
         String ns = namespace.getDecoded();
         return this.getPrefix(ns);
     }
 
     /**
-     * SIDEFFECT: URI is added to list of known namespaces if it did not exist
-     * before
+     * Returns a prefix for the given namespace. With two different namespaces, to different prefixes are returned.
+     * The returned prefixes are not persistest. Thus, two instances of a NamespaceManager might return different
+     * prefixes when called in another order.
      */
     String getPrefix(String namespace);
 
-    boolean hasPrefix(String namespace);
+    /**
+     * Determines whether the storage has a namespace prefix stored permanently. This differs from just issuuing a
+     * {@link #getPrefix(String)} request, which just determines something, but does not persist it between calls.
+     */
+    boolean hasPermanentPrefix(String namespace);
 
-    void remove(String namespace);
+    void removePermanentPrefix(String namespace);
 
-    void setPrefix(String namespace, String prefix);
+    /**
+     * Permanently stores a prefix
+     */
+    void setPermanentPrefix(String namespace, String prefix);
 
-    Collection<String> getAllPrefixes();
+    Collection<String> getAllPermanentPrefixes();
 
-    Collection<String> getAllNamespaces();
+    Collection<String> getAllPermanentNamespaces();
 
-    default void addNamespace(String namespace) {
-        this.getPrefix(namespace);
+    default void addPermanentNamespace(String namespace) {
+        this.setPermanentPrefix(namespace, this.getPrefix(namespace));
     }
 
     /**
      * Removes all namespace mappings
      */
     void clear();
-
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/NamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/NamespaceManager.java
@@ -14,12 +14,15 @@
 package org.eclipse.winery.repository.backend;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import org.eclipse.winery.common.ids.Namespace;
 
 public interface NamespaceManager {
 
     default String getPrefix(Namespace namespace) {
+        Objects.requireNonNull(namespace);
+
         String ns = namespace.getDecoded();
         return this.getPrefix(ns);
     }
@@ -40,7 +43,7 @@ public interface NamespaceManager {
     void removePermanentPrefix(String namespace);
 
     /**
-     * Permanently stores a prefix
+     * Permanently stores a prefix. No action, if namespace or prefix are null or empty.
      */
     void setPermanentPrefix(String namespace, String prefix);
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
@@ -13,16 +13,27 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
-import org.apache.commons.configuration.Configuration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
 import org.eclipse.winery.model.tosca.constants.Namespaces;
 import org.eclipse.winery.repository.backend.NamespaceManager;
 
-import java.util.*;
+import org.apache.commons.configuration.Configuration;
 
 public class ConfigurationBasedNamespaceManager implements NamespaceManager {
 
     private Configuration configuration;
+    private Map<String, String> namespaceToPrefixMap = new HashMap<>();
 
+    /**
+     * @param configuration The configuration to read from and store data into
+     */
     public ConfigurationBasedNamespaceManager(Configuration configuration) {
         this.configuration = configuration;
 
@@ -36,41 +47,91 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
 
         // example namespaces opened for users to create new types
         this.configuration.setProperty(Namespaces.EXAMPLE_NAMESPACE_URI, "ex");
-        this.configuration.setProperty(Namespaces.URI_OPENTOSCA_NODETYPE, "otnt");
     }
 
     @Override
     public String getPrefix(String namespace) {
         Objects.requireNonNull(namespace);
+        // configuration stores the permanent mapping
+        // this has precedence
         String prefix = configuration.getString(namespace);
         if (prefix == null) {
-            prefix = this.generatePrefix(namespace);
-            this.configuration.setProperty(namespace, prefix);
+            // in case no permanent mapping is found, check the in-memory ones
+            prefix = this.namespaceToPrefixMap.get(namespace);
+            if (prefix == null) {
+                prefix = this.generatePrefix(namespace);
+                this.namespaceToPrefixMap.put(namespace, prefix);
+            }
         }
         return prefix;
     }
 
     @Override
-    public boolean hasPrefix(String namespace) {
+    public boolean hasPermanentPrefix(String namespace) {
         return this.configuration.containsKey(namespace);
     }
 
     @Override
-    public void remove(String namespace) {
+    public void removePermanentPrefix(String namespace) {
         this.configuration.clearProperty(namespace);
+        // ensure that in-memory mapping also does not have the key any more
+        this.namespaceToPrefixMap.remove(namespace);
     }
 
     @Override
-    public void setPrefix(String namespace, String prefix) {
-        if (!this.getAllPrefixes().contains(prefix)) {
+    public void setPermanentPrefix(String namespace, String prefix) {
+        if (!this.getAllPermanentPrefixes().contains(prefix)) {
             this.configuration.setProperty(namespace, prefix);
+            // ensure that in-memory mapping also does not have the key any more
+            this.namespaceToPrefixMap.remove(namespace);
         }
+    }
+
+    /**
+     * Generates a string indicating the kind of definitions children maintained by the namespace
+     *
+     * @return empty string if nothing could be matched
+     */
+    private String generateKindString(String namespace) {
+        String mid;
+        if (namespace.contains("servicetemplates/")) {
+            mid = "ste";
+        } else if (namespace.contains("nodetypes/")) {
+            mid = "nty";
+        } else if (namespace.contains("nodetypeimplementations/")) {
+            mid = "ntyi";
+        } else if (namespace.contains("relationshiptypes/")) {
+            mid = "nty";
+        } else if (namespace.contains("relationshiptypeimplementations/")) {
+            mid = "rtyi";
+        } else if (namespace.contains("artifacttypes/")) {
+            mid = "aty";
+        } else if (namespace.contains("artifacttemplates/")) {
+            mid = "ate";
+        } else if (namespace.contains("requirementtypes/")) {
+            mid = "rty";
+        } else if (namespace.contains("capabilitytypes/")) {
+            mid = "cty";
+        } else if (namespace.contains("policytypes/")) {
+            mid = "pty";
+        } else if (namespace.contains("policytemplates/")) {
+            mid = "pte";
+        } else if (namespace.contains("compliancerules/")) {
+            mid = "cr";
+        } else if (namespace.contains("types/")) {
+            mid = "ty";
+        } else if (namespace.contains("templates/")) {
+            mid = "te";
+        } else {
+            mid = "";
+        }
+        return mid;
     }
 
     /**
      * Tries to generate a prefix based on the last part of the URL
      */
-    private String generatePrefixProposal(String namespace, int round) {
+    public String generatePrefixProposal(String namespace, int round) {
         Objects.requireNonNull(namespace);
         String[] split = namespace.split("/");
         if (split.length == 0) {
@@ -78,22 +139,40 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
         } else {
             String result;
             result = split[split.length - 1].replaceAll("[^A-Za-z]+", "");
+
+            String prefix;
+            if (namespace.startsWith(Namespaces.URI_START_OPENTOSCA)) {
+                prefix = "ot";
+            } else {
+                prefix = "";
+            }
+
+            String mid = this.generateKindString(namespace);
+
             if (result.isEmpty()) {
-                return String.format("ns%d", round);
+                if (prefix.isEmpty()) {
+                    prefix = "ns";
+                }
+                return String.format("%s%s%d", prefix, mid, round);
             } else {
                 if (round == 0) {
-                    return result;
+                    return prefix + mid + result;
                 } else {
-                    return String.format("%s%d", result, round);
+                    return String.format("%s%s%s%d", prefix, mid, result, round);
                 }
             }
         }
     }
 
+    /**
+     * Generates a prefix for the given namespace. There must not be a prefix existing for the namespace.
+     */
     private String generatePrefix(String namespace) {
         Objects.requireNonNull(namespace);
         String prefix;
-        Collection<String> allPrefixes = this.getAllPrefixes();
+        Set<String> allPrefixes = new HashSet<>();
+        allPrefixes.addAll(this.getAllPermanentPrefixes());
+        allPrefixes.addAll(this.namespaceToPrefixMap.values());
 
         int round = 0;
         do {
@@ -103,7 +182,7 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
         return prefix;
     }
 
-    public Collection<String> getAllPrefixes() {
+    public Collection<String> getAllPermanentPrefixes() {
         Iterator<String> keys = this.configuration.getKeys();
         Set<String> res = new HashSet<>();
         while (keys.hasNext()) {
@@ -115,7 +194,7 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
     }
 
     @Override
-    public Collection<String> getAllNamespaces() {
+    public Collection<String> getAllPermanentNamespaces() {
         Iterator<String> keys = this.configuration.getKeys();
         Set<String> res = new HashSet<>();
         while (keys.hasNext()) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
@@ -51,12 +51,15 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
 
     @Override
     public String getPrefix(String namespace) {
-        Objects.requireNonNull(namespace);
+        if (namespace == null) {
+            namespace = "";
+        }
+
         // configuration stores the permanent mapping
         // this has precedence
         String prefix = configuration.getString(namespace);
-        if (prefix == null) {
-            // in case no permanent mapping is found, check the in-memory ones
+        if (prefix == null || prefix.isEmpty()) {
+            // in case no permanent mapping is found - or the prefix is invalid, check the in-memory ones
             prefix = this.namespaceToPrefixMap.get(namespace);
             if (prefix == null) {
                 prefix = this.generatePrefix(namespace);
@@ -80,6 +83,12 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
 
     @Override
     public void setPermanentPrefix(String namespace, String prefix) {
+        if (Objects.isNull(namespace) || Objects.isNull(prefix)) {
+            return;
+        }
+        if (namespace.isEmpty() || prefix.isEmpty()) {
+            return;
+        }
         if (!this.getAllPermanentPrefixes().contains(prefix)) {
             this.configuration.setProperty(namespace, prefix);
             // ensure that in-memory mapping also does not have the key any more
@@ -151,6 +160,9 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
 
             if (result.isEmpty()) {
                 if (prefix.isEmpty()) {
+                    if ((round == 0) && namespace.isEmpty()) {
+                        return "null";
+                    }
                     prefix = "ns";
                 }
                 return String.format("%s%s%d", prefix, mid, round);
@@ -169,6 +181,7 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
      */
     private String generatePrefix(String namespace) {
         Objects.requireNonNull(namespace);
+
         String prefix;
         Set<String> allPrefixes = new HashSet<>();
         allPrefixes.addAll(this.getAllPermanentPrefixes());

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
@@ -101,7 +101,9 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
      *
      * @return empty string if nothing could be matched
      */
-    private String generateKindString(String namespace) {
+    private String generateDefinitionsChildTypeAbbreviation(String namespace) {
+        Objects.requireNonNull(namespace);
+
         String mid;
         if (namespace.contains("servicetemplates/")) {
             mid = "ste";
@@ -156,7 +158,7 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
                 prefix = "";
             }
 
-            String mid = this.generateKindString(namespace);
+            String mid = this.generateDefinitionsChildTypeAbbreviation(namespace);
 
             if (result.isEmpty()) {
                 if (prefix.isEmpty()) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
@@ -167,7 +167,7 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
                 }
                 return String.format("%s%s%d", prefix, mid, round);
             } else {
-                if (namespace.contains("propertiesdefinition") && result.equals("winery")) {
+                if (namespace.contains("propertiesdefinition") && "winery".equals(result)) {
                     // in case, it is a winery propertiesdefinition, end with "pd" (and not with winery or pdwinery)
                     result = "pd";
                 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
@@ -167,6 +167,10 @@ public class ConfigurationBasedNamespaceManager implements NamespaceManager {
                 }
                 return String.format("%s%s%d", prefix, mid, round);
             } else {
+                if (namespace.contains("propertiesdefinition") && result.equals("winery")) {
+                    // in case, it is a winery propertiesdefinition, end with "pd" (and not with winery or pdwinery)
+                    result = "pd";
+                }
                 if (round == 0) {
                     return prefix + mid + result;
                 } else {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
@@ -227,7 +227,7 @@ public class CsarImporter {
             while (namespaces.hasNext()) {
                 boolean addToStorage = false;
                 String namespace = namespaces.next();
-                if (namespaceManager.hasPrefix(namespace)) {
+                if (namespaceManager.hasPermanentPrefix(namespace)) {
                     String storedPrefix = namespaceManager.getPrefix(namespace);
                     // QUICK HACK to check whether the prefix is a generated one
                     // We assume we know the internal generation routine
@@ -242,7 +242,7 @@ public class CsarImporter {
                 }
                 if (addToStorage) {
                     String prefix = pconf.getString(namespace);
-                    namespaceManager.setPrefix(namespace, prefix);
+                    namespaceManager.setPermanentPrefix(namespace, prefix);
                 }
             }
         }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+package org.eclipse.winery.repository.backend.filebased;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConfigurationBasedNamespaceManagerTest {
+
+    private ConfigurationBasedNamespaceManager configurationBasedNamespaceManager;
+    
+    @Before
+    public void initializeNamespaceManager() {
+        this.configurationBasedNamespaceManager = new ConfigurationBasedNamespaceManager(new BaseConfiguration());
+    }
+    
+    @Test
+    public void openToscaNodeTypesCorrectlyProposed() {
+        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.generatePrefixProposal("http://opentosca.org/nodetypes/example", 0));
+    }
+
+    @Test
+    public void nonOpenToscaNodeTypesCorrectlyProposed() {
+        Assert.assertEquals("ntyexample", this.configurationBasedNamespaceManager.generatePrefixProposal("http://example.org/nodetypes/example", 0));
+    }
+
+    @Test
+    public void openToscaNodeTypesCorrect() {
+        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+    }
+
+    @Test
+    public void openToscaNodeTypesCorrectAtSecondCall() {
+        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+    }
+
+    @Test
+    public void openToscaNodeTypesCorrectAtSimilarNamespaces() {
+        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        Assert.assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
+    }
+
+    @Test
+    public void openToscaNodeTypesCorrectAtSimilarNamespacesWithUniqueness() {
+        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        Assert.assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
+        
+        // try again -> same prefixes have to be returned
+        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        Assert.assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
+    }
+
+}

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
@@ -75,5 +75,4 @@ public class ConfigurationBasedNamespaceManagerTest {
         Assert.assertEquals("null", this.configurationBasedNamespaceManager.getPrefix((String) null));
     }
 
-
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
@@ -64,4 +64,16 @@ public class ConfigurationBasedNamespaceManagerTest {
         Assert.assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
     }
 
+    @Test
+    public void xmlNullNamespaceHasPrefix() {
+        // the XML null namespace is the empty string
+        Assert.assertEquals("null", this.configurationBasedNamespaceManager.getPrefix(""));
+    }
+
+    @Test
+    public void nullNamespaceHasPrefix() {
+        Assert.assertEquals("null", this.configurationBasedNamespaceManager.getPrefix((String) null));
+    }
+
+
 }


### PR DESCRIPTION
We often have changes at `Namespaces.properties` during usage of Winery. This reduces it to no automatic changes.

Feature: More readable prefixes.

Feature: Also handle the NULL Namespace (https://github.com/eclipse/winery/pull/242/commits/c5ff12e25d77d37c682f1ccb09b4fd419f4efb54)

Had also to adapt the test cases to reflect the new prefix generation (3e9f12dda4b89367ab6f67fc071d098436a3dff8)

This PR also fixes modification of the color when just reading the color (https://github.com/eclipse/winery/pull/242/commits/4378175f6286d65a9fab13b063a0e56ef5c2993c).