### PR TITLE
Fix to update data.xml file whenever an image or icon is uploaded

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/selfserviceportal/SelfServicePortalResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/selfserviceportal/SelfServicePortalResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,9 +13,20 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.servicetemplates.selfserviceportal;
 
-import com.sun.jersey.multipart.FormDataBodyPart;
-import com.sun.jersey.multipart.FormDataParam;
-import org.apache.commons.io.IOUtils;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.eclipse.winery.common.RepositoryFileReference;
 import org.eclipse.winery.common.constants.MimeTypes;
 import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
@@ -29,15 +40,13 @@ import org.eclipse.winery.repository.datatypes.ids.elements.ServiceTemplateSelfS
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources.entitytemplates.artifacttemplates.FilesResource;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
+
+import com.sun.jersey.multipart.FormDataBodyPart;
+import com.sun.jersey.multipart.FormDataParam;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
 
 public class SelfServicePortalResource {
 
@@ -106,7 +115,12 @@ public class SelfServicePortalResource {
             throw new WebApplicationException(e);
         }
         RepositoryFileReference ref = new RepositoryFileReference(this.id, "icon.jpg");
-        return RestUtils.putContentToFile(ref, uploadedInputStream, body.getMediaType());
+        Response response = RestUtils.putContentToFile(ref, uploadedInputStream, body.getMediaType());
+        if (StringUtils.isEmpty(this.application.getIconUrl())) {
+            this.application.setIconUrl("icon.jpg");
+            persist();
+        }
+        return response;
     }
 
     @GET
@@ -126,7 +140,12 @@ public class SelfServicePortalResource {
             throw new WebApplicationException(e);
         }
         RepositoryFileReference ref = new RepositoryFileReference(this.id, "image.jpg");
-        return RestUtils.putContentToFile(ref, uploadedInputStream, body.getMediaType());
+        Response response = RestUtils.putContentToFile(ref, uploadedInputStream, body.getMediaType());
+        if (StringUtils.isEmpty(this.application.getImageUrl())) {
+            this.application.setImageUrl("image.jpg");
+            persist();
+        }
+        return response;
     }
 
     @Path("files")


### PR DESCRIPTION
The file `data.xml` is not updated upon image/icon upload. When uploading an image to the self-service portal, the image is stored in Winery, but the reference in `data.xml` is not updated. This PR fixes the issue by updating the XML upon upload. 

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders