### PR TITLE
Add processing of LICENSE and README.md files at CSAR export/import time

### DIFF
--- a/docs/adr/0026-store-license-and-readme-in-entity-root-folder-in-csar.md
+++ b/docs/adr/0026-store-license-and-readme-in-entity-root-folder-in-csar.md
@@ -1,0 +1,43 @@
+# Store `LICENSE` and `README.md` in respective entity's root folder in a CSAR
+
+## Context and Problem Statement
+
+`LICENSE` and `README.md` have to be stored in a standardized location when CSARs are exported.
+
+## Decision Drivers
+
+- Standardized CSAR structure
+
+## Considered Options
+
+* Store these files in a root folder of a respective entity
+* Store these files in separate folders in a root folder of a respective entity
+
+## Decision Outcome
+
+Chosen option: "Store these files in a root folder of a respective entity", because
+
+- Less visual clutter
+- In repository, these files are not separated and stored together with the definition file
+
+### Positive Consequences
+
+- Standardized access to `LICENSE` and `README.md` files in any Winery-exported CSAR 
+
+## Negative Consequences
+
+- Puts additional restrictions on the CSAR's structure
+
+## License
+
+Copyright (c) 2018 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+which is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -30,6 +30,7 @@ This lists the architectural decisions for Eclipse Winery.
 - [ADR-0023](0023-use-maven-as-build-tool.md) - Use Maven as build tool
 - [ADR-0024](0024-use-travis-for-continuous-integration.md) - Use TravisCI for Continuous Integration
 - [ADR-0025](0025-use-same-logback-test-xml-for-each-sub-project.md) - Use same `logback-test.xml` for each sub project
