### PR TITLE
fix loading of all elements

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IGenericRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IGenericRepository.java
@@ -216,8 +216,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
     <T extends DefinitionsChildId> SortedSet<T> getAllDefinitionsChildIds(Class<T> idClass);
 
     /**
-     * Returns all stable components available of the given id type.
-     * Components without a version are also included.
+     * Returns all stable components available of the given id type. Components without a version are also included.
      *
      * @param idClass class of the Ids to search for
      * @return empty set if no ids are available
@@ -241,8 +240,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
      * <p>
      * The generated Ids are linked as child to the id associated to the given reference
      * <p>
-     * Required for
-     * - getting plans nested in a service template: plans are nested below the PlansOfOneServiceTemplateId
+     * Required for - getting plans nested in a service template: plans are nested below the PlansOfOneServiceTemplateId
      * - exporting service templates
      *
      * @param ref     a reference to the TOSCA element to be checked. The path belonging to this element is checked.
@@ -290,20 +288,20 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
                 boolean referencesGivenQName = false;
 
                 if (element instanceof HasType) {
-                    referencesGivenQName = ((HasType) element).getTypeAsQName().equals(qNameOfTheType);
+                    referencesGivenQName = qNameOfTheType.equals(((HasType) element).getTypeAsQName());
                 }
 
                 if (!referencesGivenQName && element instanceof HasInheritance) {
                     HasType derivedFrom = ((HasInheritance) element).getDerivedFrom();
-                    referencesGivenQName = Objects.nonNull(derivedFrom) && derivedFrom.equals(qNameOfTheType);
+                    referencesGivenQName = Objects.nonNull(derivedFrom) && qNameOfTheType.equals(derivedFrom);
                 }
 
                 if (!referencesGivenQName && element instanceof TRelationshipType) {
                     TRelationshipType.ValidTarget validTarget = ((TRelationshipType) element).getValidTarget();
                     TRelationshipType.ValidSource validSource = ((TRelationshipType) element).getValidSource();
 
-                    referencesGivenQName = Objects.nonNull(validTarget) && validTarget.getTypeRef().equals(qNameOfTheType);
-                    referencesGivenQName = !referencesGivenQName && Objects.nonNull(validSource) && validSource.getTypeRef().equals(qNameOfTheType);
+                    referencesGivenQName = Objects.nonNull(validTarget) && qNameOfTheType.equals(validTarget.getTypeRef());
+                    referencesGivenQName = !referencesGivenQName && Objects.nonNull(validSource) && qNameOfTheType.equals(validSource.getTypeRef());
                 }
 
                 if (!referencesGivenQName && element instanceof TEntityTypeImplementation) {
@@ -312,8 +310,9 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
                         implementationArtifacts.getImplementationArtifact()
                             .stream()
                             .anyMatch(implementationArtifact ->
-                                implementationArtifact.getArtifactRef().equals(qNameOfTheType) ||
-                                    implementationArtifact.getArtifactType().equals(qNameOfTheType));
+                                qNameOfTheType.equals(implementationArtifact.getArtifactType()) ||
+                                    qNameOfTheType.equals(implementationArtifact.getArtifactRef())
+                            );
 
                     if (!referencesGivenQName && element instanceof TNodeTypeImplementation) {
                         TDeploymentArtifacts deploymentArtifacts = ((TNodeTypeImplementation) element).getDeploymentArtifacts();
@@ -321,8 +320,9 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
                             deploymentArtifacts.getDeploymentArtifact()
                                 .stream()
                                 .anyMatch(tDeploymentArtifact ->
-                                    tDeploymentArtifact.getArtifactRef().equals(qNameOfTheType) ||
-                                        tDeploymentArtifact.getArtifactType().equals(qNameOfTheType));
+                                    qNameOfTheType.equals(tDeploymentArtifact.getArtifactType()) ||
+                                        qNameOfTheType.equals(tDeploymentArtifact.getArtifactRef())
+                                );
                     }
                 }
 
@@ -330,7 +330,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
                     TAppliesTo appliesTo = ((TPolicyType) element).getAppliesTo();
                     referencesGivenQName = Objects.nonNull(appliesTo) && appliesTo.getNodeTypeReference()
                         .stream()
-                        .anyMatch(nodeTypeReference -> nodeTypeReference.getTypeRef().equals(qNameOfTheType));
+                        .anyMatch(nodeTypeReference -> qNameOfTheType.equals(nodeTypeReference.getTypeRef()));
                 }
 
                 if (!referencesGivenQName && element instanceof TNodeType) {
@@ -338,7 +338,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
                     referencesGivenQName = Objects.nonNull(requirementDefinitions) &&
                         requirementDefinitions.getRequirementDefinition()
                             .stream()
-                            .anyMatch(tRequirementDefinition -> tRequirementDefinition.getRequirementType().equals(qNameOfTheType));
+                            .anyMatch(tRequirementDefinition -> qNameOfTheType.equals(tRequirementDefinition.getRequirementType()));
 
                     if (!referencesGivenQName) {
                         TNodeType.CapabilityDefinitions capabilityDefinitions = ((TNodeType) element).getCapabilityDefinitions();
@@ -346,7 +346,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
                             capabilityDefinitions
                                 .getCapabilityDefinition()
                                 .stream()
-                                .anyMatch(tCapabilityDefinition -> tCapabilityDefinition.getCapabilityType().equals(qNameOfTheType));
+                                .anyMatch(tCapabilityDefinition -> qNameOfTheType.equals(tCapabilityDefinition.getCapabilityType()));
                     }
                 }
 
@@ -354,7 +354,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
                     TEntityType.PropertiesDefinition propertiesDefinition = ((TEntityType) element).getPropertiesDefinition();
                     if (Objects.nonNull(propertiesDefinition)) {
                         referencesGivenQName = Objects.nonNull(propertiesDefinition.getElement()) && propertiesDefinition.getElement().equals(qNameOfTheType)
-                            || Objects.nonNull(propertiesDefinition.getType()) && propertiesDefinition.getType().equals(qNameOfTheType);
+                            || Objects.nonNull(propertiesDefinition.getType()) && qNameOfTheType.equals(propertiesDefinition.getType());
                     }
                 }
 
@@ -732,7 +732,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
 
         return ids;
     }
-    
+
     /**
      * Determines all referencedDefinitionsChildIds
      *

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/IGenericRepositoryTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/IGenericRepositoryTest.java
@@ -22,6 +22,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.xml.namespace.QName;
+
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,5 +43,16 @@ public class IGenericRepositoryTest extends TestWithGitBackedRepository {
 
         final Set<DefinitionsChildId> expected = new HashSet<>(Arrays.asList(nodeTypeWithoutPropertiesId, policyTemplateId, policyTypeId));
         assertEquals(expected, referencedDefinitionsChildIds);
+    }
+    
+    @Test
+    public void getReferencedDefinitionsChildIDsWithEmptyArtifactRefs() throws GitAPIException {
+        this.setRevisionTo("5fb45405cc983d157dc417142ad32b01880e48af");
+        
+        final NodeTypeId nodeTypeId = new NodeTypeId("http%3A%2F%2Fwinery.opentosca.org/test/ponyuniverse", "shetland_pony", true);
+        final QName qName = nodeTypeId.getQName();
+        Collection<NodeTypeImplementationId> allNodeTypeImplementations = this.repository.getAllElementsReferencingGivenType(NodeTypeImplementationId.class, nodeTypeId.getQName());
+        assertEquals(0, allNodeTypeImplementations.size());
+        
     }
 }


### PR DESCRIPTION
Signed-off-by: Karoline Saatkamp <karoline.saatkamp@iaas.uni-stuttgart.de>

All QNames of contained elements in the winery are compared with the others if they are referenced somewhere.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [ ] Screenshots added (for UI changes)
