### PR TITLE
Ignore extracted orion editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ collected-*/
 node_modules/
 winery-debug.log
 **/gen/**
+org.eclipse.winery.repository.ui/src/assets/build-code**
 
 ## Eclipse
 **/.classpath


### PR DESCRIPTION
During the build, the repository UI generates `org.eclipse.winery.repository.ui/src/assets/built-codeEdit15_1/`. With this, these files are not shown in git gui anymore.