### PR TITLE
Switch the DA and IA tab

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/wineryArtifacts/artifact.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/wineryArtifacts/artifact.component.html
@@ -66,7 +66,7 @@
                 </div>
             </div>
 
-            <div *ngIf="!isDeploymentArtifact">
+            <div *ngIf="isImplementationArtifact">
                 <label class="control-label" for="interfaces">Interface Name</label>
                 <select [(ngModel)]="selectedInterface" id="interfaces" name="interfaces" class="form-control">
                     <option *ngFor="let interfaceItem of interfacesList" [ngValue]="interfaceItem">

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/wineryArtifacts/artifact.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/wineryArtifacts/artifact.component.ts
@@ -60,7 +60,7 @@ export class WineryArtifactComponent implements OnInit {
     baseUrl = hostURL;
     fileToRemove: FilesApiData;
     noneSelected = true;
-    isDeploymentArtifact = false;
+    isImplementationArtifact = false;
 
     commonColumns: WineryTableColumn[] = [
         { title: 'Name', name: 'name' },
@@ -94,15 +94,14 @@ export class WineryArtifactComponent implements OnInit {
         this.getArtifactTypes();
         this.newArtifact.artifactType = '';
 
-        if (this.router.url.includes('deploymentartifacts')) {
-            this.isDeploymentArtifact = true;
+        if (this.router.url.includes('implementationartifacts')) {
+            this.isImplementationArtifact = true;
             this.columns.splice(1, 0, this.implementationArtifactColumns[0]);
             this.columns.splice(2, 0, this.implementationArtifactColumns[1]);
-        } else {
             this.getInterfacesOfAssociatedType();
         }
 
-        this.name = this.isDeploymentArtifact ? 'Deployment' : 'Implementation';
+        this.name = this.isImplementationArtifact ? 'Implementation' : 'Deployment';
     }
 
     onAddClick() {
@@ -113,8 +112,8 @@ export class WineryArtifactComponent implements OnInit {
         } else {
             this.artifact.namespace = this.sharedData.toscaComponent.namespace;
         }
-        const deployment = this.isDeploymentArtifact ? 'Deployment' : 'Implementation';
-        this.artifact.name = this.sharedData.toscaComponent.localName.replace('_', '-') + '-' + deployment + 'Artifact';
+        const implementation = this.isImplementationArtifact ? 'Implementation' : 'Deployment';
+        this.artifact.name = this.sharedData.toscaComponent.localName.replace('_', '-') + '-' + implementation + 'Artifact';
         this.artifact.toscaType = ToscaTypes.ArtifactTemplate;
         this.addArtifactModal.show();
     }


### PR DESCRIPTION
Switch the deployment artifact and implementation artifact tab in the management ui for node type implementations

Signed-off-by: Karoline Saatkamp <karoline.saatkamp@iaas.uni-stuttgart.de>

The IA tab had no interface and operation element but the DA tab. According to the TOSCA spec it is the other way around. Therefore, the two tabs are switched now.

![image](https://user-images.githubusercontent.com/18379143/42443558-29c856a4-836e-11e8-9ca0-da70004e8c73.png)

![image](https://user-images.githubusercontent.com/18379143/42443586-37be1ad2-836e-11e8-9e19-ef62c977cfc0.png)


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
