### PR TITLE
Add ADR-0023

### DIFF
--- a/docs/adr/0009-manual-tosca-yaml-serialisation.md
+++ b/docs/adr/0009-manual-tosca-yaml-serialisation.md
@@ -27,4 +27,3 @@ http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
 which is available at https://www.apache.org/licenses/LICENSE-2.0.
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-

--- a/docs/adr/0018-version-identifier.md
+++ b/docs/adr/0018-version-identifier.md
@@ -1,8 +1,9 @@
-# Version Identifier
+# Version Identifier in a Debian-like Form
 
 The version identifier must be defined with its parts and meanings.
 
 The version must support three parts:
+
 1. The part of which specifies the version of the modeled component
 2. A management version specifying the TOSCA version (`w`)
 3. A work-in-progress (`wip`) version to clearly identify development steps
@@ -15,10 +16,11 @@ The version must support three parts:
 
 ## Decision Outcome
 
-Chosen Option: Debian like schema because it supports "pre-versions" such as the required `wip` version
+Chosen Option: "Debian like schema", because it supports "pre-versions" such as the required `wip` version
 
-Positive Consequences:
-  * `wip` version is always smaller than the actual release: `example_1.0-w2-wip4 < example_1.0-w2`
+### Positive Consequences
+
+* `wip` version is always smaller than the actual release: `example_1.0-w2-wip4 < example_1.0-w2`
 
 ## License
 

