### PR TITLE
fix modal for entering input and output parameters for plans

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/plans/plans.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/plans/plans.component.html
@@ -98,9 +98,8 @@
     </winery-modal-footer>
 </winery-modal>
 
-
-<winery-modal bsModal #ioModal="bs-modal" [modalRef]="ioModal">
-    <winery-modal-header [title]="'Edit Parameters'">
+<ng-template #ioModal>
+    <winery-modal-header [modalRef]="ioModalRef" [title]="'Edit Parameters'">
     </winery-modal-header>
     <winery-modal-body>
         <winery-io-parameter [inputParameters]="newPlan.inputParameters.inputParameter"
@@ -108,11 +107,12 @@
         </winery-io-parameter>
     </winery-modal-body>
     <winery-modal-footer
+        [modalRef]="ioModalRef"
         (onOk)="editPlan()"
         [closeButtonLabel]="'Cancel'"
         [okButtonLabel]="'Save'">
     </winery-modal-footer>
-</winery-modal>
+</ng-template>
 
 <winery-modal bsModal #confirmDeleteModal="bs-modal" [modalRef]="confirmDeleteModal">
     <winery-modal-header [title]="'Delete Property'">

--- a/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/plans/plans.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/serviceTemplates/plans/plans.component.ts
@@ -24,6 +24,7 @@ import { InputParameters, OutputParameters } from '../../../wineryInterfaces/par
 import { backendBaseURL, workflowModelerURL } from '../../../configuration';
 import { InstanceService } from '../../instance.service';
 import { HttpErrorResponse } from '@angular/common/http';
+import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 
 const bpmn4tosca = 'http://www.opentosca.org/bpmn4tosca';
 
