### PR TITLE
Pins the save button to the color selector

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.css
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.css
@@ -67,10 +67,6 @@ winery-uploader {
     width: 200px;
 }
 
-.save {
-    margin-left: 850px;
-}
-
 /**
  * Definition of the  Arrow selector style
  */

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.html
@@ -15,14 +15,13 @@
     <winery-loader></winery-loader>
 </div>
 <div class="content" *ngIf="!loading">
-    <button (click)="saveToServer()" [disabled]="!sharedData?.currentVersion?.editable" class="btn btn-primary btn-sm save">Save</button>
-    <br/>
     <div class="colorPickerArea" *ngIf="!loading && nodeTypeData != null">
         <div class="floatContent">
             <b>Bordercolor:</b><br>
             <input class="colorInput" name="eventColor" type="color" [(ngModel)]="borderColorLocal" [disabled]="!sharedData?.currentVersion?.editable">
             <br/>click on the area above to change border color<br/>
         </div>
+        <button (click)="saveToServer()" [disabled]="!sharedData?.currentVersion?.editable" class="btn btn-primary btn-sm">Save</button>
     </div>
     <div class="colorPickerArea" *ngIf="!loading && relationshipData != null">
         <div class="floatContent">


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
![grafik](https://user-images.githubusercontent.com/23058331/42518579-6af24a0a-8462-11e8-8bbb-113b9c7e3714.png)

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [x] Screenshots added (for UI changes)
