### PR TITLE
Adds size check and improves progress display

### DIFF
--- a/org.eclipse.winery.cli/src/main/java/org/eclipse/winery/cli/WineryCli.java
+++ b/org.eclipse.winery.cli/src/main/java/org/eclipse/winery/cli/WineryCli.java
@@ -115,23 +115,25 @@ public class WineryCli {
         boolean checkDocumentation = line.hasOption("cd");
         ConsistencyCheckerConfiguration configuration = new ConsistencyCheckerConfiguration(serviceTemplatesOnly, checkDocumentation, verbosity, repository);
 
-        ProgressBar progressBar = new ProgressBar("Check", 100, ProgressBarStyle.ASCII);
-        progressBar.start();
-        final ConsistencyChecker consistencyChecker = new ConsistencyChecker(configuration, new ConsistencyCheckerProgressListener() {
+        final ConsistencyChecker consistencyChecker = new ConsistencyChecker(configuration);
+        int numberOfDefinitionsToCheck = consistencyChecker.numberOfDefinitionsToCheck();
+        ProgressBar progressBar = new ProgressBar("Check", numberOfDefinitionsToCheck, ProgressBarStyle.ASCII);
+        consistencyChecker.setConsistencyCheckerProgressListener(new ConsistencyCheckerProgressListener() {
             @Override
             public void updateProgress(float progress) {
-                progressBar.stepTo((long) (progress * 100));
+                progressBar.stepTo((long) (progress * numberOfDefinitionsToCheck));
             }
 
             @Override
             public void updateProgress(float progress, String checkingDefinition) {
                 progressBar.setExtraMessage("Now checking " + checkingDefinition);
-                progressBar.stepTo((long) (progress * 100));
+                progressBar.stepTo((long) (progress * numberOfDefinitionsToCheck));
             }
         });
+        progressBar.start();
         consistencyChecker.checkCorruption();
-        ConsistencyErrorCollector errors = consistencyChecker.getErrorCollector();
         progressBar.stop();
+        ConsistencyErrorCollector errors = consistencyChecker.getErrorCollector();
 
         System.out.println();
         if (errors.getErrorList().isEmpty()) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyCheckerConfiguration.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyCheckerConfiguration.java
@@ -13,13 +13,17 @@
  ********************************************************************************/
 package org.eclipse.winery.repository.backend.consistencycheck;
 
+import java.util.EnumSet;
+import java.util.Objects;
+
 import org.eclipse.winery.repository.backend.IRepository;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 
-import java.util.EnumSet;
+import org.eclipse.jdt.annotation.NonNull;
 
 public class ConsistencyCheckerConfiguration {
 
+    private final boolean testMode;
     private boolean serviceTemplatesOnly;
     private boolean checkDocumentation;
     private EnumSet<ConsistencyCheckerVerbosity> verbosity;
@@ -30,13 +34,36 @@ public class ConsistencyCheckerConfiguration {
         this.checkDocumentation = false;
         this.verbosity = EnumSet.of(ConsistencyCheckerVerbosity.NONE);
         this.repository = RepositoryFactory.getRepository();
+        this.testMode = false;
     }
 
-    public ConsistencyCheckerConfiguration(boolean serviceTemplatesOnly, boolean checkDocumentation, EnumSet<ConsistencyCheckerVerbosity> verbosity, IRepository repository) {
+    /**
+     * Constructor used for testing the ConsistencyChecker functionality. Otherwise: Must not be used
+     */
+    public ConsistencyCheckerConfiguration(boolean serviceTemplatesOnly, boolean checkDocumentation, @NonNull EnumSet<ConsistencyCheckerVerbosity> verbosity) {
         this.serviceTemplatesOnly = serviceTemplatesOnly;
         this.checkDocumentation = checkDocumentation;
-        this.verbosity = verbosity;
-        this.repository = repository;
+        this.verbosity = Objects.requireNonNull(verbosity);
+        this.testMode = false;
+    }
+
+    public ConsistencyCheckerConfiguration(boolean serviceTemplatesOnly, boolean checkDocumentation, @NonNull EnumSet<ConsistencyCheckerVerbosity> verbosity, @NonNull IRepository repository) {
+        this.serviceTemplatesOnly = serviceTemplatesOnly;
+        this.checkDocumentation = checkDocumentation;
+        this.verbosity = Objects.requireNonNull(verbosity);
+        this.repository = Objects.requireNonNull(repository);
+        this.testMode = false;
+    }
+
+    /**
+     * Constructor used for testing the ConsistencyChecker functionality. Otherwise: Must not be used
+     */
+    public ConsistencyCheckerConfiguration(boolean serviceTemplatesOnly, boolean checkDocumentation, @NonNull EnumSet<ConsistencyCheckerVerbosity> verbosity, @NonNull IRepository repository, boolean testMode) {
+        this.serviceTemplatesOnly = serviceTemplatesOnly;
+        this.checkDocumentation = checkDocumentation;
+        this.verbosity = Objects.requireNonNull(verbosity);
+        this.repository = Objects.requireNonNull(repository);
+        this.testMode = testMode;
     }
 
     public boolean isServiceTemplatesOnly() {
@@ -69,5 +96,9 @@ public class ConsistencyCheckerConfiguration {
 
     public void setRepository(IRepository repository) {
         this.repository = repository;
+    }
+
+    public boolean isTestMode() {
+        return this.testMode;
     }
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyCheckerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyCheckerTest.java
@@ -41,7 +41,7 @@ public class ConsistencyCheckerTest extends TestWithGitBackedRepository {
 
     @BeforeEach
     public void initializeConsistencyChecker() {
-        ConsistencyCheckerConfiguration consistencyCheckerConfiguration = new ConsistencyCheckerConfiguration(false, true, EnumSet.of(ConsistencyCheckerVerbosity.NONE), null);
+        ConsistencyCheckerConfiguration consistencyCheckerConfiguration = new ConsistencyCheckerConfiguration(false, true, EnumSet.of(ConsistencyCheckerVerbosity.NONE));
         consistencyChecker = new ConsistencyChecker(consistencyCheckerConfiguration);
     }
 
@@ -97,7 +97,7 @@ public class ConsistencyCheckerTest extends TestWithGitBackedRepository {
         this.setRevisionTo(revision);
         EnumSet<ConsistencyCheckerVerbosity> verbosity = EnumSet.noneOf(ConsistencyCheckerVerbosity.class);
         ConsistencyCheckerConfiguration configuration = new ConsistencyCheckerConfiguration
-            (false, false, verbosity, repository);
+            (false, false, verbosity, repository, true);
         final ConsistencyChecker consistencyChecker = new ConsistencyChecker(configuration);
         consistencyChecker.checkCorruption();
         return  consistencyChecker.getErrorCollector();


### PR DESCRIPTION
I really need this for the open sourcing of node types. We need valid LICENSE and README.md files.

![grafik](https://user-images.githubusercontent.com/1366654/42602538-3bce7db2-856a-11e8-91fb-55cb0e61577f.png)


Second improvement:

Before:

![g1](https://user-images.githubusercontent.com/1366654/42602519-29764d5c-856a-11e8-8af1-b0bc810e02b2.png)

After:

![g2](https://user-images.githubusercontent.com/1366654/42602525-2b30fda4-856a-11e8-8a0c-30a9391ade2e.png)


