### PR TITLE
Fix @Nullable annotation at getName()

### DIFF
--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityTemplate.java
@@ -118,7 +118,7 @@ public abstract class TEntityTemplate extends HasId implements HasType, HasName 
         return propertyConstraints;
     }
 
-    public void setPropertyConstraints(TEntityTemplate.PropertyConstraints value) {
+    public void setPropertyConstraints(TEntityTemplate.@Nullable PropertyConstraints value) {
         this.propertyConstraints = value;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityType.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityType.java
@@ -159,14 +159,16 @@ public class TEntityType extends TExtensibleElements implements HasName, HasInhe
         this.propertiesDefinition = value;
     }
 
-    @NonNull
+    @ADR(22)
+    @Nullable
     @Override
     public String getName() {
         return name;
     }
 
+    @ADR(22)
     @Override
-    public void setName(String value) {
+    public void setName(@Nullable String value) {
         this.name = value;
     }
 


### PR DESCRIPTION
According to [ADR-0022](https://github.com/eclipse/winery/blob/master/docs/adr/0022-tosca-model-is-more-relaxed-than-the-xsd.md), our internal model should be relaxed. This PR fixes that.

Note that we do not return `""` as this is not a valid NCName and the other parts in the data model are still returning `null`. In the long run, we should follow [Java by Comparison's](http://java.by-comparison.com) "Favor Optional over Null".