### PR TITLE
Fix inital open palette in topology modeler

### DIFF
--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
@@ -33,7 +33,7 @@ export interface WineryState {
 }
 
 export const INITIAL_WINERY_STATE: WineryState = {
-    currentPaletteOpenedState: false,
+    currentPaletteOpenedState: true,
     hideNavBarAndPaletteState: false,
     sidebarContents: {
         sidebarVisible: false,


### PR DESCRIPTION
Signed-off-by: Karoline Saatkamp <karoline.saatkamp@iaas.uni-stuttgart.de>

Fix inital open palette in topology modeler

- [ ] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [ ] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