@@ -67,6 +68,8 @@ export class PlansComponent implements OnInit {
     fileToUpload: any;
     uploaderUrl: string;
 
+    ioModalRef: BsModalRef;
+
     @ViewChild('addPlanModal') addPlanModal: any;
     @ViewChild('uploader') uploader: WineryUploaderComponent;
 
@@ -75,7 +78,8 @@ export class PlansComponent implements OnInit {
 
     constructor(private notify: WineryNotificationService,
                 public sharedData: InstanceService,
-                private service: PlansService) {
+                private service: PlansService,
+                private modalService: BsModalService) {
     }
 
     ngOnInit() {
@@ -116,7 +120,7 @@ export class PlansComponent implements OnInit {
         if (isNullOrUndefined(this.newPlan.outputParameters)) {
             this.newPlan.outputParameters = new OutputParameters();
         }
-        this.ioModal.show();
+        this.ioModalRef = this.modalService.show(this.ioModal);
     }
 
     onCellSelected(plan: WineryRowData) {

--- a/org.eclipse.winery.repository.ui/src/app/wineryIoParameter/wineryIoParameter.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryIoParameter/wineryIoParameter.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2017 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -32,8 +32,8 @@
     </winery-table>
 </div>
 
-<winery-modal bsModal #addIntParametersModal="bs-modal" [modalRef]="addIntParametersModal">
-    <winery-modal-header [title]="modalTitle"></winery-modal-header>
+<ng-template #addIntParametersModal>
+    <winery-modal-header [modalRef]="addIntParametersModalRef" [title]="modalTitle"></winery-modal-header>
     <winery-modal-body>
         <form #parameterForm="ngForm">
             <div class="form-group">
@@ -81,6 +81,7 @@
         </form>
     </winery-modal-body>
     <winery-modal-footer
+        [modalRef]="addIntParametersModalRef"
         (onOk)="modalTitle === 'Input Parameter'
                                 ? onAddInputParam(paramName.value, paramType.value, required.checked)
                                 : onAddOutputParam(paramName.value, paramType.value, required.checked);"
@@ -88,15 +89,16 @@
         [okButtonLabel]="'Add'"
         [disableOkButton]="!parameterForm?.form.valid">
     </winery-modal-footer>
-</winery-modal>
+</ng-template>
 
-<winery-modal bsModal #removeElementModal="bs-modal" [modalRef]="removeElementModal">
-    <winery-modal-header [title]="modalTitle"></winery-modal-header>
+<ng-template #removeElementModal>
+    <winery-modal-header [modalRef]="removeElementModalRef" [title]="modalTitle"></winery-modal-header>
     <winery-modal-body>
         <p>
             Are you sure you want to remove <span style="font-weight:bold;">{{ elementToRemove }}</span>?
         </p>
     </winery-modal-body>
-    <winery-modal-footer [closeButtonLabel]="'Cancel'" [okButtonLabel]="'Delete'"
+    <winery-modal-footer [modalRef]="removeElementModalRef"
+                         [closeButtonLabel]="'Cancel'" [okButtonLabel]="'Delete'"
                          (onOk)="onRemoveElement()"></winery-modal-footer>
-</winery-modal>
+</ng-template>

--- a/org.eclipse.winery.repository.ui/src/app/wineryIoParameter/wineryIoParameter.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryIoParameter/wineryIoParameter.component.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,25 +11,28 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-import {Component, EventEmitter, Input, Output, ViewChild} from '@angular/core';
-import {WineryTableColumn} from '../wineryTableModule/wineryTable.component';
-import {InterfaceParameter} from '../wineryInterfaces/parameters';
-import {WineryValidatorObject} from '../wineryValidators/wineryDuplicateValidator.directive';
-import {YesNoEnum} from '../wineryInterfaces/enums';
-import {WineryNotificationService} from '../wineryNotificationModule/wineryNotification.service';
-import {NgForm} from '@angular/forms';
-import {ModalDirective} from 'ngx-bootstrap';
+import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { WineryTableColumn } from '../wineryTableModule/wineryTable.component';
+import { InterfaceParameter } from '../wineryInterfaces/parameters';
+import { WineryValidatorObject } from '../wineryValidators/wineryDuplicateValidator.directive';
+import { YesNoEnum } from '../wineryInterfaces/enums';
+import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
+import { NgForm } from '@angular/forms';
+import { BsModalRef, BsModalService, ModalDirective } from 'ngx-bootstrap';
 
 /**
  * This component provides two tables for adding and removing input and output parameters as they are used for example
  * in the {@link InterfacesComponent}. Therefore you need to specify the arrays containing the input/output parameters
- * as an {@link InterfaceParameter} array. Additionally, there are some events which fire upon adding/removing elements.
+ * as an {@link InterfaceParameter} array. Additionally, there are some events which fire upon adding/removing
+ * elements.
  *
  * <label>Inputs</label>
  * <ul>
- *     <li><code>inputParameters</code> the array for the input parameters. It must be of type {@link InterfaceParameter}.
+ *     <li><code>inputParameters</code> the array for the input parameters. It must be of type {@link
+ *     InterfaceParameter}.
  *     </li>
- *     <li><code>outputParameters</code> the array for the output parameters. It must be of type {@link InterfaceParameter}.
+ *     <li><code>outputParameters</code> the array for the output parameters. It must be of type
+ *     {@link InterfaceParameter}.
  *     </li>
  * </ul>
  *
@@ -41,11 +44,11 @@ import {ModalDirective} from 'ngx-bootstrap';
  *     <li><code>outputParameterAdded</code> fires upon adding a output parameter to the table. It also contains the
  *     added element which is of type {@link InterfaceParameter}..
  *     </li>
- *     <li><code>inputParameterRemoved</code> fires upon removing a input parameter from the table. It also contains the
- *     removed element which is of type {@link InterfaceParameter}.
+ *     <li><code>inputParameterRemoved</code> fires upon removing a input parameter from the table. It also contains
+ *     the removed element which is of type {@link InterfaceParameter}.
  *     </li>
- *     <li><code>outputParameterRemoved</code> fires upon removing a output parameter from the table. It also contains the
- *     removed element which is of type {@link InterfaceParameter}.
+ *     <li><code>outputParameterRemoved</code> fires upon removing a output parameter from the table. It also contains
+ *     the removed element which is of type {@link InterfaceParameter}.
  *     </li>
  * </ul>
  *
@@ -77,16 +80,19 @@ export class WineryIoParameterComponent {
     selectedInputParameter: InterfaceParameter;
     selectedOutputParameter: InterfaceParameter;
     columns: Array<WineryTableColumn> = [
-        {title: 'Name', name: 'name', sort: true},
-        {title: 'Type', name: 'type', sort: true},
-        {title: 'Required', name: 'required', sort: false}
+        { title: 'Name', name: 'name', sort: true },
+        { title: 'Type', name: 'type', sort: true },
+        { title: 'Required', name: 'required', sort: false }
     ];
 
     modalTitle: string;
     elementToRemove: string;
     validatorObject: WineryValidatorObject;
+    addIntParametersModalRef: BsModalRef;
+    removeElementModalRef: BsModalRef;
 
-    constructor(private notify: WineryNotificationService) {
+    constructor(private notify: WineryNotificationService,
+                private modalService: BsModalService) {
 
     }
 
@@ -94,8 +100,8 @@ export class WineryIoParameterComponent {
     addInputParam() {
         this.modalTitle = 'Input Parameter';
         this.validatorObject = new WineryValidatorObject(this.inputParameters, 'name');
+        this.addIntParametersModalRef = this.modalService.show(this.addIntParametersModal);
         this.parameterForm.reset();
-        this.addIntParametersModal.show();
     }
 
     onAddInputParam(name: string, type: string, required: boolean) {
@@ -111,7 +117,7 @@ export class WineryIoParameterComponent {
     removeInputParameter() {
         this.modalTitle = 'Remove Input Parameter';
         this.elementToRemove = this.selectedInputParameter.name;
-        this.removeElementModal.show();
+        this.removeElementModalRef = this.modalService.show(this.removeElementModal);
     }
 
     onRemoveInputParameter() {
@@ -126,8 +132,8 @@ export class WineryIoParameterComponent {
     addOutputParam() {
         this.modalTitle = 'Output Parameter';
         this.validatorObject = new WineryValidatorObject(this.outputParameters, 'name');
+        this.addIntParametersModalRef = this.modalService.show(this.addIntParametersModal);
         this.parameterForm.reset();
-        this.addIntParametersModal.show();
     }
 
     onAddOutputParam(name: string, type: string, required: boolean) {
@@ -143,7 +149,7 @@ export class WineryIoParameterComponent {
     removeOutputParameter() {
         this.modalTitle = 'Remove Output Parameter';
         this.elementToRemove = this.selectedOutputParameter.name;
-        this.removeElementModal.show();
+        this.removeElementModalRef = this.modalService.show(this.removeElementModal);
     }
 
     onRemoveOutputParameter() {

--- a/org.eclipse.winery.repository.ui/src/app/wineryModalModule/winery.modal.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryModalModule/winery.modal.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2017 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -11,7 +11,6 @@
   ~
   ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<script src="../section/section.module.ts"></script>
 <div class="modal-dialog" [ngClass]="getCssClasses()">
     <div class="modal-content">
         <ng-content></ng-content>

--- a/org.eclipse.winery.repository.ui/src/app/wineryModalModule/winery.modal.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryModalModule/winery.modal.component.ts
@@ -11,55 +11,33 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-import {AfterContentInit, AfterViewInit, Component, ContentChild, HostBinding, Input} from '@angular/core';
-import {isNullOrUndefined} from 'util';
-import {WineryModalFooterComponent} from './winery.modal.footer.component';
-import {WineryModalHeaderComponent} from './winery.modal.header.component';
-import {ModalDirective} from 'ngx-bootstrap';
-import {WineryModalSize} from './wineryModalSize';
+import { AfterContentInit, AfterViewInit, Component, ContentChild, HostBinding, Input } from '@angular/core';
+import { deprecate, isNullOrUndefined } from 'util';
+import { WineryModalFooterComponent } from './winery.modal.footer.component';
+import { WineryModalHeaderComponent } from './winery.modal.header.component';
+import { ModalDirective } from 'ngx-bootstrap';
+import { WineryModalSize } from './wineryModalSize';
 
 /**
- * This component provides a generic modal component for any kind of pop-ups.
- * To use it, the {@link WineryModalModule} must be imported in the corresponding module.
- *
- * In order to use this component, see the following example, note that the <code>modalRef</code> must be set.
- * For further information, see the sub-components {@link WineryModalHeaderComponent}, {@link WineryModalBodyComponent},
- * and {@link WineryModalFooterComponent}.
- *
- * <label>Inputs</label>
- * <ul>
- *     <li><code>modalRef</code> The modalRef must be set, otherwise the component will not work!
- *     </li>
- *     <li><code>size</code>
- *     </li>
- *     <li><code>keyboard</code>
- *     </li>
- *     <li><code>backdrop</code>
- *     </li>
- * </ul>
- *
- * @example <caption>Short Example</caption>
- * ```html
- * <winery-modal bsModal #confirmDeleteModal="bs-modal" [modalRef]="confirmDeleteModal">
- *     <winery-modal-header [title]="'Delete Property'">
- *     </winery-modal-header>
+ * @deprecated
+ * This component should not be used anymore
+ * Please use <ng-template> and the BsModalService to show a modal (e.g. plan.component.ts).
+ * @example
+ * <ng-template #removeElementModal>
+ *     <winery-modal-header [modalRef]="removeElementModalRef" [title]="modalTitle"></winery-modal-header>
  *     <winery-modal-body>
- *         <p *ngIf="elementToRemove != null">
- *         Do you want to delete the Element
- *             <span style="font-weight:bold;">{{ elementToRemove.key }}</span>?
- *         </p>
+ *         <p>Test</p>
  *     </winery-modal-body>
- *     <winery-modal-footer (onOk)="removeConfirmed();"
- *                          [closeButtonLabel]="'Cancel'"
- *                          [okButtonLabel]="'Delete'">
- *     </winery-modal-footer>
- * </winery-modal>
- * ```
+ *     <winery-modal-footer [modalRef]="removeElementModalRef"
+ *              [closeButtonLabel]="'Cancel'" [okButtonLabel]="'Delete'"
+ *              (onOk)="onRemoveElement()"></winery-modal-footer>
+ *</ng-template>
  */
 @Component({
     selector: 'winery-modal',
     templateUrl: 'winery.modal.component.html',
 })
+
 export class WineryModalComponent implements AfterViewInit, AfterContentInit {
 
     @Input() modalRef: ModalDirective;

--- a/org.eclipse.winery.repository.ui/src/app/wineryModalModule/winery.modal.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryModalModule/winery.modal.module.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,14 +11,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-import {CommonModule} from '@angular/common';
-import {NgModule} from '@angular/core';
-import {BrowserModule} from '@angular/platform-browser';
-import {ModalModule} from 'ngx-bootstrap';
-import {WineryModalBodyComponent} from './winery.modal.body.component';
-import {WineryModalComponent} from './winery.modal.component';
-import {WineryModalFooterComponent} from './winery.modal.footer.component';
-import {WineryModalHeaderComponent} from './winery.modal.header.component';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { ModalModule } from 'ngx-bootstrap';
+import { WineryModalBodyComponent } from './winery.modal.body.component';
+import { WineryModalComponent } from './winery.modal.component';
+import { WineryModalFooterComponent } from './winery.modal.footer.component';
+import { WineryModalHeaderComponent } from './winery.modal.header.component';
 
 /**
  * This module must be imported in order to use the {@link WineryModalComponent}. Documentation on how to use


### PR DESCRIPTION
Signed-off-by: Karoline Saatkamp <karoline.saatkamp@iaas.uni-stuttgart.de>

Fix the modal to add I/O parameters to plans that the modal is nested and is opening correctly in the context of the parent.

Modal to add new input and output parameters to a plan:
![image](https://user-images.githubusercontent.com/18379143/42315341-7fefe4fe-8047-11e8-8e89-9f488641414b.png)

Modal to add a parameter is now opening not inside the other modal:
![image](https://user-images.githubusercontent.com/18379143/42315447-bcb9ce90-8047-11e8-9e16-3b01b4dcb267.png)


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
