### PR TITLE
Fix/delay loading until palette is filled

### DIFF
--- a/org.eclipse.winery.topologymodeler.ui/src/app/services/backend.service.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/services/backend.service.ts
@@ -87,6 +87,9 @@ export class BackendService {
     private topologyTemplatesDiffAndVisuals = new Subject<[TTopologyTemplate, Visuals, ToscaDiff, TTopologyTemplate]>();
     topologyTemplatesDiffAndVisuals$ = this.topologyTemplatesDiffAndVisuals.asObservable();
 
+    private allEntities = new Subject<any>();
+    allEntities$ = this.allEntities.asObservable();
+
     constructor(private http: HttpClient,
                 private activatedRoute: ActivatedRoute,
                 private alert: WineryAlertService) {
@@ -101,6 +104,13 @@ export class BackendService {
                     + encodeURIComponent(encodeURIComponent(this.configuration.ns)) + '/'
                     + this.configuration.id;
                 console.log(this.topologyTemplateURL);
+
+                // All Entity types
+                this.requestAllEntitiesAtOnce().subscribe(data => {
+                    // add JSON to Promise, WineryComponent will subscribe to its Observable
+                    this.allEntities.next(data);
+                });
+
                 // ServiceTemplate / TopologyTemplate
                 this.requestServiceTemplate().subscribe(data => {
                     // add JSON to Promise, WineryComponent will subscribe to its Observable
@@ -201,6 +211,27 @@ export class BackendService {
                 resolve(false);
             }
         });
+    }
+
+    /**
+     * Requests all entities together.
+     * We use Observable.forkJoin to await all responses from the backend.
+     * This is required
+     * @returns data  The JSON from the server
+     */
+    requestAllEntitiesAtOnce(): Observable<Object> {
+        if (this.configuration) {
+            return Observable.forkJoin(this.requestGroupedNodeTypes(),
+                                        this.requestArtifactTemplates(),
+                                        this.requestTopologyTemplateAndVisuals(),
+                                        this.requestArtifactTypes(),
+                                        this.requestPolicyTypes(),
+                                        this.requestCapabilityTypes(),
+                                        this.requestRequirementTypes(),
+                                        this.requestPolicyTemplates(),
+                                        this.requestRelationshipTypes(),
+                                        this.requestNodeTypes());
+        }
     }
 
     /**

--- a/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
@@ -14,7 +14,9 @@
 
 import 'rxjs/add/operator/do';
 import { Component, OnInit } from '@angular/core';
-import { EntityType, TNodeTemplate, TRelationshipTemplate, TTopologyTemplate, Visuals } from './models/ttopology-template';
+import {
+    EntityType, TNodeTemplate, TRelationshipTemplate, TTopologyTemplate, Visuals
+} from './models/ttopology-template';
 import { ILoaded, LoadedService } from './services/loaded.service';
 import { AppReadyEventService } from './services/app-ready-event.service';
 import { BackendService } from './services/backend.service';
@@ -69,65 +71,51 @@ export class WineryComponent implements OnInit {
      * inside the Redux store of this application.
      */
     ngOnInit() {
-        // Grouped NodeTypes
-        this.backendService.groupedNodeTypes$.subscribe(JSON => {
-            this.initEntityType(JSON, 'groupedNodeTypes');
-        });
-        // Artifact Templates
-        this.backendService.artifactTemplates$.subscribe(JSON => {
-            this.initEntityType(JSON, 'artifactTemplates');
-        });
+        this.backendService.allEntities$.subscribe(JSON => {
+            // Grouped NodeTypes
+            this.initEntityType(JSON[0], 'groupedNodeTypes');
 
-        /**
-         * This subscriptionProperties receives an Observable of [string, string], the former value being
-         * the JSON representation of the topologyTemplate and the latter value being the JSON
-         * representation of the node types' visual appearances
-         * the backendService makes sure that both get requests finish before pushing data onto this Observable
-         * by using Observable.forkJoin(1$, 2$);
-         */
-        this.backendService.topologyTemplatesDiffAndVisuals$.subscribe((JSON: [TTopologyTemplate, Visuals, ToscaDiff, TTopologyTemplate]) => {
-            const topologyTemplate = JSON[0];
-            this.entityTypes.nodeVisuals = JSON[1];
+            // Artifact Templates
+            this.initEntityType(JSON[1], 'artifactTemplates');
 
-            if (JSON.length === 4 && !isNullOrUndefined(JSON[2]) && !isNullOrUndefined(JSON[3])) {
-                this.topologyDifferences = [JSON[2], JSON[3]];
+            /**
+             * This subscriptionProperties receives an Observable of [string, string], the former value being
+             * the JSON representation of the topologyTemplate and the latter value being the JSON
+             * representation of the node types' visual appearances
+             * the backendService makes sure that both get requests finish before pushing data onto this Observable
+             * by using Observable.forkJoin(1$, 2$);
+             * */
+            const topologyTemplate = JSON[2][0];
+            this.entityTypes.nodeVisuals = JSON[2][1];
+            if (JSON.length === 4 && !isNullOrUndefined(JSON[2][2]) && !isNullOrUndefined(JSON[3])) {
+                this.topologyDifferences = [JSON[2], JSON[2][3]];
             }
-
             // init the NodeTemplates and RelationshipTemplates to start their rendering
             this.initTopologyTemplate(topologyTemplate.nodeTemplates, topologyTemplate.relationshipTemplates);
 
-            this.loaded = {loadedData: true, generatedReduxState: false};
-            this.appReadyEvent.trigger();
-        });
+            // Artifact types
+            this.initEntityType(JSON[3], 'artifactTypes');
 
-        // Get other entity types
-        // Artifact Types
-        this.backendService.artifactTypes$.subscribe(JSON => {
-            this.initEntityType(JSON, 'artifactTypes');
-        });
-        // Policy Types
-        this.backendService.policyTypes$.subscribe(JSON => {
-            this.initEntityType(JSON, 'policyTypes');
-        });
-        // Capability Types
-        this.backendService.capabilityTypes$.subscribe(JSON => {
-            this.initEntityType(JSON, 'capabilityTypes');
-        });
-        // Requirement Types
-        this.backendService.requirementTypes$.subscribe(JSON => {
-            this.initEntityType(JSON, 'requirementTypes');
-        });
-        // PolicyTemplates
-        this.backendService.policyTemplates$.subscribe(JSON => {
-            this.initEntityType(JSON, 'policyTemplates');
-        });
-        // Relationship Types
-        this.backendService.relationshipTypes$.subscribe(JSON => {
-            this.initEntityType(JSON, 'relationshipTypes');
-        });
-        // NodeTypes
-        this.backendService.nodeTypes$.subscribe(JSON => {
-            this.initEntityType(JSON, 'unGroupedNodeTypes');
+            // Policy types
+            this.initEntityType(JSON[4], 'policyTypes');
+
+            // Capability Types
+            this.initEntityType(JSON[5], 'capabilityTypes');
+
+            // Requirement Types
+            this.initEntityType(JSON[6], 'requirementTypes');
+
+            // PolicyTemplates
+            this.initEntityType(JSON[7], 'policyTemplates');
+
+            // Relationship Types
+            this.initEntityType(JSON[8], 'relationshipTypes');
+
+            // NodeTypes
+            this.initEntityType(JSON[9], 'unGroupedNodeTypes');
+
+            this.loaded = { loadedData: true, generatedReduxState: false };
+            this.appReadyEvent.trigger();
         });
     }
 


### PR DESCRIPTION
Delayed the loading of the app until the grouped node types are fetched from the server which takes a little time because of requiring the 'full' ones

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://chris.beams.io/posts/git-commit/)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
