### PR TITLE
This fixes the layouting issue.

### DIFF
--- a/org.eclipse.winery.topologymodeler.ui/src/app/layout/layout.directive.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/layout/layout.directive.ts
@@ -57,12 +57,12 @@ export class LayoutDirective {
 
         // get width and height of nodes
         nodeChildrenArray.forEach(node => {
-            const width = node.elRef.nativeElement.firstChild.nextElementSibling.offsetWidth;
-            const height = node.elRef.nativeElement.firstChild.nextElementSibling.offsetHeight;
+            const width = node.elRef.nativeElement.firstChild.offsetWidth;
+            const height = node.elRef.nativeElement.firstChild.offsetHeight;
             children.push(new LayoutChildNodeModel(node.nodeTemplate.id, width, height));
             // also get their current positions and apply them to the internal list
-            const left = node.elRef.nativeElement.firstChild.nextElementSibling.offsetLeft;
-            const top = node.elRef.nativeElement.firstChild.nextElementSibling.offsetTop;
+            const left = node.elRef.nativeElement.firstChild.offsetLeft;
+            const top = node.elRef.nativeElement.firstChild.offsetTop;
             node.nodeTemplate.x = left;
             node.nodeTemplate.y = top;
         });
@@ -131,7 +131,7 @@ export class LayoutDirective {
         // if there is only 1 node selected, do nothing
         if (!(selectedNodeComponents.length === 1)) {
             const topPositions = selectedNodeComponents.map((node) => {
-                return node.elRef.nativeElement.firstChild.nextElementSibling.offsetTop;
+                return node.elRef.nativeElement.firstChild.offsetTop;
             });
             // add biggest value to smallest and divide by 2, to get the exact middle of both
             result = ((Math.max.apply(null, topPositions) + Math.min.apply(null, topPositions)) / 2);


### PR DESCRIPTION
This fixes the layouting issue of nodeTemplates that was caused by faulty references to their respective DOM representations.

- Start and end date: 2018-06-18
- Contributor: Josip Ledic, @ledicjp
- Supervisor: Karoline Saatkamp, @saatkamp; Lukas Harzenetter, @lharzenetter


- [X] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [X] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [X] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [X] Ensure to use auto format in **all** files
