### PR TITLE
Fix/display of properties

### DIFF
--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/enums.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/enums.ts
@@ -44,3 +44,9 @@ export enum toggleModalType {
     DeploymentArtifacts = 'DEPLOYMENT_ARTIFACTS',
     Policies = 'POLICIES',
 }
+
+export enum PropertyDefinitionType {
+    NONE = 'NONE',
+    KV = 'KV',
+    XML = 'XML'
+}

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/groupedNodeTypeModel.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/groupedNodeTypeModel.ts
@@ -1,5 +1,5 @@
-<!--
- * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,17 +10,12 @@
  * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
--->
+ *******************************************************************************/
 
-<winery-toscatype-table
-    [toscaType]="'deploymentArtifacts'"
-    [currentNodeData]="currentNodeData"
-    [toscaTypeData]="deploymentArtifacts">
-</winery-toscatype-table>
+export interface GroupedNodeTypeModel {
+    children: Array<NodeTypeModel>; id: string; text: string;
+}
 
-<div class="button-wrapper">
-    <div (click)="toggleModal($event);" class="btn btn-sm btn-modal" style="display: block;">
-        Add new Deployment Artifact
-    </div>
-</div>
-
+export interface NodeTypeModel {
+    full: any; id: string; text: string;
+}

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
@@ -109,7 +109,6 @@
                 (toggleModalHandler)="sendToggleAction($event)"
                 [currentNodeData]="{entityTypes: entityTypes,
                                     nodeTemplate: nodeTemplate,
-                                    currentNodePart: 'PROPERTIES',
                                     propertyDefinitionType: propertyDefinitionType}">
             </winery-properties>
         </accordion-group>

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/policies/policies.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/policies/policies.component.html
@@ -12,10 +12,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 -->
 
-<winery-properties-content
-    [currentNodeData]="currentNodeData">
-</winery-properties-content>
-
 <winery-toscatype-table
     [toscaType]="'policies'"
     [currentNodeData]="currentNodeData"

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/properties-content/properties-content.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/properties-content/properties-content.component.ts
@@ -19,6 +19,7 @@ import { IWineryState } from '../../redux/store/winery.store';
 import { WineryActions } from '../../redux/actions/winery.actions';
 import { Subscription } from 'rxjs/Subscription';
 import { JsPlumbService } from '../../services/jsPlumbService';
+import { PropertyDefinitionType } from '../../models/enums';
 
 @Component({
     selector: 'winery-properties-content',
@@ -43,21 +44,17 @@ export class PropertiesContentComponent implements OnInit, OnChanges, OnDestroy 
      * Angular lifecycle event.
      */
     ngOnChanges(changes: SimpleChanges) {
-        setTimeout(() => {
-            if (this.currentNodeData.currentNodePart === 'PROPERTIES') {
-                if (changes.currentNodeData.currentValue.nodeTemplate.properties) {
-                    try {
-                        const currentProperties = changes.currentNodeData.currentValue.nodeTemplate.properties;
-                        if (this.currentNodeData.propertyDefinitionType === 'KV') {
-                            this.nodeProperties = currentProperties.kvproperties;
-                        } else if (this.currentNodeData.propertyDefinitionType === 'XML') {
-                            this.nodeProperties = currentProperties.any;
-                        }
-                    } catch (e) {
-                    }
+        if (changes.currentNodeData.currentValue.nodeTemplate.properties) {
+            try {
+                const currentProperties = changes.currentNodeData.currentValue.nodeTemplate.properties;
+                if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.KV) {
+                    this.nodeProperties = currentProperties.kvproperties;
+                } else if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.XML) {
+                    this.nodeProperties = currentProperties.any;
                 }
+            } catch (e) {
             }
-        }, 1);
+        }
         // repaint jsPlumb to account for height change of the accordion
         setTimeout(() => this.jsPlumbService.getJsPlumbInstance().repaintEverything(), 1);
     }
@@ -66,14 +63,12 @@ export class PropertiesContentComponent implements OnInit, OnChanges, OnDestroy 
      * Angular lifecycle event.
      */
     ngOnInit() {
-
         if (this.currentNodeData.nodeTemplate.properties) {
-            console.log(this.currentNodeData);
             try {
                 const currentProperties = this.currentNodeData.nodeTemplate.properties;
-                if (this.currentNodeData.propertyDefinitionType === 'KV') {
+                if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.KV) {
                     this.nodeProperties = currentProperties.kvproperties;
-                } else if (this.currentNodeData.propertyDefinitionType === 'XML') {
+                } else if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.XML) {
                     this.nodeProperties = currentProperties.any;
                 }
             } catch (e) {
@@ -92,22 +87,18 @@ export class PropertiesContentComponent implements OnInit, OnChanges, OnDestroy 
             .debounceTime(300)
             .distinctUntilChanged()
             .subscribe(value => {
-                if (this.currentNodeData.propertyDefinitionType === 'KV') {
+                if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.KV) {
                     this.nodeProperties[this.key] = value;
                 } else {
                     this.nodeProperties = value;
                 }
-                switch (this.currentNodeData.currentNodePart) {
-                    case 'PROPERTIES':
-                        this.$ngRedux.dispatch(this.actions.setProperty({
-                            nodeProperty: {
-                                newProperty: this.nodeProperties,
-                                propertyType: this.currentNodeData.propertyDefinitionType,
-                                nodeId: this.currentNodeData.nodeTemplate.id
-                            }
-                        }));
-                        break;
-                }
+                this.$ngRedux.dispatch(this.actions.setProperty({
+                    nodeProperty: {
+                        newProperty: this.nodeProperties,
+                        propertyType: this.currentNodeData.propertyDefinitionType,
+                        nodeId: this.currentNodeData.nodeTemplate.id
+                    }
+                }));
             }));
     }
 


### PR DESCRIPTION
Reduced the loading time of the node template properties display

- Start and end date: 2018-05-17 to 2018-05-20
- Contributor: Thommy Zelenik, @zelenikty
- Supervisor: Karoline Saatkamp, @saatkamp, Lukas Harzenetter, @lharzenetter, Oliver Kopp, @koppor

Node template properties are now faster displayed as before. Next step: Display the properties upon application load

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
