### PR TITLE
Allow null in getTopologyTemplate

### DIFF
--- a/docs/adr/0022-tosca-model-is-more-relaxed-than-the-xsd.md
+++ b/docs/adr/0022-tosca-model-is-more-relaxed-than-the-xsd.md
@@ -1,0 +1,39 @@
+# tosca.model is more relaxed than the XSD
+
+* Status: Accepted
+* Date: 2018-06-06
+
+## Context and Problem Statement
+
+There is a data model for a) serializing/deserializing the XML contents, b) internal backend handling, c) working with algorithms, d) communicating with the REST service.
+Currently, this is the same model.
+The UI might generate non-valid XML files (in the sence of not passing the XSD validation).
+For instance, if a user creates a service template, that service template does not contain a topology template.
+Furthermore, a topolgoy template needs to have at least one node template.
+
+## Considered Options
+
+* Keep one model and allow non-XSD validating models in `org.eclipse.winery.model.tosca`
+* Only allow (XSD-) validating models
+* Develop two models
+
+## Decision Outcome
+
+Chosen option: "Keep one model and allow non-XSD validating models in `org.eclipse.winery.model.tosca`", because 
+
+- XSD is meant for "executable" TOSCA definitions, not for intermediate modeling results
+- currently too much effort to develop two models  
+
+## License
+
+Copyright (c) 2018 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+which is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TServiceTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TServiceTemplate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,41 +14,20 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
-/**
- * <p>Java class for tServiceTemplate complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tServiceTemplate">
- *   &lt;complexContent>
- *     &lt;extension base="{http://docs.oasis-open.org/tosca/ns/2011/12}tExtensibleElements">
- *       &lt;sequence>
- *         &lt;element name="Tags" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tTags" minOccurs="0"/>
- *         &lt;element name="BoundaryDefinitions" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tBoundaryDefinitions"
- * minOccurs="0"/>
- *         &lt;element name="TopologyTemplate" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tTopologyTemplate"/>
- *         &lt;element name="Plans" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tPlans" minOccurs="0"/>
- *       &lt;/sequence>
- *       &lt;attribute name="id" use="required" type="{http://www.w3.org/2001/XMLSchema}ID" />
- *       &lt;attribute name="name" type="{http://www.w3.org/2001/XMLSchema}string" />
- *       &lt;attribute name="targetNamespace" type="{http://www.w3.org/2001/XMLSchema}anyURI" />
- *       &lt;attribute name="substitutableNodeType" type="{http://www.w3.org/2001/XMLSchema}QName" />
- *       &lt;anyAttribute processContents='lax' namespace='##other'/>
- *     &lt;/extension>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
+import org.eclipse.jdt.annotation.Nullable;
+
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tServiceTemplate", propOrder = {
     "tags",
@@ -81,7 +60,6 @@ public class TServiceTemplate extends HasId implements HasName, HasTargetNamespa
     protected QName substitutableNodeType;
 
     public TServiceTemplate() {
-
     }
 
     public TServiceTemplate(Builder builder) {
@@ -115,60 +93,33 @@ public class TServiceTemplate extends HasId implements HasName, HasTargetNamespa
         return Objects.hash(super.hashCode(), tags, boundaryDefinitions, topologyTemplate, plans, name, targetNamespace, substitutableNodeType);
     }
 
-    /**
-     * Gets the value of the tags property.
-     *
-     * @return possible object is {@link TTags }
-     */
     @Nullable
     public TTags getTags() {
         return tags;
     }
 
-    /**
-     * Sets the value of the tags property.
-     *
-     * @param value allowed object is {@link TTags }
-     */
-    public void setTags(TTags value) {
+    public void setTags(@Nullable TTags value) {
         this.tags = value;
     }
 
-    /**
-     * Gets the value of the boundaryDefinitions property.
-     *
-     * @return possible object is {@link TBoundaryDefinitions }
-     */
     @Nullable
     public TBoundaryDefinitions getBoundaryDefinitions() {
         return boundaryDefinitions;
     }
 
-    /**
-     * Sets the value of the boundaryDefinitions property.
-     *
-     * @param value allowed object is {@link TBoundaryDefinitions }
-     */
-    public void setBoundaryDefinitions(TBoundaryDefinitions value) {
+    public void setBoundaryDefinitions(@Nullable TBoundaryDefinitions value) {
         this.boundaryDefinitions = value;
     }
 
     /**
-     * Gets the value of the topologyTemplate property.
-     *
-     * @return possible object is {@link TTopologyTemplate }
+     * Even though the XSD requires that the topology template is always set, during modeling, it might be null
      */
-    @NonNull
+    @Nullable
     public TTopologyTemplate getTopologyTemplate() {
         return topologyTemplate;
     }
 
-    /**
-     * Sets the value of the topologyTemplate property.
-     *
-     * @param value allowed object is {@link TTopologyTemplate }
-     */
-    public void setTopologyTemplate(TTopologyTemplate value) {
+    public void setTopologyTemplate(@Nullable TTopologyTemplate value) {
         this.topologyTemplate = value;
     }
 


### PR DESCRIPTION
## Context and Problem Statement
 
There is a data model for a) serializing/deserializing the XML contents, b) internal backend handling, c) working with algorithms, d) communicating with the REST service.
Currently, this is the same model.
The UI might generate non-valid XML files (in the sence of not passing the XSD validation).
For instance, if a user creates a service template, that service template does not contain a topology template.
Furthermore, a topolgoy template needs to have at least one node template.
 
## Considered Options
 
* Keep one model and allow non-XSD validating models in `org.eclipse.winery.model.tosca`
* Only allow (XSD-) validating models
* Develop two models
 
## Decision Outcome
 
Chosen option: "Keep one model and allow non-XSD validating models in `org.eclipse.winery.model.tosca`", because 

- XSD is meant for "executable" TOSCA definitions, not for intermediate modeling results
- currently too much effort to develop two models  
 