### PR TITLE
Display all relationship templates

### DIFF
--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
@@ -936,6 +936,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit, DoChec
                 this.handleNewRelationship(currentRelationships);
             } else if (difference > 0 || difference < 0) {
                 this.allRelationshipTemplates = currentRelationships;
+                this.allRelationshipTemplates.forEach(relTemplate => this.manageRelationships(relTemplate));
             }
         } else if (storeRelationshipsLength !== 0 && localRelationshipsCopyLength !== 0) {
             this.updateRelName(currentRelationships);


### PR DESCRIPTION
Signed-off-by: Thommy Zelenik <t.zelenik@live.de>

Fixed the issue that in some cases a relationship template is not displayed upon loading a service template

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://chris.beams.io/posts/git-commit/)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
