### PR TITLE
Deploy common and repository.configuration

### DIFF
--- a/org.eclipse.winery.common/pom.xml
+++ b/org.eclipse.winery.common/pom.xml
@@ -30,7 +30,6 @@
     </distributionManagement>
     <properties>
         <checkstyle.config.location>../checkstyle.xml</checkstyle.config.location>
-        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     <dependencies>
         <dependency>

--- a/org.eclipse.winery.repository.configuration/pom.xml
+++ b/org.eclipse.winery.repository.configuration/pom.xml
@@ -23,9 +23,6 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.winery.repository.configuration</artifactId>
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
     <build>
         <resources>
             <resource>


### PR DESCRIPTION
Enable the deployment of the `org.eclipse.winery.common` and `org.eclipse.winery.repository.configuration`.