--- a/docs/adr/0023-use-maven-as-build-tool.md
+++ b/docs/adr/0023-use-maven-as-build-tool.md
@@ -1,0 +1,78 @@
+# Use Maven as build tool
+
+## Context and Problem Statement
+
+Which build tool should be used?
+
+## Considered Options
+
+* [Maven](https://maven.apache.org/)
+* [Gradle](https://gradle.org/)
+* [Ant](https://ant.apache.org/)
+
+## Decision Outcome
+
+Chosen option: "Maven", because
+
+* None of Gradle's customizability and the overhead in setup that comes with that is required.
+* The structure the comes with Maven makes the build files easier to understand compared to ANT.
+
+## Pros and Cons of the Options
+
+### Maven
+
+* Good, because most of Eclipse projects use Maven for building.
+* Good, because [there is a plugin for almost everything](https://www.slant.co/versus/2107/11592/~apache-maven_vs_gradle)
+* Good, because [it has good integration with third party tools](http://pages.zeroturnaround.com/rs/zeroturnaround/images/java-build-tools-part-2.pdf)
+* Good, because [it has robust performance](http://pages.zeroturnaround.com/rs/zeroturnaround/images/java-build-tools-part-2.pdf)
+* Good, because [it has a high popularity](http://pages.zeroturnaround.com/rs/zeroturnaround/images/java-build-tools-part-2.pdf)
+* Good, [if one favors declarative over imperative](https://www.slant.co/versus/2107/11592/~apache-maven_vs_gradle)
+* Bad, because [getting a dependency list is not straight forward](https://stackoverflow.com/q/1677473/873282)
+* Bad, because [it based on a fixed and linear model of phases](https://dzone.com/articles/gradle-vs-maven)
+* Bad, because [it is hard to customize](https://www.slant.co/versus/2107/11592/~apache-maven_vs_gradle)
+* Bad, because [it needs plugins for everything](https://www.slant.co/versus/2107/11592/~apache-maven_vs_gradle)
+* Bad, because [it is verbose leading to huge build files](https://technologyconversations.com/2014/06/18/build-tools/)
+
+### Gradle
+
+* Good, because [its build scripts are short](https://technologyconversations.com/2014/06/18/build-tools/)
+* Good, because [it follows the convention over configuration approach](https://www.safaribooksonline.com/library/view/building-and-testing/9781449306816/ch04.html)
+* Good, because [it offers a graph-based task dependencies](https://dzone.com/articles/gradle-vs-maven)
+* Good, because [it is easy to customize](http://pages.zeroturnaround.com/rs/zeroturnaround/images/java-build-tools-part-2.pdf)
+* Good, because [it offers custom dependency scopes](https://gradle.org/maven-vs-gradle/)
+* Good, because [it has good community support](https://linuxhint.com/ant-vs-maven-vs-gradle/)
+* Good, because [its performance can be 100 times more than maven's performance](https://gradle.org/gradle-vs-maven-performance/).
+* Bad, because [not that many plugins are available/maintained yet](https://blog.philipphauer.de/moving-back-from-gradle-to-maven/)
+* Bad, because [it lacks a wide variety of application server integrations](http://pages.zeroturnaround.com/rs/zeroturnaround/images/java-build-tools-part-2.pdf)
+* Bad, because [it has a medium popularity](http://pages.zeroturnaround.com/rs/zeroturnaround/images/java-build-tools-part-2.pdf)
+* Bad, because [it allows custom build scripts which need to be debugged](https://www.softwareyoga.com/10-reasons-why-we-chose-maven-over-gradle/)
+
+### Ant
+
+* Good, because [it offers a lot of control over the build process](https://technologyconversations.com/2014/06/18/build-tools/)
+* Good, because [it has an agile dependency manager](https://blog.alejandrocelaya.com/2014/02/22/dependency-management-in-java-projects-with-ant-and-ivy/)
+* Good, because [it has a low learning curve](https://technologyconversations.com/2014/06/18/build-tools/)
+* Bad, because [build scripts can quickly become huge](https://technologyconversations.com/2014/06/18/build-tools/)
+* Bad, because [everything has to be written from scratch](http://www.baeldung.com/ant-maven-gradle)
+* Bad, because [no conventions are enforced which can make it hard to understand someone else's build script](http://www.baeldung.com/ant-maven-gradle)
+* Bad, because [it has nearly no community support](http://pages.zeroturnaround.com/rs/zeroturnaround/images/java-build-tools-part-2.pdf)
+* Bad, because [it has a low popularity](http://pages.zeroturnaround.com/rs/zeroturnaround/images/java-build-tools-part-2.pdf)
+* Bad, because [it offers too much freedom](https://www.slant.co/versus/2106/2107/~apache-ant_vs_apache-maven)
+
+## Links
+
+* GADR: <https://github.com/adr/gadr-java/blob/master/gadr-java--build-tool.md>
+
+## License
+
+Copyright (c) 2018 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+which is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -22,8 +22,12 @@ This lists the architectural decisions for Eclipse Winery.
 - [ADR-0015](0015-copy-source-to-files.md) - Offer copying files from the source to the files folder
 - [ADR-0016](0016-reflection-test-for-tosca-yaml-builder.md) - Reflection test for TOSCA YAML builder
 - [ADR-0017](0017-modify-jax-b-generated-classes.md) - Modify JAX-B generated classes
-- [ADR-0018](0018-version-identifier.md) - Version Identifiers in TOSCA
-- [ADR-0019](0019-version-in-the-name.md) - Version Identifier in the Name
+- [ADR-0018](0018-version-identifier.md) - Version Identifier in a Debian-like Form
+- [ADR-0019](0019-version-in-the-name.md) - Versions of TOSCA elements in the name
+- [ADR-0020](0020-TOSCA-definitions-contain-extactly-one-element.md) - TOSCA Definitions contain excaly one element
+- [ADR-0021](0021-use-logback-for-logging.md) - Use logback for logging
+- [ADR-0022](0022-tosca-model-is-more-relaxed-than-the-xsd.md) - tosca.model is more relaxed than the XSD
+- [ADR-0023](0023-use-maven-as-build-tool.md) - Use Maven as build tool
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
 Adds an ADR for Maven as build tool. Motivation: Research on [GADR](https://github.com/adr/gadr-java) vs. [MADR](https://adr.github.io/madr/).

I also updated the TOC and slightly fixed ADR-0018.