+- [ADR-0026](0026-store-license-and-readme-in-entity-root-folder-in-csar.md) - Store `LICENSE` and `README.md` in respective entity's root folder in a CSAR 
 
 <!-- adrlogstop -->
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Constants.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Constants.java
@@ -71,4 +71,7 @@ public class Constants {
 
     public static final String DIRNAME_SELF_SERVICE_METADATA = "SELFSERVICE-Metadata";
 
+    public static final String LICENSE_FILE_NAME = "LICENSE";
+    public static final String README_FILE_NAME = "README.md";
+
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/CsarExporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/CsarExporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -137,6 +137,9 @@ public class CsarExporter {
                 Collection<DefinitionsChildId> referencedIds;
                 referencedIds = exporter.exportTOSCA(repository, currentId, zos, refMap, conf);
                 zos.closeArchiveEntry();
+
+                // for each entryId add license and readme files (if they exist) to the refMap
+                addLicenseAndReadmeFiles(repository, currentId, refMap);
 
                 exportedState.flagAsExported(currentId);
                 exportedState.flagAsExportRequired(referencedIds);
@@ -403,9 +406,9 @@ public class CsarExporter {
      * Adds all self service meta data to the targetDir
      *
      * @param repository the repository to work from
-     * @param entryId the service template to export for
-     * @param targetDir the directory in the CSAR where to put the content to
-     * @param refMap    is used later to create the CSAR
+     * @param entryId    the service template to export for
+     * @param targetDir  the directory in the CSAR where to put the content to
+     * @param refMap     is used later to create the CSAR
      */
     private void addSelfServiceMetaData(IRepository repository, ServiceTemplateId entryId, String targetDir, Map<RepositoryFileReference, String> refMap) throws IOException {
         final SelfServiceMetaDataId selfServiceMetaDataId = new SelfServiceMetaDataId(entryId);
@@ -471,6 +474,17 @@ public class CsarExporter {
             refMap.put(ref, targetDir + fileName);
         } else {
             CsarExporter.LOGGER.error("Data corrupt: pointing to non-existent file " + ref);
+        }
+    }
+
+    private void addLicenseAndReadmeFiles(IRepository repository, DefinitionsChildId entryId, Map<RepositoryFileReference, String> refMap) {
+        final RepositoryFileReference licenseRef = new RepositoryFileReference(entryId, Constants.LICENSE_FILE_NAME);
+        if (repository.exists(licenseRef)) {
+            refMap.put(licenseRef, BackendUtils.getPathInsideRepo(licenseRef));
+        }
+        final RepositoryFileReference readmeRef = new RepositoryFileReference(entryId, Constants.README_FILE_NAME);
+        if (repository.exists(readmeRef)) {
+            refMap.put(readmeRef, BackendUtils.getPathInsideRepo(readmeRef));
         }
     }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,27 +13,70 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.importing;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.tika.mime.MediaType;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
 import org.eclipse.winery.common.RepositoryFileReference;
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.common.ids.XmlId;
-import org.eclipse.winery.common.ids.definitions.*;
+import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.common.ids.definitions.EntityTypeId;
+import org.eclipse.winery.common.ids.definitions.NodeTypeId;
+import org.eclipse.winery.common.ids.definitions.RelationshipTypeId;
+import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
 import org.eclipse.winery.common.ids.definitions.imports.GenericImportId;
 import org.eclipse.winery.common.ids.definitions.imports.XSDImportId;
 import org.eclipse.winery.common.ids.elements.PlanId;
 import org.eclipse.winery.common.ids.elements.PlansId;
 import org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFile;
 import org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileParser;
-import org.eclipse.winery.model.tosca.*;
+import org.eclipse.winery.model.tosca.Definitions;
+import org.eclipse.winery.model.tosca.TArtifactReference;
 import org.eclipse.winery.model.tosca.TArtifactReference.Exclude;
 import org.eclipse.winery.model.tosca.TArtifactReference.Include;
+import org.eclipse.winery.model.tosca.TArtifactTemplate;
 import org.eclipse.winery.model.tosca.TArtifactTemplate.ArtifactReferences;
+import org.eclipse.winery.model.tosca.TDefinitions;
 import org.eclipse.winery.model.tosca.TDefinitions.Types;
+import org.eclipse.winery.model.tosca.TEntityType;
 import org.eclipse.winery.model.tosca.TEntityType.PropertiesDefinition;
+import org.eclipse.winery.model.tosca.TExtensibleElements;
+import org.eclipse.winery.model.tosca.TImport;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TPlan;
 import org.eclipse.winery.model.tosca.TPlan.PlanModelReference;
+import org.eclipse.winery.model.tosca.TPlans;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
 import org.eclipse.winery.model.tosca.constants.Namespaces;
 import org.eclipse.winery.model.tosca.kvproperties.WinerysPropertiesDefinition;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
@@ -51,28 +94,14 @@ import org.eclipse.winery.repository.datatypes.ids.elements.DirectoryId;
 import org.eclipse.winery.repository.datatypes.ids.elements.SelfServiceMetaDataId;
 import org.eclipse.winery.repository.datatypes.ids.elements.VisualAppearanceId;
 import org.eclipse.winery.repository.export.CsarExporter;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.tika.mime.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
-
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Method;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.FileVisitResult.SKIP_SUBTREE;
@@ -435,6 +464,9 @@ public class CsarImporter {
                 entryServiceTemplate = Optional.of((ServiceTemplateId) wid);
             }
 
+            // import license and readme files
+            importLicenseAndReadme(defsPath.getParent().getParent(), wid, tmf, errors);
+
             // node types and relationship types are subclasses of TEntityType
             // Therefore, we check the entity type separately here
             if (ci instanceof TEntityType) {
@@ -688,6 +720,21 @@ public class CsarImporter {
         if (Files.exists(file)) {
             RepositoryFileReference ref = new RepositoryFileReference(visId, fileName);
             importFile(file, ref, tmf, rootPath, errors);
+        }
+    }
+
+    private void importLicenseAndReadme(Path rootPath, DefinitionsChildId wid, TOSCAMetaFile tmf, final List<String> errors) {
+        String pathInsideRepo = Util.getPathInsideRepo(wid);
+        Path defPath = rootPath.resolve(pathInsideRepo);
+        Path readmeFile = defPath.resolve(Constants.README_FILE_NAME);
+        Path licenseFile = defPath.resolve(Constants.LICENSE_FILE_NAME);
+        if (Files.exists(readmeFile)) {
+            RepositoryFileReference ref = new RepositoryFileReference(wid, Constants.README_FILE_NAME);
+            importFile(readmeFile, ref, tmf, rootPath, errors);
+        }
+        if (Files.exists(licenseFile)) {
+            RepositoryFileReference ref = new RepositoryFileReference(wid, Constants.LICENSE_FILE_NAME);
+            importFile(licenseFile, ref, tmf, rootPath, errors);
         }
     }
 


### PR DESCRIPTION
Add processing of `LICENSE` and `README.md` files at CSAR export/import time
Changes made:
- Add ADR
- Change CsarExporter to support export of `LICENSE` and `README.md` 
- Change CsarImporter to support import of `LICENSE` and `README.md`

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
