### PR TITLE
Fix star imports in Java files

### DIFF
--- a/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/main/java/org/eclipse/winery/bpmn2bpel/FileUtil.java
+++ b/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/main/java/org/eclipse/winery/bpmn2bpel/FileUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2015-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,15 +13,21 @@
  *******************************************************************************/
 package org.eclipse.winery.bpmn2bpel;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.*;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class providing operations on files.
@@ -39,7 +45,6 @@ public class FileUtil {
 		} else {
 			return tempDirPath;
 		}
-
 	}
 
 	public static Path writeStringToFile(String content, Path targetPath) throws IOException {
@@ -76,5 +81,4 @@ public class FileUtil {
 			}
 		}
 	}
-
 }

--- a/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/main/java/org/eclipse/winery/bpmn2bpel/parser/SortParser.java
+++ b/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/main/java/org/eclipse/winery/bpmn2bpel/parser/SortParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,18 +13,22 @@
  *******************************************************************************/
 package org.eclipse.winery.bpmn2bpel.parser;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.eclipse.winery.bpmn2bpel.model.ManagementFlow;
 import org.eclipse.winery.bpmn2bpel.model.Node;
 import org.eclipse.winery.bpmn2bpel.model.OrGatewayMerge;
 import org.eclipse.winery.bpmn2bpel.model.OrGatewaySplit;
 
-import java.util.*;
-
 /**
  * This class will do two things.
  * <p>
- * First, it will finds all of the following nodes for each exclusive gateway, and construct a
- * branch for each following nodes.
+ * First, it will finds all of the following nodes for each exclusive gateway, and construct a branch for each following
+ * nodes.
  * <p>
  * second, it will convert the nodes to a management flow.
  */

