### PR TITLE
Add -cb command line option and fix Copybara generator for 0 byte files

### DIFF
--- a/org.eclipse.winery.cli/pom.xml
+++ b/org.eclipse.winery.cli/pom.xml
@@ -52,6 +52,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.winery</groupId>
+            <artifactId>org.eclipse.winery.tools.copybaragenerator</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${ch.qos.logback.logback-classic.version}</version>

--- a/org.eclipse.winery.tools.copybaragenerator/src/main/java/org/eclipse/winery/tools/copybaragenerator/CopybaraGenerator.java
+++ b/org.eclipse.winery.tools.copybaragenerator/src/main/java/org/eclipse/winery/tools/copybaragenerator/CopybaraGenerator.java
@@ -59,10 +59,15 @@ public class CopybaraGenerator {
                     // We read 80 bytes, because the string "Apache License" could be centered
                     byte[] firstBytes = new byte[80];
                     int readBytes = inputStream.read(firstBytes);
-                    String firstBytesAsString = new String(firstBytes, 0, readBytes);
-                    // trim -> remove whitespaces before
-                    // We might have read more than one line (because of 80 bytes maximum), therefore, we just check whether the string begins with "Apache License"
-                    return (firstBytesAsString.trim().startsWith(licenceString));
+                    if (readBytes <= 0) {
+                        LOGGER.debug("LICENSE file is empty for {}", id.toReadableString());
+                        return false;
+                    } else {
+                        String firstBytesAsString = new String(firstBytes, 0, readBytes);
+                        // trim -> remove whitespaces before
+                        // We might have read more than one line (because of 80 bytes maximum), therefore, we just check whether the string begins with "Apache License"
+                        return (firstBytesAsString.trim().startsWith(licenceString));
+                    }
                 } catch (IOException e) {
                     LOGGER.error("Could not create input stream for {}", repositoryFileReference.toString(), e);
                     return false;


### PR DESCRIPTION
Refs https://github.com/eclipse/winery/pull/329 and https://github.com/eclipse/winery/pull/311

Integrates the copybara config generator in the CLI