--- a/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/main/java/org/eclipse/winery/bpmn2bpel/planwriter/BpelPlanArtefactWriter.java
+++ b/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/main/java/org/eclipse/winery/bpmn2bpel/planwriter/BpelPlanArtefactWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2015-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,18 +13,23 @@
  *******************************************************************************/
 package org.eclipse.winery.bpmn2bpel.planwriter;
 
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.winery.bpmn2bpel.model.Gateway;
+import org.eclipse.winery.bpmn2bpel.model.Link;
+import org.eclipse.winery.bpmn2bpel.model.ManagementFlow;
+import org.eclipse.winery.bpmn2bpel.model.ManagementTask;
+import org.eclipse.winery.bpmn2bpel.model.Node;
+
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.Velocity;
-import org.eclipse.winery.bpmn2bpel.model.*;
 import org.jgrapht.traverse.DepthFirstIterator;
 import org.jgrapht.traverse.GraphIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.List;
 
 public class BpelPlanArtefactWriter {
 
@@ -70,7 +75,6 @@ public class BpelPlanArtefactWriter {
 		LOGGER.debug("Completed BPEL process template" + bpelProcessContent);
 
 		return bpelProcessContent;
-
 	}
 
 	public String completePlanWsdlTemplate() {
@@ -124,5 +128,4 @@ public class BpelPlanArtefactWriter {
 
 		return xsdWriter.toString();
 	}
-
 }

--- a/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/main/java/org/eclipse/winery/bpmn2bpel/planwriter/ManagementTaskTemplateWrapper.java
+++ b/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/main/java/org/eclipse/winery/bpmn2bpel/planwriter/ManagementTaskTemplateWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2015-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,13 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.bpmn2bpel.planwriter;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.bpmn2bpel.model.ManagementTask;
 import org.eclipse.winery.bpmn2bpel.model.param.Parameter;
 import org.eclipse.winery.bpmn2bpel.model.param.TopologyParameter;
-
-import javax.xml.namespace.QName;
-import java.util.*;
-
 
 /**
  * Add convenience methods to the {@link ManagementTask} that can be used in the Velocity template.

--- a/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/test/java/org/eclipse/winery/bpmn2bpel/JsonParserTest.java
+++ b/org.eclipse.winery.bpmn4tosca.converter.tobpel/src/test/java/org/eclipse/winery/bpmn2bpel/JsonParserTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2015-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,13 +13,6 @@
  *******************************************************************************/
 package org.eclipse.winery.bpmn2bpel;
 
-import org.eclipse.winery.bpmn2bpel.model.*;
-import org.eclipse.winery.bpmn2bpel.model.param.*;
-import org.eclipse.winery.bpmn2bpel.parser.Bpmn4JsonParser;
-import org.eclipse.winery.bpmn2bpel.parser.ParseException;
-import org.junit.Test;
-
-import javax.xml.namespace.QName;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -27,6 +20,28 @@ import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.bpmn2bpel.model.EndTask;
+import org.eclipse.winery.bpmn2bpel.model.Link;
+import org.eclipse.winery.bpmn2bpel.model.ManagementFlow;
+import org.eclipse.winery.bpmn2bpel.model.ManagementTask;
+import org.eclipse.winery.bpmn2bpel.model.Node;
+import org.eclipse.winery.bpmn2bpel.model.StartTask;
+import org.eclipse.winery.bpmn2bpel.model.Task;
+import org.eclipse.winery.bpmn2bpel.model.param.ConcatParameter;
+import org.eclipse.winery.bpmn2bpel.model.param.DeploymentArtefactParameter;
+import org.eclipse.winery.bpmn2bpel.model.param.ImplementationArtefactParameter;
+import org.eclipse.winery.bpmn2bpel.model.param.ParamType;
+import org.eclipse.winery.bpmn2bpel.model.param.Parameter;
+import org.eclipse.winery.bpmn2bpel.model.param.PlanParameter;
+import org.eclipse.winery.bpmn2bpel.model.param.StringParameter;
+import org.eclipse.winery.bpmn2bpel.model.param.TopologyParameter;
+import org.eclipse.winery.bpmn2bpel.parser.Bpmn4JsonParser;
+import org.eclipse.winery.bpmn2bpel.parser.ParseException;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -44,12 +59,10 @@ public class JsonParserTest {
 
 		assertNodeSets(expectedFlow.vertexSet(), actualFlow.vertexSet());
 		assertLinkSets(expectedFlow.edgeSet(), actualFlow.edgeSet());
-
 	}
 
 	public static void assertNodeSets(Set<Node> expectedNodes, Set<Node> actualNodes) {
 		assertEquals(expectedNodes.size(), actualNodes.size());
-
 
 		for (Iterator<Node> iterator = expectedNodes.iterator(); iterator.hasNext(); ) {
 			Node expectedNode = (Node) iterator.next();
@@ -65,8 +78,6 @@ public class JsonParserTest {
 	public static void assertLinkSets(Set<Link> expectedLinks, Set<Link> actualLinks) {
 		//assertEquals(expectedNodes.size(), actualNodes.size());
 		assertEquals(expectedLinks.size(), actualLinks.size());
-
-
 	}
 
 	public static void assertLink(Link expectedLink, Link actualLink) {
@@ -86,7 +97,6 @@ public class JsonParserTest {
 		return null;
 	}
 
-
 	public static void assertNodes(Node expected, Node actual) {
 		//assertEquals(expected.getId(), actual.getId());
 		assertEquals("node: id ", expected.getId(), actual.getId());
@@ -95,7 +105,6 @@ public class JsonParserTest {
 		if (expected instanceof Task) {
 			assertTasks((Task) expected, (Task) actual);
 		}
-
 	}
 
 	public static void assertTasks(Task expected, Task actual) {
@@ -148,7 +157,6 @@ public class JsonParserTest {
 		assertEquals("Parameter: value", expected.getValue(), actual.getValue());
 	}
 
-
 	private static Parameter getParameterByName(String name, List<Parameter> parameters) {
 
 		Iterator<Parameter> iter = parameters.iterator();
@@ -161,7 +169,6 @@ public class JsonParserTest {
 		return null;
 	}
 
-
 	private static ManagementFlow createReferenceFlow() {
 		ManagementFlow flow = new ManagementFlow();
 
@@ -170,7 +177,6 @@ public class JsonParserTest {
 		startTask.setName("StartEvent");
 		startTask.addOutputParameter(createParameter("SSHUserInput", ParamType.TOPOLOGY, "StartEvent.SSHUserInput"));
 		flow.addVertex(startTask);
-
 
 		ManagementTask createEC2Task = new ManagementTask();
 		createEC2Task.setId("element10");
@@ -203,14 +209,11 @@ public class JsonParserTest {
 		endTask.addInputParameter(createParameter("AppURL", ParamType.CONCAT, "http://,UbuntuVM.IPAddress,:8080/,PHPApplication.ID"));
 		flow.addVertex(endTask);
 
-
 		flow.addEdge(startTask, createEC2Task);
 		flow.addEdge(createEC2Task, runUbuntuTask);
 		flow.addEdge(runUbuntuTask, endTask);
 
 		return flow;
-
-
 	}
 
 	private static Parameter createParameter(String name, ParamType type, String value) {
@@ -244,5 +247,4 @@ public class JsonParserTest {
 
 		return param;
 	}
-
 }

--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/version/ToscaDiff.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/version/ToscaDiff.java
@@ -13,15 +13,22 @@
  ********************************************************************************/
 package org.eclipse.winery.common.version;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import de.danielbechler.diff.node.DiffNode;
-import de.danielbechler.diff.selector.ElementSelector;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
 import org.eclipse.winery.model.tosca.HasIdInIdOrNameField;
 import org.eclipse.winery.model.tosca.TExtensibleElements;
 import org.eclipse.winery.model.tosca.kvproperties.PropertyDefinitionKV;
 
-import java.util.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import de.danielbechler.diff.node.DiffNode;
+import de.danielbechler.diff.selector.ElementSelector;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ToscaDiff {

--- a/org.eclipse.winery.generators.ia/src/main/java/org/eclipse/winery/generators/ia/Generator.java
+++ b/org.eclipse.winery.generators.ia/src/main/java/org/eclipse/winery/generators/ia/Generator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,28 +13,37 @@
  *******************************************************************************/
 package org.eclipse.winery.generators.ia;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.eclipse.winery.model.tosca.TBoolean;
+import org.eclipse.winery.model.tosca.TInterface;
+import org.eclipse.winery.model.tosca.TOperation;
+import org.eclipse.winery.model.tosca.TParameter;
+
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.io.FileUtils;
-import org.eclipse.winery.model.tosca.TBoolean;
-import org.eclipse.winery.model.tosca.TInterface;
-import org.eclipse.winery.model.tosca.TOperation;
-import org.eclipse.winery.model.tosca.TParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.*;
-import java.net.URL;
-import java.nio.charset.Charset;
-import java.nio.file.*;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 
 public class Generator {
 
@@ -63,7 +72,6 @@ public class Generator {
     private final String javaPackage;
     private final String namespace;
     private final URL iaArtifactTemplateUploadUrl;
-
 
     /**
      * Creates a new IA Generator instance for the given {@link TInterface}.

--- a/org.eclipse.winery.model.bpmn4tosca/src/main/java/org/eclipse/winery/bpmn2bpel/model/Task.java
+++ b/org.eclipse.winery.model.bpmn4tosca/src/main/java/org/eclipse/winery/bpmn2bpel/model/Task.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2015-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,9 +13,13 @@
  *******************************************************************************/
 package org.eclipse.winery.bpmn2bpel.model;
 
-import org.eclipse.winery.bpmn2bpel.model.param.Parameter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
-import java.util.*;
+import org.eclipse.winery.bpmn2bpel.model.param.Parameter;
 
 public abstract class Task extends Node {
 

--- a/org.eclipse.winery.model.csar.toscametafile/src/main/java/org/eclipse/winery/model/csar/toscametafile/TOSCAMetaFile.java
+++ b/org.eclipse.winery.model.csar.toscametafile/src/main/java/org/eclipse/winery/model/csar/toscametafile/TOSCAMetaFile.java
@@ -13,10 +13,14 @@
  *******************************************************************************/
 package org.eclipse.winery.model.csar.toscametafile;
 
-import org.eclipse.virgo.util.parser.manifest.ManifestContents;
-
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.virgo.util.parser.manifest.ManifestContents;
 
 /**
  * Provides structured access to the content of a TOSCA meta file.
@@ -71,17 +75,16 @@ public class TOSCAMetaFile implements Serializable {
     }
 
     /**
-     * @return Value of attribute <code>Entry-Definitions</code> in block 0
-     * (contains relative path to the root TOSCA file in the CSAR). If
-     * attribute is not specified <code>null</code>.
+     * @return Value of attribute <code>Entry-Definitions</code> in block 0 (contains relative path to the root TOSCA
+     * file in the CSAR). If attribute is not specified <code>null</code>.
      */
     public String getEntryDefinitions() {
         return this.block0.get(TOSCAMetaFileAttributes.ENTRY_DEFINITIONS);
     }
 
     /**
-     * @return Value of attribute <code>Description</code> in block 0 (contains
-     * description of CSAR). If attribute is not specified
+     * @return Value of attribute <code>Description</code> in block 0 (contains description of CSAR). If attribute is
+     * not specified
      * <code>null</code>.
      */
     public String getDescription() {
@@ -89,9 +92,8 @@ public class TOSCAMetaFile implements Serializable {
     }
 
     /**
-     * @return Value of attribute <code>Topology</code> in block 0 (contains
-     * relative path to topology picture in the CSAR). If attribute is
-     * not specified <code>null</code>.
+     * @return Value of attribute <code>Topology</code> in block 0 (contains relative path to topology picture in the
+     * CSAR). If attribute is not specified <code>null</code>.
      */
     public String getTopology() {
         return this.block0.get(TOSCAMetaFileAttributes.TOPOLOGY);
@@ -105,8 +107,7 @@ public class TOSCAMetaFile implements Serializable {
     }
 
     /**
-     * @return File blocks (block 1 to last block; contains meta data of files
-     * in the CSAR). Every block is a element
+     * @return File blocks (block 1 to last block; contains meta data of files in the CSAR). Every block is a element
      * <code>Map&lt;String, String&gt;</code> in the returned
      * <code>List</code>.
      */
@@ -118,8 +119,7 @@ public class TOSCAMetaFile implements Serializable {
      * Returns the mime type for the given name
      *
      * @param name a reference to a file
-     * @return the mime type associated with the given name, null if no mime
-     * type was found
+     * @return the mime type associated with the given name, null if no mime type was found
      */
     public String getMimeType(String name) {
         Objects.requireNonNull(name);

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TArtifactDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TArtifactDefinition.java
@@ -13,20 +13,26 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.winery.model.tosca.yaml.support.Annotations;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
-import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
-import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-import java.util.*;
+
+import org.eclipse.winery.model.tosca.yaml.support.Annotations;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
+import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
+import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tArtifactDefinition", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TAttributeDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TAttributeDefinition.java
@@ -13,16 +13,22 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
 import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
 import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
-import java.util.Objects;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tAttributeDefinition", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TCapabilityDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TCapabilityDefinition.java
@@ -13,21 +13,28 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
-import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
-import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
+import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
+import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tCapabilityDefinition", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TGroupDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TGroupDefinition.java
@@ -13,20 +13,27 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.winery.model.tosca.yaml.support.Metadata;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
-import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
-import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-import java.util.*;
+
+import org.eclipse.winery.model.tosca.yaml.support.Metadata;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
+import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
+import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tGroupDefinition", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TGroupType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TGroupType.java
@@ -13,17 +13,24 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementDefinition;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
-import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-import java.util.*;
+
+import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementDefinition;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
+import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
+
+import org.eclipse.jdt.annotation.NonNull;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tGroupType", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeFilterDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeFilterDefinition.java
@@ -13,7 +13,16 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
 import org.eclipse.winery.model.tosca.yaml.support.TMapObject;
 import org.eclipse.winery.model.tosca.yaml.support.TMapPropertyFilterDefinition;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
@@ -21,10 +30,7 @@ import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
 import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
 import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import java.util.*;
+import org.eclipse.jdt.annotation.NonNull;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tNodeFilter", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeTemplate.java
@@ -13,8 +13,19 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.model.tosca.yaml.support.Metadata;
 import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementAssignment;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
@@ -22,12 +33,8 @@ import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
 import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
 import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.namespace.QName;
-import java.util.*;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tNodeTemplate", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeType.java
@@ -13,16 +13,23 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
 import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementDefinition;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
 import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import java.util.*;
+import org.eclipse.jdt.annotation.NonNull;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tNodeType", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TParameterDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TParameterDefinition.java
@@ -13,18 +13,24 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
 import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
 import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tParameterDefinition", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TPolicyDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TPolicyDefinition.java
@@ -13,20 +13,27 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.winery.model.tosca.yaml.support.Metadata;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
-import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
-import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-import java.util.*;
+
+import org.eclipse.winery.model.tosca.yaml.support.Metadata;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
+import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
+import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tPolicyDefinition", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TPropertyDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TPropertyDefinition.java
@@ -13,19 +13,25 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import io.github.adr.embedded.ADR;
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
-import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
+import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
+
+import io.github.adr.embedded.ADR;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tPropertyDefinition", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TRelationshipType.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TRelationshipType.java
@@ -13,17 +13,24 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
-import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-import java.util.*;
+
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
+import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
+
+import org.eclipse.jdt.annotation.NonNull;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tRelationshipType", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TRepositoryDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TRepositoryDefinition.java
@@ -13,16 +13,22 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
 import org.eclipse.winery.model.tosca.yaml.tosca.datatypes.Credential;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
 import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
 import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
 
-import javax.xml.bind.annotation.*;
-import java.util.Objects;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tRepositoryDefinition", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TServiceTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TServiceTemplate.java
@@ -13,8 +13,19 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
 import org.eclipse.winery.model.tosca.yaml.support.Metadata;
 import org.eclipse.winery.model.tosca.yaml.support.TMapImportDefinition;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
@@ -22,8 +33,8 @@ import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
 import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
 import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
 
-import javax.xml.bind.annotation.*;
-import java.util.*;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/Annotations.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/Annotations.java
@@ -13,12 +13,16 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml.support;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 public @interface Annotations {
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.METHOD, ElementType.PACKAGE, ElementType.PARAMETER, ElementType.TYPE})
+    @Target( {ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.METHOD, ElementType.PACKAGE, ElementType.PARAMETER, ElementType.TYPE})
     @interface StandardExtension {
 
     }

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/Metadata.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/Metadata.java
@@ -13,11 +13,15 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml.support;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
 import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
-
-import java.util.*;
 
 public class Metadata implements Map<String, String> {
     private Map<String, String> value;

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TListString.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TListString.java
@@ -13,10 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml.support;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.*;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "TListString", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TMapImportDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TMapImportDefinition.java
@@ -13,12 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml.support;
 
-import org.eclipse.winery.model.tosca.yaml.TImportDefinition;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.*;
+
+import org.eclipse.winery.model.tosca.yaml.TImportDefinition;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tMapImportDefinition", namespace = "http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TMapObject.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TMapObject.java
@@ -13,10 +13,15 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml.support;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.*;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tMapObject", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TMapRequirementAssignment.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TMapRequirementAssignment.java
@@ -13,12 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml.support;
 
-import org.eclipse.winery.model.tosca.yaml.TRequirementAssignment;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.*;
+
+import org.eclipse.winery.model.tosca.yaml.TRequirementAssignment;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tMapRequirementAssignment", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TMapRequirementDefinition.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/TMapRequirementDefinition.java
@@ -13,12 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml.support;
 
-import org.eclipse.winery.model.tosca.yaml.TRequirementDefinition;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.*;
+
+import org.eclipse.winery.model.tosca.yaml.TRequirementDefinition;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tMapRequirementDefinition", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/visitor/AbstractVisitor.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/visitor/AbstractVisitor.java
@@ -13,15 +13,54 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml.visitor;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.winery.model.tosca.yaml.*;
-import org.eclipse.winery.model.tosca.yaml.support.Metadata;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import org.eclipse.winery.model.tosca.yaml.TArtifactDefinition;
+import org.eclipse.winery.model.tosca.yaml.TArtifactType;
+import org.eclipse.winery.model.tosca.yaml.TAttributeAssignment;
+import org.eclipse.winery.model.tosca.yaml.TAttributeDefinition;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityAssignment;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityDefinition;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityType;
+import org.eclipse.winery.model.tosca.yaml.TConstraintClause;
+import org.eclipse.winery.model.tosca.yaml.TDataType;
+import org.eclipse.winery.model.tosca.yaml.TEntityType;
+import org.eclipse.winery.model.tosca.yaml.TEntrySchema;
+import org.eclipse.winery.model.tosca.yaml.TGroupDefinition;
+import org.eclipse.winery.model.tosca.yaml.TGroupType;
+import org.eclipse.winery.model.tosca.yaml.TImplementation;
+import org.eclipse.winery.model.tosca.yaml.TImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceAssignment;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceType;
+import org.eclipse.winery.model.tosca.yaml.TNodeFilterDefinition;
+import org.eclipse.winery.model.tosca.yaml.TNodeTemplate;
+import org.eclipse.winery.model.tosca.yaml.TNodeType;
+import org.eclipse.winery.model.tosca.yaml.TOperationDefinition;
+import org.eclipse.winery.model.tosca.yaml.TParameterDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPolicyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPolicyType;
+import org.eclipse.winery.model.tosca.yaml.TPropertyAssignment;
+import org.eclipse.winery.model.tosca.yaml.TPropertyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPropertyFilterDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipAssignment;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipType;
+import org.eclipse.winery.model.tosca.yaml.TRepositoryDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRequirementAssignment;
+import org.eclipse.winery.model.tosca.yaml.TRequirementDefinition;
+import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
+import org.eclipse.winery.model.tosca.yaml.TSubstitutionMappings;
+import org.eclipse.winery.model.tosca.yaml.TTopologyTemplateDefinition;
+import org.eclipse.winery.model.tosca.yaml.TVersion;
+import org.eclipse.winery.model.tosca.yaml.support.Metadata;
+
+import org.eclipse.jdt.annotation.NonNull;
 
 public abstract class AbstractVisitor<R extends AbstractResult<R>, P extends AbstractParameter<P>> implements IVisitor<R, P> {
     @Override

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/visitor/IVisitor.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/visitor/IVisitor.java
@@ -13,7 +13,45 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml.visitor;
 
-import org.eclipse.winery.model.tosca.yaml.*;
+import org.eclipse.winery.model.tosca.yaml.TArtifactDefinition;
+import org.eclipse.winery.model.tosca.yaml.TArtifactType;
+import org.eclipse.winery.model.tosca.yaml.TAttributeAssignment;
+import org.eclipse.winery.model.tosca.yaml.TAttributeDefinition;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityAssignment;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityDefinition;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityType;
+import org.eclipse.winery.model.tosca.yaml.TConstraintClause;
+import org.eclipse.winery.model.tosca.yaml.TDataType;
+import org.eclipse.winery.model.tosca.yaml.TEntityType;
+import org.eclipse.winery.model.tosca.yaml.TEntrySchema;
+import org.eclipse.winery.model.tosca.yaml.TGroupDefinition;
+import org.eclipse.winery.model.tosca.yaml.TGroupType;
+import org.eclipse.winery.model.tosca.yaml.TImplementation;
+import org.eclipse.winery.model.tosca.yaml.TImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceAssignment;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceType;
+import org.eclipse.winery.model.tosca.yaml.TNodeFilterDefinition;
+import org.eclipse.winery.model.tosca.yaml.TNodeTemplate;
+import org.eclipse.winery.model.tosca.yaml.TNodeType;
+import org.eclipse.winery.model.tosca.yaml.TOperationDefinition;
+import org.eclipse.winery.model.tosca.yaml.TParameterDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPolicyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPolicyType;
+import org.eclipse.winery.model.tosca.yaml.TPropertyAssignment;
+import org.eclipse.winery.model.tosca.yaml.TPropertyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPropertyFilterDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipAssignment;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipType;
+import org.eclipse.winery.model.tosca.yaml.TRepositoryDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRequirementAssignment;
+import org.eclipse.winery.model.tosca.yaml.TRequirementDefinition;
+import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
+import org.eclipse.winery.model.tosca.yaml.TSubstitutionMappings;
+import org.eclipse.winery.model.tosca.yaml.TTopologyTemplateDefinition;
+import org.eclipse.winery.model.tosca.yaml.TVersion;
 import org.eclipse.winery.model.tosca.yaml.support.Metadata;
 
 public interface IVisitor<R extends AbstractResult, P extends AbstractParameter> {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/RelationshipSourceOrTarget.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/RelationshipSourceOrTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,10 +13,14 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca;
 
-import com.fasterxml.jackson.annotation.*;
-import io.github.adr.embedded.ADR;
-
 import javax.xml.namespace.QName;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import io.github.adr.embedded.ADR;
 
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 // see https://stackoverflow.com/q/44789227/873282 for an explanation for this solution

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TAppliesTo.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TAppliesTo.java
@@ -14,14 +14,18 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
+import org.eclipse.jdt.annotation.NonNull;
 
 /**
  * <p>Java class for tAppliesTo complex type.
@@ -78,10 +82,9 @@ public class TAppliesTo {
      * Gets the value of the nodeTypeReference property.
      * <p>
      * <p>
-     * This accessor method returns a reference to the live list,
-     * not a snapshot. Therefore any modification you make to the
-     * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the nodeTypeReference property.
+     * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you make to
+     * the returned list will be present inside the JAXB object. This is why there is not a <CODE>set</CODE> method for
+     * the nodeTypeReference property.
      * <p>
      * <p>
      * For example, to add a new item, do as follows:
@@ -91,8 +94,7 @@ public class TAppliesTo {
      * <p>
      * <p>
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link TAppliesTo.NodeTypeReference }
+     * Objects of the following type(s) are allowed in the list {@link TAppliesTo.NodeTypeReference }
      */
     @NonNull
     public List<TAppliesTo.NodeTypeReference> getNodeTypeReference() {
@@ -101,7 +103,6 @@ public class TAppliesTo {
         }
         return this.nodeTypeReference;
     }
-
 
     /**
      * <p>Java class for anonymous complex type.

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TExportedInterface.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TExportedInterface.java
@@ -14,14 +14,20 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
 import org.eclipse.winery.model.tosca.visitor.Visitor;
+
+import org.eclipse.jdt.annotation.NonNull;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tExportedInterface", propOrder = {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TInterface.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TInterface.java
@@ -14,13 +14,18 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+import org.eclipse.jdt.annotation.NonNull;
 
 /**
  * <p>Java class for tInterface complex type.
@@ -78,10 +83,9 @@ public class TInterface implements HasName {
      * Gets the value of the operation property.
      * <p>
      * <p>
-     * This accessor method returns a reference to the live list,
-     * not a snapshot. Therefore any modification you make to the
-     * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the operation property.
+     * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you make to
+     * the returned list will be present inside the JAXB object. This is why there is not a <CODE>set</CODE> method for
+     * the operation property.
      * <p>
      * <p>
      * For example, to add a new item, do as follows:
@@ -91,8 +95,7 @@ public class TInterface implements HasName {
      * <p>
      * <p>
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link TOperation }
+     * Objects of the following type(s) are allowed in the list {@link TOperation }
      */
     @NonNull
     public List<TOperation> getOperation() {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTypeImplementation.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTypeImplementation.java
@@ -14,15 +14,20 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.model.tosca.visitor.Visitor;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * <p>Java class for tNodeTypeImplementation complex type.

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPlans.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPlans.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,14 +14,19 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * <p>Java class for tPlans complex type.
@@ -71,10 +76,9 @@ public class TPlans {
      * Gets the value of the plan property.
      * <p>
      * <p>
-     * This accessor method returns a reference to the live list,
-     * not a snapshot. Therefore any modification you make to the
-     * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the plan property.
+     * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you make to
+     * the returned list will be present inside the JAXB object. This is why there is not a <CODE>set</CODE> method for
+     * the plan property.
      * <p>
      * <p>
      * For example, to add a new item, do as follows:
@@ -84,8 +88,7 @@ public class TPlans {
      * <p>
      * <p>
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link TPlan }
+     * Objects of the following type(s) are allowed in the list {@link TPlan }
      */
     @NonNull
     public List<TPlan> getPlan() {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipTypeImplementation.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipTypeImplementation.java
@@ -14,13 +14,18 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.model.tosca.visitor.Visitor;
+
+import org.eclipse.jdt.annotation.NonNull;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 // by using @XmlTransient at TEntityTypeImplementation, this orders *all* elements, even if IntelliJ marks them in red

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRequiredContainerFeature.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRequiredContainerFeature.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,11 +14,15 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+import org.eclipse.jdt.annotation.NonNull;
 
 /**
  * <p>Java class for tRequiredContainerFeature complex type.

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TTopologyElementInstanceStates.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TTopologyElementInstanceStates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,13 +14,18 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+import org.eclipse.jdt.annotation.NonNull;
 
 /**
  * <p>Java class for tTopologyElementInstanceStates complex type.
@@ -73,10 +78,9 @@ public class TTopologyElementInstanceStates {
      * Gets the value of the instanceState property.
      * <p>
      * <p>
-     * This accessor method returns a reference to the live list,
-     * not a snapshot. Therefore any modification you make to the
-     * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the instanceState property.
+     * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you make to
+     * the returned list will be present inside the JAXB object. This is why there is not a <CODE>set</CODE> method for
+     * the instanceState property.
      * <p>
      * <p>
      * For example, to add a new item, do as follows:
@@ -86,8 +90,7 @@ public class TTopologyElementInstanceStates {
      * <p>
      * <p>
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link TTopologyElementInstanceStates.InstanceState }
+     * Objects of the following type(s) are allowed in the list {@link TTopologyElementInstanceStates.InstanceState }
      */
     @NonNull
     public List<TTopologyElementInstanceStates.InstanceState> getInstanceState() {
@@ -96,7 +99,6 @@ public class TTopologyElementInstanceStates {
         }
         return this.instanceState;
     }
-
 
     /**
      * <p>Java class for anonymous complex type.

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/utils/ModelUtilities.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/utils/ModelUtilities.java
@@ -14,32 +14,56 @@
 
 package org.eclipse.winery.model.tosca.utils;
 
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.model.tosca.TNodeTemplate.Capabilities;
-import org.eclipse.winery.model.tosca.TNodeTemplate.Requirements;
-import org.eclipse.winery.model.tosca.TRelationshipTemplate.SourceOrTargetElement;
-import org.eclipse.winery.model.tosca.constants.Namespaces;
-import org.eclipse.winery.model.tosca.constants.QNames;
-import org.eclipse.winery.model.tosca.kvproperties.PropertyDefinitionKV;
-import org.eclipse.winery.model.tosca.kvproperties.PropertyDefinitionKVList;
-import org.eclipse.winery.model.tosca.kvproperties.WinerysPropertiesDefinition;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Comment;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
-import java.io.StringReader;
-import java.lang.reflect.Method;
-import java.util.*;
-import java.util.stream.Collectors;
+
+import org.eclipse.winery.model.tosca.TBoundaryDefinitions;
+import org.eclipse.winery.model.tosca.TCapability;
+import org.eclipse.winery.model.tosca.TCapabilityDefinition;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TEntityType;
+import org.eclipse.winery.model.tosca.TExtensibleElements;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate.Capabilities;
+import org.eclipse.winery.model.tosca.TNodeTemplate.Requirements;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TPlan;
+import org.eclipse.winery.model.tosca.TPlans;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate.SourceOrTargetElement;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TRequirementDefinition;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.model.tosca.constants.Namespaces;
+import org.eclipse.winery.model.tosca.constants.QNames;
+import org.eclipse.winery.model.tosca.kvproperties.PropertyDefinitionKV;
+import org.eclipse.winery.model.tosca.kvproperties.PropertyDefinitionKVList;
+import org.eclipse.winery.model.tosca.kvproperties.WinerysPropertiesDefinition;
+
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Comment;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 public class ModelUtilities {
 
@@ -48,10 +72,9 @@ public class ModelUtilities {
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ModelUtilities.class);
 
     /**
-     * @deprecated Use {@link TEntityType#getWinerysPropertiesDefinition()}
-     * 
      * @param et the entity type to query
      * @return null if et == null
+     * @deprecated Use {@link TEntityType#getWinerysPropertiesDefinition()}
      */
     @Deprecated
     public static WinerysPropertiesDefinition getWinerysPropertiesDefinition(TEntityType et) {
@@ -208,11 +231,11 @@ public class ModelUtilities {
      * Special method to get the name of an extensible element as the TOSCA specification does not have a separate super
      * type for elements with a name
      * <p>
-     * @see Util#instanceSupportsNameAttribute(java.lang.Class) is related
      *
      * @param e the extensible element offering a name attribute (besides an id attribute)
      * @return the name of the extensible element
      * @throws IllegalStateException if e does not offer the method "getName"
+     * @see Util#instanceSupportsNameAttribute(java.lang.Class) is related
      */
     public static String getName(TExtensibleElements e) {
         Method method;
@@ -298,7 +321,7 @@ public class ModelUtilities {
             floatValue = Float.parseFloat(x);
         } catch (NumberFormatException e) {
             LOGGER.debug("Could not parse x value", e);
-            return Optional.empty();    
+            return Optional.empty();
         }
         return Optional.of(floatValue.intValue());
     }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/AbstractComponentInstanceResourceWithNameDerivedFromAbstractFinal.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/AbstractComponentInstanceResourceWithNameDerivedFromAbstractFinal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,17 +13,7 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources._support;
 
-import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.repository.rest.RestUtils;
-import org.eclipse.winery.repository.rest.resources.apiData.AvailableSuperclassesApiData;
-import org.eclipse.winery.repository.rest.resources.apiData.InheritanceResourceApiData;
-import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.nodetypeimplementations.NodeTypeImplementationResource;
-import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.relationshiptypeimplementations.RelationshipTypeImplementationResource;
-import org.eclipse.winery.repository.rest.resources.entitytypes.EntityTypeResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.lang.reflect.Method;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -32,7 +22,24 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.namespace.QName;
-import java.lang.reflect.Method;
+
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.model.tosca.HasInheritance;
+import org.eclipse.winery.model.tosca.HasType;
+import org.eclipse.winery.model.tosca.TBoolean;
+import org.eclipse.winery.model.tosca.TEntityType;
+import org.eclipse.winery.model.tosca.TNodeTypeImplementation;
+import org.eclipse.winery.model.tosca.TRelationshipTypeImplementation;
+import org.eclipse.winery.model.tosca.utils.ModelUtilities;
+import org.eclipse.winery.repository.rest.RestUtils;
+import org.eclipse.winery.repository.rest.resources.apiData.AvailableSuperclassesApiData;
+import org.eclipse.winery.repository.rest.resources.apiData.InheritanceResourceApiData;
+import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.nodetypeimplementations.NodeTypeImplementationResource;
+import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.relationshiptypeimplementations.RelationshipTypeImplementationResource;
+import org.eclipse.winery.repository.rest.resources.entitytypes.EntityTypeResource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Models a component instance with name, derived from, abstract, and final Tags are provided by

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/ConstraintResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/ConstraintResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,15 +13,20 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources._support;
 
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.eclipse.winery.model.tosca.TConstraint;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.collections.withoutid.EntityWithoutIdResource;
 import org.eclipse.winery.repository.rest.resources.entitytypes.nodetypes.NodeTypeResource;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.List;
 
 public class ConstraintResource extends EntityWithoutIdResource<TConstraint> {
 

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/GenericVisualAppearanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/GenericVisualAppearanceResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,20 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources._support;
 
-import com.sun.jersey.multipart.FormDataBodyPart;
-import com.sun.jersey.multipart.FormDataParam;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.RepositoryFileReference;
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.common.ids.elements.ToscaElementId;
@@ -24,13 +36,8 @@ import org.eclipse.winery.repository.datatypes.ids.elements.VisualAppearanceId;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources.entitytypes.TopologyGraphElementEntityTypeResource;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.xml.namespace.QName;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Map;
+import com.sun.jersey.multipart.FormDataBodyPart;
+import com.sun.jersey.multipart.FormDataParam;
 
 //import com.fasterxml.jackson.annotation.JsonIgnore; // currently not required
 
@@ -46,7 +53,6 @@ public abstract class GenericVisualAppearanceResource {
     protected final Map<QName, String> otherAttributes;
     protected final TopologyGraphElementEntityTypeResource res;
     protected final ToscaElementId id;
-
 
     /**
      * @param otherAttributes the other attributes of the node/relationship type
@@ -64,8 +70,7 @@ public abstract class GenericVisualAppearanceResource {
     }
 
     /**
-     * Used for GUI when accessing the resource as data E.g., for topology
-     * template
+     * Used for GUI when accessing the resource as data E.g., for topology template
      */
     public URI getAbsoluteURL() {
         String URI = Environment.getUrlConfiguration().getRepositoryApiUrl();
@@ -90,8 +95,7 @@ public abstract class GenericVisualAppearanceResource {
     }
 
     /**
-     * Arbitrary images are supported. There currently is no check for valid
-     * image media types
+     * Arbitrary images are supported. There currently is no check for valid image media types
      */
     protected Response putImage(String name, InputStream uploadedInputStream, MediaType mediaType) {
         RepositoryFileReference target = this.getRepoFileRef(name);

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/IHasName.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/IHasName.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,11 +13,15 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources._support;
 
-import io.swagger.annotations.ApiOperation;
-
-import javax.ws.rs.*;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import io.swagger.annotations.ApiOperation;
 
 /**
  * Ensures that the AbstractComponentInstance has a getName method
@@ -37,5 +41,4 @@ public interface IHasName {
     @PUT
     @Path("name")
     Response setName(@FormParam("value") String name);
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/collections/EntityCollectionResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/collections/EntityCollectionResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2014 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,23 +13,29 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources._support.collections;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.winery.common.Util;
+import org.eclipse.winery.repository.rest.resources._support.IPersistable;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.eclipse.winery.common.Util;
-import org.eclipse.winery.repository.rest.resources._support.IPersistable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Class managing a list of entities. It is intended to manage subresources, which are stored in a list. Either all
@@ -50,7 +56,6 @@ public abstract class EntityCollectionResource<EntityResourceT extends EntityRes
     protected final Class<EntityT> entityTClazz;
 
     protected final Class<EntityResourceT> entityResourceTClazz;
-
 
     /**
      * @param entityTClazz the class of EntityT. Required as it is not possible to call new EntityT (see

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/collections/EntityResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/collections/EntityResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2015 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,14 +13,19 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources._support.collections;
 
-import org.eclipse.winery.repository.rest.RestUtils;
-import org.eclipse.winery.repository.rest.resources._support.IPersistable;
+import java.util.List;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import java.util.List;
+
+import org.eclipse.winery.repository.rest.RestUtils;
+import org.eclipse.winery.repository.rest.resources._support.IPersistable;
 
 /**
  * Class to hold a single entity residing in a list of entities
@@ -42,11 +47,9 @@ public abstract class EntityResource<EntityT> {
 
     protected IIdDetermination<EntityT> idDetermination;
 
-
     /**
-     * @param idDetermination the object offering determination of an id of
-     *                        EntityT. May be null. If null, then setIdDetermination(obj)
-     *                        has to be called to enable this class functioning properly
+     * @param idDetermination the object offering determination of an id of EntityT. May be null. If null, then
+     *                        setIdDetermination(obj) has to be called to enable this class functioning properly
      * @param o               the object this resource is representing
      * @param idx             the index of the object in the list
      * @param list            the list, where the object is stored in
@@ -61,8 +64,7 @@ public abstract class EntityResource<EntityT> {
     }
 
     /**
-     * Quick hack for AbstractReqOrCapDefResource which is itself an
-     * IIdDetermination
+     * Quick hack for AbstractReqOrCapDefResource which is itself an IIdDetermination
      */
     protected final void setIdDetermination(IIdDetermination<EntityT> idDetermination) {
         this.idDetermination = idDetermination;
@@ -87,12 +89,10 @@ public abstract class EntityResource<EntityT> {
     /**
      * Replaces the whole entity by the given entity
      * <p>
-     * As we use the hash code as index, the index changes when the resource is
-     * updated. This is not in line with REST. The alternative implementation is
-     * to use the index in the list as resource identification. That changes at
-     * each modification of the list itself (if elements are deleted / inserted
-     * before the current entry). When using the hash value, users may
-     * concurrently edit items and the list may also be updated
+     * As we use the hash code as index, the index changes when the resource is updated. This is not in line with REST.
+     * The alternative implementation is to use the index in the list as resource identification. That changes at each
+     * modification of the list itself (if elements are deleted / inserted before the current entry). When using the
+     * hash value, users may concurrently edit items and the list may also be updated
      *
      * @return the new id.
      */
@@ -114,5 +114,4 @@ public abstract class EntityResource<EntityT> {
         }
         return RestUtils.persist(this.res);
     }
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/dataadapter/injectionadapter/InjectorReplaceOptions.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/dataadapter/injectionadapter/InjectorReplaceOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,14 +14,19 @@
 
 package org.eclipse.winery.repository.rest.resources._support.dataadapter.injectionadapter;
 
-import org.eclipse.winery.model.tosca.TTopologyTemplate;
-import org.eclipse.winery.model.tosca.constants.Namespaces;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.model.tosca.constants.Namespaces;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "")

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/RepositoryAdminResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/RepositoryAdminResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,18 +13,25 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.admin;
 
-import com.sun.jersey.core.header.FormDataContentDisposition;
-import com.sun.jersey.multipart.FormDataParam;
-import org.eclipse.winery.repository.backend.IRepositoryAdministration;
-import org.eclipse.winery.repository.backend.RepositoryFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+
+import org.eclipse.winery.repository.backend.IRepositoryAdministration;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+
+import com.sun.jersey.core.header.FormDataContentDisposition;
+import com.sun.jersey.multipart.FormDataParam;
 
 public class RepositoryAdminResource {
 

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/types/AbstractTypesManager.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/types/AbstractTypesManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,26 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.admin.types;
 
-import org.apache.commons.lang3.StringUtils;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.common.ids.admin.TypesId;
 import org.eclipse.winery.repository.rest.datatypes.TypeWithShortName;
@@ -21,19 +40,12 @@ import org.eclipse.winery.repository.rest.datatypes.select2.Select2DataItem;
 import org.eclipse.winery.repository.rest.resources.admin.AbstractAdminResource;
 import org.eclipse.winery.repository.rest.resources.apiData.TypeWithShortNameApiData;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import java.util.*;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Handles longname/shortname by using properties
  * <p>
- * FIXME: This class does NOT support dynamic reloading of the underlying
- * Configuration instance
+ * FIXME: This class does NOT support dynamic reloading of the underlying Configuration instance
  */
 public abstract class AbstractTypesManager extends AbstractAdminResource {
 
@@ -42,7 +54,6 @@ public abstract class AbstractTypesManager extends AbstractAdminResource {
 
     // hashes from a long type string to the type object holding complete type data
     private final HashMap<String, TypeWithShortName> hashTypeStringToType;
-
 
     public AbstractTypesManager(TypesId id) {
         super(id);
@@ -67,8 +78,7 @@ public abstract class AbstractTypesManager extends AbstractAdminResource {
     /**
      * Adds data to the internal data structure WITHOUT persisting it
      * <p>
-     * More or less a quick hack to enable adding default types without
-     * persisting them in the storage
+     * More or less a quick hack to enable adding default types without persisting them in the storage
      *
      * @param t the type to add
      */
@@ -170,5 +180,4 @@ public abstract class AbstractTypesManager extends AbstractAdminResource {
         this.addTypeWithShortName(tws);
         return Response.noContent().build();
     }
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/artifacts/GenericArtifactsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/artifacts/GenericArtifactsResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,9 +13,32 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.artifacts;
 
-import io.swagger.annotations.ApiOperation;
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jdt.annotation.NonNull;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedSet;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.common.ids.Namespace;
 import org.eclipse.winery.common.ids.XmlId;
@@ -24,9 +47,13 @@ import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
 import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
 import org.eclipse.winery.common.ids.definitions.NodeTypeId;
 import org.eclipse.winery.generators.ia.Generator;
-import org.eclipse.winery.model.tosca.*;
+import org.eclipse.winery.model.tosca.TArtifactTemplate;
+import org.eclipse.winery.model.tosca.TArtifactType;
+import org.eclipse.winery.model.tosca.TDeploymentArtifact;
 import org.eclipse.winery.model.tosca.TEntityTemplate.Properties;
 import org.eclipse.winery.model.tosca.TImplementationArtifacts.ImplementationArtifact;
+import org.eclipse.winery.model.tosca.TInterface;
+import org.eclipse.winery.model.tosca.TNodeType;
 import org.eclipse.winery.model.tosca.constants.QNames;
 import org.eclipse.winery.repository.backend.BackendUtils;
 import org.eclipse.winery.repository.backend.IRepository;
@@ -41,33 +68,16 @@ import org.eclipse.winery.repository.rest.resources._support.collections.withid.
 import org.eclipse.winery.repository.rest.resources.apiData.GenerateArtifactApiData;
 import org.eclipse.winery.repository.rest.resources.entitytemplates.artifacttemplates.ArtifactTemplateResource;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.topologytemplates.NodeTemplateResource;
+
+import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jdt.annotation.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
 import org.xml.sax.InputSource;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
-import java.io.StringReader;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
 
 /**
  * Resource handling both deployment and implementation artifacts

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/PropertiesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/PropertiesResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,9 +13,16 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytemplates;
 
-import io.github.adr.embedded.ADR;
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.eclipse.winery.model.tosca.TEntityTemplate;
 import org.eclipse.winery.model.tosca.TEntityType;
 import org.eclipse.winery.model.tosca.kvproperties.WinerysPropertiesDefinition;
@@ -23,13 +30,12 @@ import org.eclipse.winery.repository.backend.BackendUtils;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.AbstractComponentInstanceResource;
+
+import io.github.adr.embedded.ADR;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.Map;
 
 public class PropertiesResource {
 

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/InstanceStatesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/InstanceStatesResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,36 +13,41 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes;
 
-import org.apache.commons.lang3.StringUtils;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.model.tosca.TTopologyElementInstanceStates;
 import org.eclipse.winery.model.tosca.TTopologyElementInstanceStates.InstanceState;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources.apiData.InstanceStateApiData;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 /**
- * Resource for instance states.
- * Used by relationship types and node types
+ * Resource for instance states. Used by relationship types and node types
  */
 public class InstanceStatesResource {
 
     private TopologyGraphElementEntityTypeResource typeResource;
     private TTopologyElementInstanceStates instanceStates;
 
-
     /**
      * @param instanceStates the instanceStates to manage
-     * @param typeResource   the type resource, where the instance states are
-     *                       managed. This reference is required to fire "persist()" in
-     *                       case of updates
+     * @param typeResource   the type resource, where the instance states are managed. This reference is required to
+     *                       fire "persist()" in case of updates
      */
     public InstanceStatesResource(TTopologyElementInstanceStates instanceStates, TopologyGraphElementEntityTypeResource typeResource) {
         this.instanceStates = instanceStates;
@@ -119,5 +124,4 @@ public class InstanceStatesResource {
 
         return RestUtils.persist(this.typeResource);
     }
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/ArtifactTypesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/artifacttypes/ArtifactTypesResource.java
@@ -13,16 +13,22 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.artifacttypes;
 
-import io.swagger.annotations.Api;
+import java.util.SortedSet;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.rest.resources._support.AbstractComponentsWithoutTypeReferenceResource;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.util.SortedSet;
+import io.swagger.annotations.Api;
 
 @Api(tags = "Artifact Types")
 public class ArtifactTypesResource extends AbstractComponentsWithoutTypeReferenceResource<ArtifactTypeResource> {
@@ -67,8 +73,8 @@ public class ArtifactTypesResource extends AbstractComponentsWithoutTypeReferenc
     }
 
     /**
-     * Returns the first matching ArtifactTypeResource for the given file
-     * extension. Returns null if no such ArtifactType can be found
+     * Returns the first matching ArtifactTypeResource for the given file extension. Returns null if no such
+     * ArtifactType can be found
      * <p>
      * The case of the extension is ignored.
      * <p>

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/reqandcapdefs/AbstractReqOrCapDefResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/reqandcapdefs/AbstractReqOrCapDefResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,6 +13,18 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.nodetypes.reqandcapdefs;
 
+import java.lang.reflect.Method;
+import java.util.List;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.model.tosca.TCapabilityDefinition;
 import org.eclipse.winery.model.tosca.TConstraint;
 import org.eclipse.winery.model.tosca.TRequirementDefinition;
@@ -21,22 +33,15 @@ import org.eclipse.winery.repository.rest.resources._support.ConstraintsResource
 import org.eclipse.winery.repository.rest.resources._support.collections.IIdDetermination;
 import org.eclipse.winery.repository.rest.resources._support.collections.withid.EntityWithIdResource;
 import org.eclipse.winery.repository.rest.resources.entitytypes.nodetypes.NodeTypeResource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.xml.namespace.QName;
-import java.lang.reflect.Method;
-import java.util.List;
 
 /**
  * Bundles common properties of TRequirementDefinition and TCapabilityDefinition
  * <p>
- * We agreed in the project not to modify org.eclipse.winery.model.tosca.
- * Therefore, this resource models the common properties of a
- * TRequirementDefinition and a TCapabilityDefinition
+ * We agreed in the project not to modify org.eclipse.winery.model.tosca. Therefore, this resource models the common
+ * properties of a TRequirementDefinition and a TCapabilityDefinition
  */
 public abstract class AbstractReqOrCapDefResource<ReqOrCapDef> extends EntityWithIdResource<ReqOrCapDef> implements IIdDetermination<ReqOrCapDef> {
 
@@ -49,11 +54,9 @@ public abstract class AbstractReqOrCapDefResource<ReqOrCapDef> extends EntityWit
 
     private List<TConstraint> constraints;
 
-
     /**
-     * @param constraints additional parameter (in comparison to the constructor
-     *                    of EntityWithIdResource) as we require that sublist for the
-     *                    constrinats sub resource
+     * @param constraints additional parameter (in comparison to the constructor of EntityWithIdResource) as we require
+     *                    that sublist for the constrinats sub resource
      */
     public AbstractReqOrCapDefResource(IIdDetermination<ReqOrCapDef> idDetermination, ReqOrCapDef reqOrCapDef, int idx, List<ReqOrCapDef> list, NodeTypeResource res, List<TConstraint> constraints) {
         super(idDetermination, reqOrCapDef, idx, list, res);
@@ -159,9 +162,7 @@ public abstract class AbstractReqOrCapDefResource<ReqOrCapDef> extends EntityWit
     /**
      * required by the JSP.
      * <p>
-     * Therefore, we have two getters for the type: QName for the JSP and String
-     * for REST clients
+     * Therefore, we have two getters for the type: QName for the JSP and String for REST clients
      */
     public abstract QName getType();
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/properties/PropertiesDefinitionResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/properties/PropertiesDefinitionResource.java
@@ -13,6 +13,21 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.properties;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.winery.model.tosca.TEntityType;
 import org.eclipse.winery.model.tosca.TEntityType.PropertiesDefinition;
 import org.eclipse.winery.model.tosca.kvproperties.WinerysPropertiesDefinition;
@@ -26,15 +41,9 @@ import org.eclipse.winery.repository.rest.datatypes.NamespaceAndDefinedLocalName
 import org.eclipse.winery.repository.rest.resources.apiData.PropertiesDefinitionEnum;
 import org.eclipse.winery.repository.rest.resources.apiData.PropertiesDefinitionResourceApiData;
 import org.eclipse.winery.repository.rest.resources.entitytypes.EntityTypeResource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Models
@@ -43,8 +52,7 @@ import java.util.List;
  * <li>Winery's KV properties (in the subresource "winery")</li>
  * </ol>
  * <p>
- * This class does not have "KV" in its name, because it models
- * {@link TEntityType.PropertiesDefinition}
+ * This class does not have "KV" in its name, because it models {@link TEntityType.PropertiesDefinition}
  */
 public class PropertiesDefinitionResource {
 
@@ -56,7 +64,6 @@ public class PropertiesDefinitionResource {
     // we assume that this class is created at each request
     // therefore, we can have "wpd" final
     private final WinerysPropertiesDefinition wpd;
-
 
     public PropertiesDefinitionResource(EntityTypeResource res) {
         this.parentRes = res;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResource.java
@@ -13,6 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.relationshiptypes;
 
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.ids.definitions.NodeTypeImplementationId;
 import org.eclipse.winery.common.ids.definitions.RelationshipTypeId;
 import org.eclipse.winery.model.tosca.TExtensibleElements;
@@ -30,14 +41,9 @@ import org.eclipse.winery.repository.rest.resources.apiData.ValidEndingsApiDataS
 import org.eclipse.winery.repository.rest.resources.entitytypes.InstanceStatesResource;
 import org.eclipse.winery.repository.rest.resources.entitytypes.TopologyGraphElementEntityTypeResource;
 import org.eclipse.winery.repository.rest.resources.interfaces.InterfacesResource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.xml.namespace.QName;
-import java.util.List;
 
 public class RelationshipTypeResource extends TopologyGraphElementEntityTypeResource {
 

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/requirementtypes/RequiredCapabilityTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/requirementtypes/RequiredCapabilityTypeResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,16 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.requirementtypes;
 
-import com.sun.jersey.api.NotFoundException;
-import org.apache.commons.lang3.StringUtils;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.ids.definitions.CapabilityTypeId;
 import org.eclipse.winery.model.tosca.TRequirementType;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
@@ -22,11 +30,8 @@ import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources.apiData.AvailableSuperclassesApiData;
 import org.eclipse.winery.repository.rest.resources.apiData.RequiredCapabilityTypeApiData;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.xml.namespace.QName;
+import com.sun.jersey.api.NotFoundException;
+import org.apache.commons.lang3.StringUtils;
 
 public class RequiredCapabilityTypeResource {
 

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/imports/xsdimports/XSDImportsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/imports/xsdimports/XSDImportsResource.java
@@ -13,18 +13,24 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.imports.xsdimports;
 
-import io.swagger.annotations.ApiOperation;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
 import org.eclipse.winery.common.ids.Namespace;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.rest.resources._support.AbstractComponentsWithoutTypeReferenceResource;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import java.util.List;
+import io.swagger.annotations.ApiOperation;
 
 /**
- * Manages all imports of type XML Schema Definition.
- * The actual implementation is done in the AbstractComponentsResource
+ * Manages all imports of type XML Schema Definition. The actual implementation is done in the
+ * AbstractComponentsResource
  * <p>
  * FIXME: This class should be generalized to handle ImportId
  */
@@ -47,5 +53,4 @@ public class XSDImportsResource extends AbstractComponentsWithoutTypeReferenceRe
     public XSDImportResource getComponentInstanceResource(@PathParam("namespace") String namespace, @PathParam("id") String id) {
         return this.getComponentInstanceResource(namespace, id, true);
     }
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/interfaces/InterfacesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/interfaces/InterfacesResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,6 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.interfaces;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.eclipse.winery.model.tosca.TInterface;
 import org.eclipse.winery.model.tosca.TNodeType;
 import org.eclipse.winery.model.tosca.TOperation;
@@ -22,12 +33,6 @@ import org.eclipse.winery.repository.rest.resources.apiData.InterfacesSelectApiD
 import org.eclipse.winery.repository.rest.resources.entitytypes.TopologyGraphElementEntityTypeResource;
 import org.eclipse.winery.repository.rest.resources.entitytypes.nodetypes.NodeTypeResource;
 import org.eclipse.winery.repository.rest.resources.entitytypes.relationshiptypes.RelationshipTypeResource;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.List;
 
 public class InterfacesResource {
 
@@ -111,5 +116,4 @@ public class InterfacesResource {
 
         return list;
     }
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/PropertyMappingsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/PropertyMappingsResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2014 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,21 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.servicetemplates.boundarydefinitions;
 
-import io.swagger.annotations.ApiOperation;
-import org.apache.commons.lang3.StringUtils;
+import java.util.Iterator;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.model.tosca.TBoundaryDefinitions.Properties.PropertyMappings;
 import org.eclipse.winery.model.tosca.TEntityTemplate;
@@ -25,19 +38,13 @@ import org.eclipse.winery.repository.rest.resources.apiData.boundarydefinitions.
 import org.eclipse.winery.repository.rest.resources.apiData.boundarydefinitions.PropertyMappingsApi;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import java.util.Iterator;
+import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang3.StringUtils;
 
 public class PropertyMappingsResource {
 
     private final PropertyMappings propertyMappings;
     private final ServiceTemplateResource res;
-
 
     public PropertyMappingsResource(PropertyMappings propertyMappings, ServiceTemplateResource res) {
         this.propertyMappings = propertyMappings;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/interfaces/ExportedOperationResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/interfaces/ExportedOperationResource.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2014 Contributors to the Eclipse Foundation
+ * Copyright (c) 2014-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,32 +13,41 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.servicetemplates.boundarydefinitions.interfaces;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import org.eclipse.winery.model.tosca.*;
+import java.io.StringWriter;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.winery.model.tosca.TExportedOperation;
 import org.eclipse.winery.model.tosca.TExportedOperation.NodeOperation;
 import org.eclipse.winery.model.tosca.TExportedOperation.Plan;
 import org.eclipse.winery.model.tosca.TExportedOperation.RelationshipOperation;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TPlan;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.IPersistable;
 import org.eclipse.winery.repository.rest.resources._support.collections.IIdDetermination;
 import org.eclipse.winery.repository.rest.resources._support.collections.withid.EntityWithIdResource;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.io.StringWriter;
-import java.util.List;
 
 public class ExportedOperationResource extends EntityWithIdResource<TExportedOperation> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExportedOperationResource.class);
-
 
     public ExportedOperationResource(IIdDetermination<TExportedOperation> idDetermination, TExportedOperation o, int idx, List<TExportedOperation> list, IPersistable res) {
         super(idDetermination, o, idx, list, res);
@@ -69,8 +78,7 @@ public class ExportedOperationResource extends EntityWithIdResource<TExportedOpe
     }
 
     /**
-     * @return "NodeOperation" | "RelationshipOperation" | "Plan" | null. null
-     * is returned if no type is set
+     * @return "NodeOperation" | "RelationshipOperation" | "Plan" | null. null is returned if no type is set
      */
     @Path("type")
     @GET
@@ -235,5 +243,4 @@ public class ExportedOperationResource extends EntityWithIdResource<TExportedOpe
         }
         return RestUtils.persist(this.res);
     }
-
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/interfaces/InterfacesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/interfaces/InterfacesResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2014-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,17 +14,26 @@
 
 package org.eclipse.winery.repository.rest.resources.servicetemplates.boundarydefinitions.interfaces;
 
-import org.eclipse.winery.model.tosca.*;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.winery.model.tosca.TExportedInterface;
+import org.eclipse.winery.model.tosca.TExportedOperation;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TPlan;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.IPersistable;
 import org.eclipse.winery.repository.rest.resources._support.collections.withid.EntityWithIdCollectionResource;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.Arrays;
-import java.util.List;
 
 public class InterfacesResource extends EntityWithIdCollectionResource<ExportedInterfaceResource, TExportedInterface> {
 
@@ -38,8 +47,8 @@ public class InterfacesResource extends EntityWithIdCollectionResource<ExportedI
     }
 
     /**
-     * A special handling for TExportedInterface is required as this object uses IDREF, which must not be a string,
-     * but the real object when persisting.
+     * A special handling for TExportedInterface is required as this object uses IDREF, which must not be a string, but
+     * the real object when persisting.
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/reqscaps/CapabilitiesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/reqscaps/CapabilitiesResource.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2014-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2014-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,6 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.servicetemplates.boundarydefinitions.reqscaps;
 
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.winery.model.tosca.TCapability;
 import org.eclipse.winery.model.tosca.TCapabilityRef;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
@@ -21,12 +32,6 @@ import org.eclipse.winery.repository.rest.resources._support.collections.Collect
 import org.eclipse.winery.repository.rest.resources._support.collections.withoutid.EntityWithoutIdCollectionResource;
 import org.eclipse.winery.repository.rest.resources.apiData.RequirementsOrCapabilityApiData;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.util.List;
 
 /**
  * This class is an adaption from {@link org.eclipse.winery.repository.resources.servicetemplates.boundarydefinitions.reqscaps.RequirementsResource}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/reqscaps/RequirementsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/reqscaps/RequirementsResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2014-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,6 +14,17 @@
 
 package org.eclipse.winery.repository.rest.resources.servicetemplates.boundarydefinitions.reqscaps;
 
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.winery.model.tosca.TRequirement;
 import org.eclipse.winery.model.tosca.TRequirementRef;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
@@ -22,12 +33,6 @@ import org.eclipse.winery.repository.rest.resources._support.collections.Collect
 import org.eclipse.winery.repository.rest.resources._support.collections.withoutid.EntityWithoutIdCollectionResource;
 import org.eclipse.winery.repository.rest.resources.apiData.RequirementsOrCapabilityApiData;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.util.List;
 
 /**
  * This class is mirrored at {@link org.eclipse.winery.repository.resources.servicetemplates.boundarydefinitions.reqscaps.CapabilitiesResource}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/ParametersResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/ParametersResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,25 +13,31 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.servicetemplates.plans;
 
-import org.apache.commons.lang3.StringUtils;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.winery.model.tosca.TBoolean;
 import org.eclipse.winery.model.tosca.TParameter;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.IPersistable;
 import org.eclipse.winery.repository.rest.resources._support.collections.withid.EntityWithIdCollectionResource;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.util.List;
 
 public class ParametersResource extends EntityWithIdCollectionResource<ParameterResource, TParameter> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ParametersResource.class);
-
 
     public ParametersResource(List<TParameter> parameters, IPersistable typeResource) {
         super(ParameterResource.class, TParameter.class, parameters, typeResource);

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/PlanResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/PlanResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2015 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,6 +14,17 @@
 
 package org.eclipse.winery.repository.rest.resources.servicetemplates.plans;
 
+import java.io.IOException;
+import java.util.List;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.winery.common.ids.XmlId;
 import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
 import org.eclipse.winery.common.ids.elements.PlanId;
@@ -27,14 +38,9 @@ import org.eclipse.winery.repository.rest.resources._support.IHasName;
 import org.eclipse.winery.repository.rest.resources._support.collections.IIdDetermination;
 import org.eclipse.winery.repository.rest.resources._support.collections.withid.EntityWithIdResource;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.io.IOException;
-import java.util.List;
 
 /**
  * Does <em>not</em> implement {@link org.eclipse.winery.repository.resources.IHasTypeReference}, because the type of a
@@ -43,7 +49,6 @@ import java.util.List;
 public class PlanResource extends EntityWithIdResource<TPlan> implements IHasName {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PlanResource.class);
-
 
     public PlanResource(IIdDetermination<TPlan> idDetermination, TPlan o, int idx, List<TPlan> list, ServiceTemplateResource res) {
         super(idDetermination, o, idx, list, res);

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/NodeTemplateResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/NodeTemplateResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2014 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.servicetemplates.topologytemplates;
 
-import io.swagger.annotations.ApiOperation;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.ids.Namespace;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.constants.Namespaces;
@@ -25,11 +35,7 @@ import org.eclipse.winery.repository.rest.resources.artifacts.DeploymentArtifact
 import org.eclipse.winery.repository.rest.resources.entitytemplates.TEntityTemplateResource;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
-import javax.xml.namespace.QName;
-import java.util.List;
-import java.util.Map;
+import io.swagger.annotations.ApiOperation;
 
 public class NodeTemplateResource extends TEntityTemplateResource<TNodeTemplate> implements INodeTemplateResourceOrNodeTypeImplementationResource {
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/GetType.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/GetType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,9 +13,29 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend;
 
-import org.eclipse.winery.common.ids.definitions.*;
+import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
+import org.eclipse.winery.common.ids.definitions.CapabilityTypeId;
+import org.eclipse.winery.common.ids.definitions.NodeTypeId;
+import org.eclipse.winery.common.ids.definitions.PolicyTypeId;
+import org.eclipse.winery.common.ids.definitions.RelationshipTypeId;
+import org.eclipse.winery.common.ids.definitions.RequirementTypeId;
 import org.eclipse.winery.common.interfaces.IWineryRepositoryCommon;
-import org.eclipse.winery.model.tosca.*;
+import org.eclipse.winery.model.tosca.TArtifactTemplate;
+import org.eclipse.winery.model.tosca.TArtifactType;
+import org.eclipse.winery.model.tosca.TCapability;
+import org.eclipse.winery.model.tosca.TCapabilityType;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TEntityType;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TNodeTypeImplementation;
+import org.eclipse.winery.model.tosca.TPolicyTemplate;
+import org.eclipse.winery.model.tosca.TPolicyType;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TRelationshipTypeImplementation;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TRequirementType;
 
 /**
  * Offers getType for each subclass {@link org.eclipse.winery.model.tosca.HasType}

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
@@ -13,29 +13,42 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
-import com.google.common.collect.Iterables;
-import com.google.common.eventbus.EventBus;
-import org.apache.tika.mime.MediaType;
-import org.eclipse.jgit.api.*;
-import org.eclipse.jgit.api.ResetCommand.ResetType;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.diff.DiffEntry;
-import org.eclipse.jgit.errors.NoWorkTreeException;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-import org.eclipse.winery.common.RepositoryFileReference;
-import org.eclipse.winery.repository.backend.BackendUtils;
-import org.eclipse.winery.repository.configuration.GitBasedRepositoryConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import org.eclipse.winery.common.RepositoryFileReference;
+import org.eclipse.winery.repository.backend.BackendUtils;
+import org.eclipse.winery.repository.configuration.GitBasedRepositoryConfiguration;
+
+import com.google.common.collect.Iterables;
+import com.google.common.eventbus.EventBus;
+import org.apache.tika.mime.MediaType;
+import org.eclipse.jgit.api.AddCommand;
+import org.eclipse.jgit.api.CleanCommand;
+import org.eclipse.jgit.api.CommitCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand;
+import org.eclipse.jgit.api.ResetCommand.ResetType;
+import org.eclipse.jgit.api.RmCommand;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.errors.NoWorkTreeException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Allows to reset repository to a certain commit id
@@ -107,7 +120,7 @@ public class GitBasedRepository extends FilebasedRepository {
      * @throws GitAPIException thrown when anything with adding or committing goes wrong.
      */
     public void addCommit(String message) throws GitAPIException {
-        addCommit(new String[]{"."}, message);
+        addCommit(new String[] {"."}, message);
     }
 
     public void addCommit(String[] patterns, String message) throws GitAPIException {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/xsd/RepositoryBasedXsdImportManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/xsd/RepositoryBasedXsdImportManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,6 +13,28 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.xsd;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+
+import org.eclipse.winery.common.RepositoryFileReference;
+import org.eclipse.winery.common.ids.Namespace;
+import org.eclipse.winery.common.ids.definitions.imports.XSDImportId;
+import org.eclipse.winery.repository.backend.BackendUtils;
+import org.eclipse.winery.repository.backend.ImportUtils;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.backend.constants.MediaTypes;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.xerces.xs.XSConstants;
 import org.apache.xerces.xs.XSModel;
@@ -22,20 +44,8 @@ import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Multimaps;
 import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.winery.common.RepositoryFileReference;
-import org.eclipse.winery.common.ids.Namespace;
-import org.eclipse.winery.common.ids.definitions.imports.XSDImportId;
-import org.eclipse.winery.repository.backend.BackendUtils;
-import org.eclipse.winery.repository.backend.ImportUtils;
-import org.eclipse.winery.repository.backend.RepositoryFactory;
-import org.eclipse.winery.repository.backend.constants.MediaTypes;
 import org.slf4j.ext.XLogger;
 import org.slf4j.ext.XLoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class RepositoryBasedXsdImportManager implements XsdImportManager {
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/driverspecificationandinjection/DASpecification.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/driverspecificationandinjection/DASpecification.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,20 +14,28 @@
 
 package org.eclipse.winery.repository.driverspecificationandinjection;
 
-import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
-import org.eclipse.winery.common.ids.definitions.NodeTypeImplementationId;
-import org.eclipse.winery.common.ids.definitions.RelationshipTypeId;
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.repository.backend.IRepository;
-import org.eclipse.winery.repository.backend.RepositoryFactory;
-
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
+import org.eclipse.winery.common.ids.definitions.NodeTypeImplementationId;
+import org.eclipse.winery.common.ids.definitions.RelationshipTypeId;
+import org.eclipse.winery.model.tosca.TArtifactType;
+import org.eclipse.winery.model.tosca.TBoolean;
+import org.eclipse.winery.model.tosca.TDeploymentArtifact;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeTypeImplementation;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.model.tosca.utils.ModelUtilities;
+import org.eclipse.winery.repository.backend.IRepository;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
 
 public class DASpecification {
 
@@ -114,7 +122,6 @@ public class DASpecification {
                 TNodeTemplate targetNodeTemplate = ModelUtilities.getTargetNodeTemplateOfRelationshipTemplate(topologyTemplate, relationshipTemplate);
                 return getNodesWithSuitableConcreteDAs(targetNodeTemplate, deploymentArtifact, topologyTemplate);
             }
-
         } else {
             return nodeTemplate;
         }
@@ -170,9 +177,6 @@ public class DASpecification {
 
     /**
      * method already exists in Splitting. Put into ModelUtilities
-     *
-     * @param relationshipTypeQName
-     * @return
      */
     private static TRelationshipType getBasisRelationshipType(QName relationshipTypeQName) {
         RelationshipTypeId parentRelationshipTypeId = new RelationshipTypeId(relationshipTypeQName);

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/driverspecificationandinjection/DriverInjection.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/driverspecificationandinjection/DriverInjection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,16 +14,22 @@
 
 package org.eclipse.winery.repository.driverspecificationandinjection;
 
-import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.repository.backend.RepositoryFactory;
-import org.eclipse.winery.repository.exceptions.WineryRepositoryException;
-
-import javax.xml.namespace.QName;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
+import org.eclipse.winery.model.tosca.TArtifactTemplate;
+import org.eclipse.winery.model.tosca.TBoolean;
+import org.eclipse.winery.model.tosca.TDeploymentArtifact;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.model.tosca.utils.ModelUtilities;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.exceptions.WineryRepositoryException;
 
 public class DriverInjection {
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/patterndetection/Detection.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/patterndetection/Detection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,27 +14,52 @@
 
 package org.eclipse.winery.repository.patterndetection;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
 import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
-import org.eclipse.winery.repository.patterndetection.keywords.*;
-import org.eclipse.winery.repository.patterndetection.model.*;
-import org.eclipse.winery.repository.patterndetection.model.patterns.*;
+import org.eclipse.winery.repository.patterndetection.keywords.Messaging;
+import org.eclipse.winery.repository.patterndetection.keywords.OperatingSystem;
+import org.eclipse.winery.repository.patterndetection.keywords.Server;
+import org.eclipse.winery.repository.patterndetection.keywords.Service;
+import org.eclipse.winery.repository.patterndetection.keywords.Storage;
+import org.eclipse.winery.repository.patterndetection.keywords.VirtualHardware;
+import org.eclipse.winery.repository.patterndetection.model.AbstractTopology;
+import org.eclipse.winery.repository.patterndetection.model.PatternComponent;
+import org.eclipse.winery.repository.patterndetection.model.PatternPosition;
+import org.eclipse.winery.repository.patterndetection.model.RelationshipEdge;
+import org.eclipse.winery.repository.patterndetection.model.TNodeTemplateExtended;
+import org.eclipse.winery.repository.patterndetection.model.patterns.ElasticLoadBalancerPattern;
+import org.eclipse.winery.repository.patterndetection.model.patterns.ElasticQueuePattern;
+import org.eclipse.winery.repository.patterndetection.model.patterns.ElasticityManagerPattern;
+import org.eclipse.winery.repository.patterndetection.model.patterns.EnvironmentBasedAvailabilityPattern;
+import org.eclipse.winery.repository.patterndetection.model.patterns.ExecutionEnvironmentPattern;
+import org.eclipse.winery.repository.patterndetection.model.patterns.ExecutionEnvironmentPattern2;
+import org.eclipse.winery.repository.patterndetection.model.patterns.KeyValueStoragePattern;
+import org.eclipse.winery.repository.patterndetection.model.patterns.MessageOrientedMiddlewarePattern;
+import org.eclipse.winery.repository.patterndetection.model.patterns.NodeBasedAvailabilityPattern;
+import org.eclipse.winery.repository.patterndetection.model.patterns.RelationalDatabasePattern;
 import org.eclipse.winery.repository.patterndetection.model.patterntaxonomies.IaaSTaxonomy;
 import org.eclipse.winery.repository.patterndetection.model.patterntaxonomies.PaaSTaxonomy;
+
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.alg.isomorphism.IsomorphicGraphMapping;
 import org.jgrapht.alg.isomorphism.VF2SubgraphIsomorphismInspector;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.SimpleDirectedGraph;
 import org.jgrapht.graph.SimpleDirectedWeightedGraph;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
 
 public class Detection {
 
@@ -422,7 +447,6 @@ public class Detection {
                         if (p.getName().equals(v.getLabel())) {
                             matched.add(true);
                             originGraph.addVertex(v);
-
                         } else {
                             matched.add(false);
                         }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
@@ -14,7 +14,19 @@
 
 package org.eclipse.winery.repository.splitting;
 
-import org.eclipse.jdt.annotation.NonNull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+
+import javax.xml.namespace.QName;
 
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.common.ids.definitions.CapabilityTypeId;
@@ -23,7 +35,15 @@ import org.eclipse.winery.common.ids.definitions.RequirementTypeId;
 import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
 import org.eclipse.winery.common.version.VersionUtils;
 import org.eclipse.winery.common.version.WineryVersion;
-import org.eclipse.winery.model.tosca.*;
+import org.eclipse.winery.model.tosca.TCapability;
+import org.eclipse.winery.model.tosca.TCapabilityType;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TRequirementType;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
 import org.eclipse.winery.repository.backend.BackendUtils;
 import org.eclipse.winery.repository.backend.IRepository;
@@ -31,13 +51,8 @@ import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.driverspecificationandinjection.DASpecification;
 import org.eclipse.winery.repository.driverspecificationandinjection.DriverInjection;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.namespace.QName;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class Splitting {
 

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/IGenericRepositoryTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/IGenericRepositoryTest.java
@@ -14,15 +14,20 @@
 
 package org.eclipse.winery.repository.backend;
 
-import org.eclipse.winery.common.ids.definitions.*;
-import org.eclipse.winery.repository.TestWithGitBackedRepository;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.xml.namespace.QName;
+
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.common.ids.definitions.NodeTypeId;
+import org.eclipse.winery.common.ids.definitions.NodeTypeImplementationId;
+import org.eclipse.winery.common.ids.definitions.PolicyTemplateId;
+import org.eclipse.winery.common.ids.definitions.PolicyTypeId;
+import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
+import org.eclipse.winery.repository.TestWithGitBackedRepository;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.Test;
@@ -36,7 +41,7 @@ public class IGenericRepositoryTest extends TestWithGitBackedRepository {
         this.setRevisionTo("origin/plain");
         final ServiceTemplateId serviceTemplateWithFourPolicies = new ServiceTemplateId("http%3A%2F%2Fplain.winery.opentosca.org%2Fservicetemplates", "ServiceTemplateWithFourPolicies", true);
         final Collection<DefinitionsChildId> referencedDefinitionsChildIds = this.repository.getReferencedDefinitionsChildIds(serviceTemplateWithFourPolicies);
-        
+
         NodeTypeId nodeTypeWithoutPropertiesId = new NodeTypeId("http://plain.winery.opentosca.org/nodetypes", "NodeTypeWithoutProperties", false);
         PolicyTemplateId policyTemplateId = new PolicyTemplateId("http://plain.winery.opentosca.org/policytemplates", "PolicyTemplateWithoutProperties", false);
         PolicyTypeId policyTypeId = new PolicyTypeId("http://plain.winery.opentosca.org/policytypes", "PolicyTypeWithoutProperties", false);
@@ -44,15 +49,14 @@ public class IGenericRepositoryTest extends TestWithGitBackedRepository {
         final Set<DefinitionsChildId> expected = new HashSet<>(Arrays.asList(nodeTypeWithoutPropertiesId, policyTemplateId, policyTypeId));
         assertEquals(expected, referencedDefinitionsChildIds);
     }
-    
+
     @Test
     public void getReferencedDefinitionsChildIDsWithEmptyArtifactRefs() throws GitAPIException {
         this.setRevisionTo("5fb45405cc983d157dc417142ad32b01880e48af");
-        
+
         final NodeTypeId nodeTypeId = new NodeTypeId("http%3A%2F%2Fwinery.opentosca.org/test/ponyuniverse", "shetland_pony", true);
         final QName qName = nodeTypeId.getQName();
         Collection<NodeTypeImplementationId> allNodeTypeImplementations = this.repository.getAllElementsReferencingGivenType(NodeTypeImplementationId.class, nodeTypeId.getQName());
         assertEquals(0, allNodeTypeImplementations.size());
-        
     }
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/FilebasedRepositoryTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/FilebasedRepositoryTest.java
@@ -13,8 +13,21 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.SortedSet;
+
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.RepositoryFileReference;
-import org.eclipse.winery.common.ids.definitions.*;
+import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
+import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
+import org.eclipse.winery.common.ids.definitions.CapabilityTypeId;
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.common.ids.definitions.NodeTypeId;
+import org.eclipse.winery.common.ids.definitions.RequirementTypeId;
 import org.eclipse.winery.common.ids.definitions.imports.XSDImportId;
 import org.eclipse.winery.model.tosca.TArtifactTemplate;
 import org.eclipse.winery.model.tosca.TEntityType;
@@ -23,13 +36,6 @@ import org.eclipse.winery.repository.backend.BackendUtils;
 import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateFilesDirectoryId;
 import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateSourceDirectoryId;
 import org.eclipse.winery.repository.datatypes.ids.elements.DirectoryId;
-
-import javax.xml.namespace.QName;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.SortedSet;
 
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/JsonBasedNamespaceManagerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/JsonBasedNamespaceManagerTest.java
@@ -20,7 +20,8 @@ import org.eclipse.winery.model.tosca.constants.Namespaces;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class JsonBasedNamespaceManagerTest {
 
@@ -33,7 +34,7 @@ class JsonBasedNamespaceManagerTest {
         JsonBasedNamespaceManager namespaceManager = new JsonBasedNamespaceManager(f);
 
         String prefix = namespaceManager.getPrefix(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE);
-        
+
         assertEquals("winery", prefix);
         assertFalse(f.exists());
     }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/driverspecificationandinjection/DASpecificationTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/driverspecificationandinjection/DASpecificationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,16 +14,21 @@
 
 package org.eclipse.winery.repository.driverspecificationandinjection;
 
-import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
-import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.repository.TestWithGitBackedRepository;
-
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
+import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
+import org.eclipse.winery.model.tosca.TArtifactType;
+import org.eclipse.winery.model.tosca.TDeploymentArtifact;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.repository.TestWithGitBackedRepository;
 
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/WineryUtil.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/WineryUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,9 +13,13 @@
  *******************************************************************************/
 package org.eclipse.winery.topologymodeler;
 
-import org.eclipse.winery.common.interfaces.QNameWithName;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
-import java.util.*;
+import org.eclipse.winery.common.interfaces.QNameWithName;
 
 public class WineryUtil {
 
@@ -26,7 +30,6 @@ public class WineryUtil {
 
         String localName;
         String name;
-
 
         public LocalNameNamePair(String localName, String name) {
             this.localName = localName;
@@ -80,5 +83,4 @@ public class WineryUtil {
         }
         return res;
     }
-
 }

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/analyzer/RequirementAnalyzer.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/analyzer/RequirementAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,17 +14,24 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer;
 
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.winery.model.tosca.TCapability;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TRequirementDefinition;
+import org.eclipse.winery.model.tosca.TRequirementType;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
+
 /**
- * This class analyzes the occurrence of TOSCA {@link TRequirement}s in a {@link TTopologyTemplate} and checks whether they
- * are already fulfilled or not.
+ * This class analyzes the occurrence of TOSCA {@link TRequirement}s in a {@link TTopologyTemplate} and checks whether
+ * they are already fulfilled or not.
  */
 public class RequirementAnalyzer {
 

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/analyzer/TOSCAAnalyzer.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/analyzer/TOSCAAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,14 +14,21 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer;
 
-import org.eclipse.winery.model.tosca.*;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TRequirementType;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+
 /**
- * This class contains several methods to analyze the content of a TOSCA {@link TTopologyTemplate} and to fill a data model
- * with the analyzed information. This class serves the access to all types and templates of a topology.
+ * This class contains several methods to analyze the content of a TOSCA {@link TTopologyTemplate} and to fill a data
+ * model with the analyzed information. This class serves the access to all types and templates of a topology.
  */
 public class TOSCAAnalyzer {
 
@@ -35,8 +42,8 @@ public class TOSCAAnalyzer {
     List<TRequirementType> requirementTypes;
 
     /**
-     * This method analyzes the TOSCA {@link TTopologyTemplate} for {@link TNodeTemplate}s, {@link TRelationshipTemplate}s
-     * and existing {@link TRequirement}s and adds them to a list.
+     * This method analyzes the TOSCA {@link TTopologyTemplate} for {@link TNodeTemplate}s, {@link
+     * TRelationshipTemplate}s and existing {@link TRequirement}s and adds them to a list.
      *
      * @param topology the TOSCA {@link TTopologyTemplate}
      */

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/helper/JAXBHelper.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/helper/JAXBHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,18 +14,30 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.helper;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import org.eclipse.winery.common.Util;
-import org.eclipse.winery.model.tosca.*;
-import org.slf4j.LoggerFactory;
-
-import javax.xml.bind.*;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+
+import org.eclipse.winery.common.Util;
+import org.eclipse.winery.model.tosca.Definitions;
+import org.eclipse.winery.model.tosca.TDefinitions;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class contains methods for marshalling and unmarshalling a topology XML string via JAXB.
@@ -270,7 +282,6 @@ public class JAXBHelper {
 
         return null;
     }
-
 
     /**
      * Marshalls a JAXB object of the TOSCA model to an XML string.

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/helper/Utils.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/helper/Utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,14 +14,20 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.helper;
 
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
-import org.slf4j.LoggerFactory;
-
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.model.tosca.TCapabilityDefinition;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TRequirementType;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
+
+import org.slf4j.LoggerFactory;
 
 /**
  * Contains methods to match requirements and capabilities and find elements in the {@link TTopologyTemplate}

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/CompletionInterface.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/CompletionInterface.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,7 +14,16 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion;
 
-import org.eclipse.winery.model.tosca.*;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TRequirementType;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.repository.client.IWineryRepositoryClient;
 import org.eclipse.winery.repository.client.WineryRepositoryClientFactory;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.DeferredAnalyzer;
@@ -24,15 +33,13 @@ import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSC
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Constants;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.JAXBHelper;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.RESTHelper;
+
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
-
 /**
- * This class is the entry point of the TOSCA topology completion which is called by the Winery Topology Modeler.
- * It receives an incomplete {@link TTopologyTemplate} from Winery.
- * The completion of the incomplete {@link TTopologyTemplate} is managed by this class.
+ * This class is the entry point of the TOSCA topology completion which is called by the Winery Topology Modeler. It
+ * receives an incomplete {@link TTopologyTemplate} from Winery. The completion of the incomplete {@link
+ * TTopologyTemplate} is managed by this class.
  */
 public class CompletionInterface {
 
@@ -42,7 +49,8 @@ public class CompletionInterface {
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(CompletionInterface.class.getName());
 
     /**
-     * This global variable is returned to the Winery Topology Modelerer via getCurrentTopology() to display intermediate results when an user interaction is necessary.
+     * This global variable is returned to the Winery Topology Modelerer via getCurrentTopology() to display
+     * intermediate results when an user interaction is necessary.
      */
     private TTopologyTemplate currentTopology;
 
@@ -57,7 +65,8 @@ public class CompletionInterface {
     private List<TEntityTemplate> relationshipTemplateChoices;
 
     /**
-     * This Map contains {@link TNodeTemplate}s and {@link TRelationshipTemplate}s to be chosen by the user during the step-by-step approach.
+     * This Map contains {@link TNodeTemplate}s and {@link TRelationshipTemplate}s to be chosen by the user during the
+     * step-by-step approach.
      */
     private Map<TNodeTemplate, Map<TNodeTemplate, List<TEntityTemplate>>> nodeTemplateChoices;
 
@@ -67,19 +76,24 @@ public class CompletionInterface {
     private String errorMessage = "";
 
     /**
-     * This method receives an incomplete {@link TTopologyTemplate} and the repository content from Winery. After analyzing the {@link TTopologyTemplate}, the topology is completed. This method will
-     * return a message after the completion whether the completion was successful, has failed or the user has to interact.
+     * This method receives an incomplete {@link TTopologyTemplate} and the repository content from Winery. After
+     * analyzing the {@link TTopologyTemplate}, the topology is completed. This method will return a message after the
+     * completion whether the completion was successful, has failed or the user has to interact.
      *
      * @param topology            (XMLString) the {@link TTopologyTemplate} to be completed as XMLString
      * @param serviceTemplateName the name of the ServiceTemplate for REST calls
      * @param topologyTemplateURL the URL where the template is saved to
-     * @param overwriteTopology   determines in which way the {@link TTopologyTemplate} is saved. The current {@link TTopologyTemplate} can either be overwritten or a new topology can be created.
-     * @param topologyName        the name of the {@link TTopologyTemplate} when a new {@link TTopologyTemplate} shall be created
-     * @param topologyNamespace   the namespace of the {@link TTopologyTemplate} when a new {@link TTopologyTemplate} shall be created
+     * @param overwriteTopology   determines in which way the {@link TTopologyTemplate} is saved. The current {@link
+     *                            TTopologyTemplate} can either be overwritten or a new topology can be created.
+     * @param topologyName        the name of the {@link TTopologyTemplate} when a new {@link TTopologyTemplate} shall
+     *                            be created
+     * @param topologyNamespace   the namespace of the {@link TTopologyTemplate} when a new {@link TTopologyTemplate}
+     *                            shall be created
      * @param repositoryURL       the URL to the repository to receive and write TOSCA specific information
      * @param stepByStep          whether the topology completion is processed step-by-step or not
      * @param restarted           whether the topology completion is restarted or started for the first time
-     * @return a message to Winery that contains information whether the topology is complete, the user has to interact or an error occurred.
+     * @return a message to Winery that contains information whether the topology is complete, the user has to interact
+     * or an error occurred.
      */
     public String complete(String topology, String serviceTemplateName, String topologyTemplateURL, Boolean overwriteTopology,
                            String topologyName, String topologyNamespace, String repositoryURL, boolean stepByStep, boolean restarted) {
@@ -136,7 +150,6 @@ public class CompletionInterface {
                 relationshipTemplateChoices = completionManager.getChoices();
 
                 return Constants.CompletionMessages.USERINTERACTION.toString();
-
             } else if (completionManager.getNodeTemplateUserInteraction() && stepByStep) {
                 // the topology completion is processed Step-by-Step, the user has to choose Node and RelationshipTemplates to be inserted
                 currentTopology = completedTopology.get(0);
@@ -179,8 +192,8 @@ public class CompletionInterface {
     }
 
     /**
-     * This method checks if the topology is already complete. It will be called before executing the topology completion but
-     * only in case the topology completion isn't restarted after a user selection.
+     * This method checks if the topology is already complete. It will be called before executing the topology
+     * completion but only in case the topology completion isn't restarted after a user selection.
      *
      * @param toscaAnalyzer the topology to be checked
      * @return whether the topology is complete or not
@@ -205,7 +218,8 @@ public class CompletionInterface {
     }
 
     /**
-     * Returns the choices whenever there are several possible complete {@link TTopologyTemplate}s. They will be displayed in Winery and chosen by the user.
+     * Returns the choices whenever there are several possible complete {@link TTopologyTemplate}s. They will be
+     * displayed in Winery and chosen by the user.
      *
      * @return the possible {@link TTopologyTemplate} choices as a list.
      */
@@ -223,7 +237,8 @@ public class CompletionInterface {
     }
 
     /**
-     * Returns several {@link TNodeTemplate} and {@link TRelationshipTemplate} choices when the user selected the step-by-step approach.
+     * Returns several {@link TNodeTemplate} and {@link TRelationshipTemplate} choices when the user selected the
+     * step-by-step approach.
      *
      * @return the {@link TNodeTemplate} choices
      */

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/CompletionManager.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/CompletionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,7 +14,17 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion;
 
-import org.eclipse.winery.model.tosca.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.DeferredAnalyzer;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.PlaceHolderAnalyzer;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.RequirementAnalyzer;
@@ -23,12 +33,6 @@ import org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompl
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer.PlaceHolderCompleter;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer.RequirementCompleter;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer.StepByStepCompleter;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
 
 /**
  * This class manages the completion of a TOSCA {@link TTopologyTemplate}.
@@ -45,9 +49,9 @@ public class CompletionManager {
     /**
      * Map containing the topology solutions.
      * <p>
-     * The first parameter of the map is an index used to traverse the map easily. The second parameter of the solutions map
-     * is another map containing a possible topology solution and a boolean value that determines if the topology is complete.
-     * When all topologies of the solution map are complete, it will be returned to Winery.
+     * The first parameter of the map is an index used to traverse the map easily. The second parameter of the solutions
+     * map is another map containing a possible topology solution and a boolean value that determines if the topology is
+     * complete. When all topologies of the solution map are complete, it will be returned to Winery.
      */
     private final Map<Integer, Map<TTopologyTemplate, Boolean>> solutions;
 
@@ -57,12 +61,14 @@ public class CompletionManager {
     private final boolean stepByStep;
 
     /**
-     * Map containing {@link TNodeTemplate}s and {@link TRelationshipTemplate}s to be chosen by the user in the step-by-step approach.
+     * Map containing {@link TNodeTemplate}s and {@link TRelationshipTemplate}s to be chosen by the user in the
+     * step-by-step approach.
      */
     private Map<TNodeTemplate, Map<TNodeTemplate, List<TEntityTemplate>>> templateChoices;
 
     /**
-     * Whether a user interaction for choosing inserted {@link TNodeTemplate}s and {@link TRelationshipTemplate}s is necessary or not.
+     * Whether a user interaction for choosing inserted {@link TNodeTemplate}s and {@link TRelationshipTemplate}s is
+     * necessary or not.
      */
     private boolean nodeTemplateUserInteraction = false;
 
@@ -159,7 +165,6 @@ public class CompletionManager {
                 LOGGER.info("Returning topology for user interaction");
 
                 return solutionList;
-
             } else if (unfulfilledRequirements.isEmpty() && !placeHolders.isEmpty()) {
 
                 // complete a topology containing place holders step by step using the StepByStepCompleter class
@@ -238,7 +243,6 @@ public class CompletionManager {
                     manageCompletion(topologySolution);
                     index++;
                 }
-
             } else if (unfulfilledRequirements.isEmpty() && !placeHolders.isEmpty() || !unfulfilledRequirements.isEmpty() && !placeHolders.isEmpty()) {
 
                 LOGGER.info("The topology contains one or more PlaceHolders.");
@@ -341,12 +345,12 @@ public class CompletionManager {
     }
 
     /**
-     * Returns whether user interaction by choosing {@link TNodeTemplate}s and {@link TRelationshipTemplate}s is necessary or not
+     * Returns whether user interaction by choosing {@link TNodeTemplate}s and {@link TRelationshipTemplate}s is
+     * necessary or not
      *
      * @return the field nodeTemplateUserInteraction
      */
     public boolean getNodeTemplateUserInteraction() {
         return nodeTemplateUserInteraction;
     }
-
 }

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/completer/DeferredCompleter.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/completer/DeferredCompleter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,13 +14,25 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer;
 
-import org.eclipse.winery.model.tosca.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.winery.model.tosca.TCapability;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TRequirementType;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.NodeTemplateConnector;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
-
-import java.util.*;
 
 /**
  * This class serves the completion of a topology containing Deferred {@link TRelationshipTemplate}s.

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/completer/PlaceHolderCompleter.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/completer/PlaceHolderCompleter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,14 +14,19 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer;
 
-import org.eclipse.winery.model.tosca.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.NodeTemplateConnector;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.placeholderhandling.PlaceHolderHandler;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This class completes a {@link TTopologyTemplate} containing place holders.

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/completer/RequirementCompleter.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/completer/RequirementCompleter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,16 +14,22 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer;
 
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.NodeTemplateConnector;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.model.tosca.utils.ModelUtilities;
+import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
+import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.NodeTemplateConnector;
+import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
 
 public class RequirementCompleter {
 

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/completer/StepByStepCompleter.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/addons/topologycompleter/topologycompletion/completer/StepByStepCompleter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,14 +14,24 @@
 
 package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer;
 
-import org.eclipse.winery.model.tosca.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.NodeTemplateConnector;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
 import org.eclipse.winery.topologymodeler.addons.topologycompleter.placeholderhandling.PlaceHolderHandler;
-
-import java.util.*;
 
 /**
  * This class handles topologies that are completed step by step

--- a/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/resources/TopologyCompletionResource.java
+++ b/org.eclipse.winery.topologymodeler/src/main/java/org/eclipse/winery/topologymodeler/resources/TopologyCompletionResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,19 +14,30 @@
 
 package org.eclipse.winery.topologymodeler.resources;
 
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.JAXBHelper;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.RESTHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.StringReader;
 
-import javax.ws.rs.*;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
-import java.io.StringReader;
+
+import org.eclipse.winery.model.tosca.Definitions;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.JAXBHelper;
+import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.RESTHelper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class contains resources used for the topology completion.
@@ -42,8 +53,7 @@ public class TopologyCompletionResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(TopologyCompletionResource.class);
 
     /**
-     * Adds selected {@link TNodeTemplate}s and {@link TRelationshipTemplate}s
-     * to a topology.
+     * Adds selected {@link TNodeTemplate}s and {@link TRelationshipTemplate}s to a topology.
      *
      * @param topology                      the {@link TTopologyTemplate} as XML string
      * @param allChoices                    all possible choices as XML
@@ -116,7 +126,6 @@ public class TopologyCompletionResource {
             }
 
             return Response.ok().build();
-
         } catch (JAXBException e) {
             LOGGER.error("Could not save topology", e);
             return Response.serverError().build();

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/Utils.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/Utils.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,12 +13,11 @@
  *******************************************************************************/
 package org.eclipse.winery.yaml.common;
 
-import org.apache.commons.codec.digest.DigestUtils;
-import org.eclipse.winery.repository.backend.filebased.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -26,6 +25,12 @@ import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
+
+import org.eclipse.winery.repository.backend.filebased.FileUtils;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Utils {
     private static final Logger logger = LoggerFactory.getLogger(Utils.class);

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/DefinitionsVisitor.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/DefinitionsVisitor.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,13 +13,17 @@
  *******************************************************************************/
 package org.eclipse.winery.yaml.common.validator;
 
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.eclipse.winery.model.tosca.yaml.TNodeTemplate;
 import org.eclipse.winery.model.tosca.yaml.TRepositoryDefinition;
 import org.eclipse.winery.yaml.common.validator.support.Parameter;
 import org.eclipse.winery.yaml.common.validator.support.Result;
-
-import java.nio.file.Path;
-import java.util.*;
 
 public class DefinitionsVisitor extends ImportVisitor {
     private Map<String, List<String>> nodeTemplates;

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/FieldValidator.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/FieldValidator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,14 +13,22 @@
  *******************************************************************************/
 package org.eclipse.winery.yaml.common.validator;
 
-import org.eclipse.winery.model.tosca.yaml.TArtifactDefinition;
-import org.eclipse.winery.yaml.common.exception.InvalidToscaSyntax;
-import org.eclipse.winery.yaml.common.reader.yaml.Builder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import java.util.*;
-import java.util.stream.Collectors;
+
+import org.eclipse.winery.model.tosca.yaml.TArtifactDefinition;
+import org.eclipse.winery.yaml.common.exception.InvalidToscaSyntax;
+import org.eclipse.winery.yaml.common.reader.yaml.Builder;
 
 public class FieldValidator {
     private Map<Class, Set<String>> declaredFields;

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/TypeValidator.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/TypeValidator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,30 @@
  *******************************************************************************/
 package org.eclipse.winery.yaml.common.validator;
 
-import org.eclipse.winery.model.tosca.yaml.*;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.model.tosca.yaml.TArtifactType;
+import org.eclipse.winery.model.tosca.yaml.TAttributeDefinition;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityType;
+import org.eclipse.winery.model.tosca.yaml.TDataType;
+import org.eclipse.winery.model.tosca.yaml.TEntityType;
+import org.eclipse.winery.model.tosca.yaml.TEntrySchema;
+import org.eclipse.winery.model.tosca.yaml.TGroupDefinition;
+import org.eclipse.winery.model.tosca.yaml.TGroupType;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceType;
+import org.eclipse.winery.model.tosca.yaml.TNodeTemplate;
+import org.eclipse.winery.model.tosca.yaml.TNodeType;
+import org.eclipse.winery.model.tosca.yaml.TPolicyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPolicyType;
+import org.eclipse.winery.model.tosca.yaml.TPropertyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipType;
+import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
 import org.eclipse.winery.yaml.common.Defaults;
 import org.eclipse.winery.yaml.common.Namespaces;
 import org.eclipse.winery.yaml.common.exception.InvalidDefinition;
@@ -23,12 +46,6 @@ import org.eclipse.winery.yaml.common.exception.UndefinedType;
 import org.eclipse.winery.yaml.common.validator.support.ExceptionVisitor;
 import org.eclipse.winery.yaml.common.validator.support.Parameter;
 import org.eclipse.winery.yaml.common.validator.support.Result;
-
-import javax.xml.namespace.QName;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 public class TypeValidator extends ExceptionVisitor<Result, Parameter> {
     private TypeVisitor typeVisitor;

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/TypeVisitor.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/TypeVisitor.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,14 +13,26 @@
  *******************************************************************************/
 package org.eclipse.winery.yaml.common.validator;
 
-import org.eclipse.winery.model.tosca.yaml.*;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.winery.model.tosca.yaml.TArtifactType;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityType;
+import org.eclipse.winery.model.tosca.yaml.TDataType;
+import org.eclipse.winery.model.tosca.yaml.TGroupType;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceType;
+import org.eclipse.winery.model.tosca.yaml.TNodeType;
+import org.eclipse.winery.model.tosca.yaml.TPolicyType;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipType;
 import org.eclipse.winery.model.tosca.yaml.support.Metadata;
 import org.eclipse.winery.yaml.common.Namespaces;
 import org.eclipse.winery.yaml.common.validator.support.Parameter;
 import org.eclipse.winery.yaml.common.validator.support.Result;
-
-import java.nio.file.Path;
-import java.util.*;
 
 public class TypeVisitor extends ImportVisitor {
     private Map<String, List<String>> artifactTypes;

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/Validator.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/validator/Validator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,18 +13,27 @@
  *******************************************************************************/
 package org.eclipse.winery.yaml.common.validator;
 
-import org.eclipse.winery.model.tosca.yaml.*;
-import org.eclipse.winery.model.tosca.yaml.support.Metadata;
-import org.eclipse.winery.model.tosca.yaml.tosca.datatypes.Credential;
-import org.eclipse.winery.yaml.common.Defaults;
-import org.eclipse.winery.yaml.common.exception.*;
-import org.eclipse.winery.yaml.common.validator.support.ExceptionVisitor;
-import org.eclipse.winery.yaml.common.validator.support.Parameter;
-import org.eclipse.winery.yaml.common.validator.support.Result;
-
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
+
+import org.eclipse.winery.model.tosca.yaml.TImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceType;
+import org.eclipse.winery.model.tosca.yaml.TOperationDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRepositoryDefinition;
+import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
+import org.eclipse.winery.model.tosca.yaml.support.Metadata;
+import org.eclipse.winery.model.tosca.yaml.tosca.datatypes.Credential;
+import org.eclipse.winery.yaml.common.Defaults;
+import org.eclipse.winery.yaml.common.exception.InvalidToscaSyntax;
+import org.eclipse.winery.yaml.common.exception.InvalidToscaVersion;
+import org.eclipse.winery.yaml.common.exception.MultiException;
+import org.eclipse.winery.yaml.common.exception.UndefinedFile;
+import org.eclipse.winery.yaml.common.exception.UndefinedRequiredKeyname;
+import org.eclipse.winery.yaml.common.exception.UndefinedToscaVersion;
+import org.eclipse.winery.yaml.common.validator.support.ExceptionVisitor;
+import org.eclipse.winery.yaml.common.validator.support.Parameter;
+import org.eclipse.winery.yaml.common.validator.support.Result;
 
 public class Validator extends ExceptionVisitor<Result, Parameter> {
     private final Path path;

--- a/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/writer/yaml/Writer.java
+++ b/org.eclipse.winery.yaml.common/src/main/java/org/eclipse/winery/yaml/common/writer/yaml/Writer.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,17 +13,6 @@
  *******************************************************************************/
 package org.eclipse.winery.yaml.common.writer.yaml;
 
-import org.eclipse.winery.model.tosca.yaml.*;
-import org.eclipse.winery.model.tosca.yaml.support.*;
-import org.eclipse.winery.model.tosca.yaml.tosca.datatypes.Credential;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
-import org.eclipse.winery.model.tosca.yaml.visitor.AbstractVisitor;
-import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
-import org.eclipse.winery.yaml.common.Namespaces;
-import org.eclipse.winery.yaml.common.writer.yaml.support.Printer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,6 +22,62 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import org.eclipse.winery.model.tosca.yaml.TArtifactDefinition;
+import org.eclipse.winery.model.tosca.yaml.TArtifactType;
+import org.eclipse.winery.model.tosca.yaml.TAttributeAssignment;
+import org.eclipse.winery.model.tosca.yaml.TAttributeDefinition;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityAssignment;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityDefinition;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityType;
+import org.eclipse.winery.model.tosca.yaml.TConstraintClause;
+import org.eclipse.winery.model.tosca.yaml.TDataType;
+import org.eclipse.winery.model.tosca.yaml.TEntityType;
+import org.eclipse.winery.model.tosca.yaml.TEntrySchema;
+import org.eclipse.winery.model.tosca.yaml.TGroupDefinition;
+import org.eclipse.winery.model.tosca.yaml.TGroupType;
+import org.eclipse.winery.model.tosca.yaml.TImplementation;
+import org.eclipse.winery.model.tosca.yaml.TImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceAssignment;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceType;
+import org.eclipse.winery.model.tosca.yaml.TNodeFilterDefinition;
+import org.eclipse.winery.model.tosca.yaml.TNodeTemplate;
+import org.eclipse.winery.model.tosca.yaml.TNodeType;
+import org.eclipse.winery.model.tosca.yaml.TOperationDefinition;
+import org.eclipse.winery.model.tosca.yaml.TParameterDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPolicyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPolicyType;
+import org.eclipse.winery.model.tosca.yaml.TPropertyAssignment;
+import org.eclipse.winery.model.tosca.yaml.TPropertyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPropertyFilterDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipAssignment;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.yaml.TRelationshipType;
+import org.eclipse.winery.model.tosca.yaml.TRepositoryDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRequirementAssignment;
+import org.eclipse.winery.model.tosca.yaml.TRequirementDefinition;
+import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
+import org.eclipse.winery.model.tosca.yaml.TSubstitutionMappings;
+import org.eclipse.winery.model.tosca.yaml.TTopologyTemplateDefinition;
+import org.eclipse.winery.model.tosca.yaml.TVersion;
+import org.eclipse.winery.model.tosca.yaml.support.Metadata;
+import org.eclipse.winery.model.tosca.yaml.support.TListString;
+import org.eclipse.winery.model.tosca.yaml.support.TMapImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.support.TMapObject;
+import org.eclipse.winery.model.tosca.yaml.support.TMapPropertyFilterDefinition;
+import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementAssignment;
+import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementDefinition;
+import org.eclipse.winery.model.tosca.yaml.tosca.datatypes.Credential;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
+import org.eclipse.winery.model.tosca.yaml.visitor.AbstractVisitor;
+import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
+import org.eclipse.winery.yaml.common.Namespaces;
+import org.eclipse.winery.yaml.common.writer.yaml.support.Printer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Writer extends AbstractVisitor<Printer, Writer.Parameter> {
 

--- a/org.eclipse.winery.yaml.converter/src/main/java/org/eclipse/winery/yaml/converter/Converter.java
+++ b/org.eclipse.winery.yaml.converter/src/main/java/org/eclipse/winery/yaml/converter/Converter.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,6 +12,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package org.eclipse.winery.yaml.converter;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
 import org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFile;
@@ -26,18 +40,9 @@ import org.eclipse.winery.yaml.common.exception.MultiException;
 import org.eclipse.winery.yaml.common.reader.yaml.Reader;
 import org.eclipse.winery.yaml.converter.xml.X2YConverter;
 import org.eclipse.winery.yaml.converter.yaml.Y2XConverter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
 public class Converter {
     private static final Logger LOGGER = LoggerFactory.getLogger(Converter.class);

--- a/org.eclipse.winery.yaml.converter/src/main/java/org/eclipse/winery/yaml/converter/xml/X2YConverter.java
+++ b/org.eclipse.winery.yaml.converter/src/main/java/org/eclipse/winery/yaml/converter/xml/X2YConverter.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,25 +13,83 @@
  *******************************************************************************/
 package org.eclipse.winery.yaml.converter.xml;
 
-import org.eclipse.collections.impl.bimap.mutable.HashBiMap;
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.winery.common.ids.definitions.*;
-import org.eclipse.winery.model.tosca.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
+import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
+import org.eclipse.winery.common.ids.definitions.CapabilityTypeId;
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.common.ids.definitions.NodeTypeId;
+import org.eclipse.winery.common.ids.definitions.NodeTypeImplementationId;
+import org.eclipse.winery.common.ids.definitions.PolicyTemplateId;
+import org.eclipse.winery.common.ids.definitions.PolicyTypeId;
+import org.eclipse.winery.common.ids.definitions.RelationshipTypeId;
+import org.eclipse.winery.common.ids.definitions.RelationshipTypeImplementationId;
+import org.eclipse.winery.common.ids.definitions.RequirementTypeId;
+import org.eclipse.winery.model.tosca.Definitions;
+import org.eclipse.winery.model.tosca.TArtifactTemplate;
+import org.eclipse.winery.model.tosca.TBoolean;
+import org.eclipse.winery.model.tosca.TBoundaryDefinitions;
+import org.eclipse.winery.model.tosca.TCapability;
+import org.eclipse.winery.model.tosca.TDeploymentArtifacts;
+import org.eclipse.winery.model.tosca.TDocumentation;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
 import org.eclipse.winery.model.tosca.TEntityType;
+import org.eclipse.winery.model.tosca.TImplementationArtifact;
+import org.eclipse.winery.model.tosca.TImplementationArtifacts;
+import org.eclipse.winery.model.tosca.TInterface;
+import org.eclipse.winery.model.tosca.TNodeTypeImplementation;
+import org.eclipse.winery.model.tosca.TOperation;
+import org.eclipse.winery.model.tosca.TParameter;
+import org.eclipse.winery.model.tosca.TPolicy;
+import org.eclipse.winery.model.tosca.TPolicyTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTypeImplementation;
+import org.eclipse.winery.model.tosca.TRequirement;
+import org.eclipse.winery.model.tosca.TRequirementType;
+import org.eclipse.winery.model.tosca.TTag;
+import org.eclipse.winery.model.tosca.TTags;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.model.tosca.kvproperties.PropertyDefinitionKV;
 import org.eclipse.winery.model.tosca.kvproperties.WinerysPropertiesDefinition;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.model.tosca.yaml.*;
+import org.eclipse.winery.model.tosca.yaml.TArtifactDefinition;
 import org.eclipse.winery.model.tosca.yaml.TArtifactType;
+import org.eclipse.winery.model.tosca.yaml.TCapabilityAssignment;
 import org.eclipse.winery.model.tosca.yaml.TCapabilityDefinition;
 import org.eclipse.winery.model.tosca.yaml.TCapabilityType;
+import org.eclipse.winery.model.tosca.yaml.TImplementation;
+import org.eclipse.winery.model.tosca.yaml.TImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceDefinition;
 import org.eclipse.winery.model.tosca.yaml.TNodeTemplate;
 import org.eclipse.winery.model.tosca.yaml.TNodeType;
+import org.eclipse.winery.model.tosca.yaml.TOperationDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPolicyDefinition;
 import org.eclipse.winery.model.tosca.yaml.TPolicyType;
+import org.eclipse.winery.model.tosca.yaml.TPropertyAssignment;
+import org.eclipse.winery.model.tosca.yaml.TPropertyAssignmentOrDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPropertyDefinition;
 import org.eclipse.winery.model.tosca.yaml.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.yaml.TRelationshipType;
+import org.eclipse.winery.model.tosca.yaml.TRequirementAssignment;
 import org.eclipse.winery.model.tosca.yaml.TRequirementDefinition;
 import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
+import org.eclipse.winery.model.tosca.yaml.TSubstitutionMappings;
+import org.eclipse.winery.model.tosca.yaml.TTopologyTemplateDefinition;
 import org.eclipse.winery.model.tosca.yaml.support.Defaults;
 import org.eclipse.winery.model.tosca.yaml.support.Metadata;
 import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementAssignment;
@@ -43,17 +101,11 @@ import org.eclipse.winery.yaml.common.exception.MultiException;
 import org.eclipse.winery.yaml.common.writer.yaml.Writer;
 import org.eclipse.winery.yaml.converter.xml.support.TypeConverter;
 import org.eclipse.winery.yaml.converter.xml.support.ValueConverter;
+
+import org.eclipse.collections.impl.bimap.mutable.HashBiMap;
+import org.eclipse.jdt.annotation.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.namespace.QName;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class X2YConverter {
     public final static Logger LOGGER = LoggerFactory.getLogger(X2YConverter.class);

--- a/org.eclipse.winery.yaml.converter/src/main/java/org/eclipse/winery/yaml/converter/yaml/Y2XConverter.java
+++ b/org.eclipse.winery.yaml.converter/src/main/java/org/eclipse/winery/yaml/converter/yaml/Y2XConverter.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,22 +14,65 @@
 
 package org.eclipse.winery.yaml.converter.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.Util;
-import org.eclipse.winery.model.tosca.*;
+import org.eclipse.winery.model.tosca.Definitions;
+import org.eclipse.winery.model.tosca.TAppliesTo;
+import org.eclipse.winery.model.tosca.TArtifactReference;
+import org.eclipse.winery.model.tosca.TArtifactTemplate;
 import org.eclipse.winery.model.tosca.TArtifactType;
+import org.eclipse.winery.model.tosca.TBoundaryDefinitions;
 import org.eclipse.winery.model.tosca.TCapabilityDefinition;
 import org.eclipse.winery.model.tosca.TCapabilityType;
+import org.eclipse.winery.model.tosca.TDeploymentArtifact;
+import org.eclipse.winery.model.tosca.TDeploymentArtifacts;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
 import org.eclipse.winery.model.tosca.TEntityType;
+import org.eclipse.winery.model.tosca.TImplementationArtifacts;
+import org.eclipse.winery.model.tosca.TImport;
+import org.eclipse.winery.model.tosca.TInterface;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TNodeTypeImplementation;
+import org.eclipse.winery.model.tosca.TOperation;
+import org.eclipse.winery.model.tosca.TParameter;
+import org.eclipse.winery.model.tosca.TPolicy;
+import org.eclipse.winery.model.tosca.TPolicyTemplate;
 import org.eclipse.winery.model.tosca.TPolicyType;
 import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.TRequirement;
 import org.eclipse.winery.model.tosca.TRequirementDefinition;
+import org.eclipse.winery.model.tosca.TRequirementType;
 import org.eclipse.winery.model.tosca.TServiceTemplate;
-import org.eclipse.winery.model.tosca.yaml.*;
+import org.eclipse.winery.model.tosca.TTag;
+import org.eclipse.winery.model.tosca.TTags;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.model.tosca.yaml.TArtifactDefinition;
+import org.eclipse.winery.model.tosca.yaml.TAttributeDefinition;
+import org.eclipse.winery.model.tosca.yaml.TImplementation;
+import org.eclipse.winery.model.tosca.yaml.TImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceDefinition;
+import org.eclipse.winery.model.tosca.yaml.TInterfaceType;
+import org.eclipse.winery.model.tosca.yaml.TOperationDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPolicyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPropertyAssignment;
+import org.eclipse.winery.model.tosca.yaml.TPropertyAssignmentOrDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPropertyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TRequirementAssignment;
+import org.eclipse.winery.model.tosca.yaml.TTopologyTemplateDefinition;
 import org.eclipse.winery.model.tosca.yaml.support.Metadata;
 import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementAssignment;
 import org.eclipse.winery.repository.backend.IRepository;
@@ -44,15 +87,11 @@ import org.eclipse.winery.yaml.converter.yaml.support.TypeConverter;
 import org.eclipse.winery.yaml.converter.yaml.support.extension.TImplementationArtifactDefinition;
 import org.eclipse.winery.yaml.converter.yaml.visitors.ReferenceVisitor;
 import org.eclipse.winery.yaml.converter.yaml.visitors.SchemaVisitor;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.namespace.QName;
-import java.io.File;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class Y2XConverter {
     public final static Logger LOGGER = LoggerFactory.getLogger(Y2XConverter.class);

--- a/org.eclipse.winery.yaml.converter/src/main/java/org/eclipse/winery/yaml/converter/yaml/visitors/SchemaVisitor.java
+++ b/org.eclipse.winery.yaml.converter/src/main/java/org/eclipse/winery/yaml/converter/yaml/visitors/SchemaVisitor.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,9 +13,23 @@
  *******************************************************************************/
 package org.eclipse.winery.yaml.converter.yaml.visitors;
 
-import org.eclipse.jdt.annotation.NonNull;
+import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.Util;
-import org.eclipse.winery.model.tosca.yaml.*;
+import org.eclipse.winery.model.tosca.yaml.TDataType;
+import org.eclipse.winery.model.tosca.yaml.TEntityType;
+import org.eclipse.winery.model.tosca.yaml.TImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.TPropertyDefinition;
+import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
 import org.eclipse.winery.model.tosca.yaml.support.TMapImportDefinition;
 import org.eclipse.winery.yaml.common.Namespaces;
 import org.eclipse.winery.yaml.common.exception.MultiException;
@@ -25,11 +39,9 @@ import org.eclipse.winery.yaml.common.writer.WriterUtils;
 import org.eclipse.winery.yaml.converter.yaml.support.SchemaBuilder;
 import org.eclipse.winery.yaml.converter.yaml.visitors.support.Parameter;
 import org.eclipse.winery.yaml.converter.yaml.visitors.support.Result;
-import org.w3c.dom.Document;
 
-import javax.xml.namespace.QName;
-import java.nio.file.Path;
-import java.util.*;
+import org.eclipse.jdt.annotation.NonNull;
+import org.w3c.dom.Document;
 
 public class SchemaVisitor extends ExceptionVisitor<Result, Parameter> {
     private Map<QName, Map<String, QName>> propertyDefinition;


### PR DESCRIPTION
Since Winery code style does not allow star imports, I used Regex `import .+\.\*;` to find  and fix files that currently use star imports.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
