### PR TITLE
Add possibility to build an executable winery.war

### DIFF
--- a/org.eclipse.winery.cli/pom.xml
+++ b/org.eclipse.winery.cli/pom.xml
@@ -31,7 +31,6 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>me.tongfei</groupId>
@@ -42,32 +41,21 @@
             <groupId>org.eclipse.winery</groupId>
             <artifactId>org.eclipse.winery.repository</artifactId>
             <version>2.0.0-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.winery</groupId>
-            <artifactId>org.eclipse.winery.repository.rest</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <classifier>classes</classifier>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.winery</groupId>
             <artifactId>org.eclipse.winery.tools.copybaragenerator</artifactId>
             <version>2.0.0-SNAPSHOT</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${ch.qos.logback.logback-classic.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <version>${org.slf4j}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
     <build>

--- a/org.eclipse.winery.cli/src/main/java/org/eclipse/winery/cli/WineryCli.java
+++ b/org.eclipse.winery.cli/src/main/java/org/eclipse/winery/cli/WineryCli.java
@@ -17,7 +17,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.EnumSet;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.xml.namespace.QName;
 
@@ -30,7 +29,6 @@ import org.eclipse.winery.repository.backend.consistencycheck.ConsistencyChecker
 import org.eclipse.winery.repository.backend.consistencycheck.ConsistencyErrorCollector;
 import org.eclipse.winery.repository.backend.consistencycheck.ElementErrorList;
 import org.eclipse.winery.repository.backend.filebased.FilebasedRepository;
-import org.eclipse.winery.repository.rest.server.WineryUsingHttpServer;
 import org.eclipse.winery.tools.copybaragenerator.CopybaraGenerator;
 
 import me.tongfei.progressbar.ProgressBar;
@@ -41,12 +39,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.eclipse.jetty.server.Server;
 
 public class WineryCli {
 
     public static void main(String[] args) throws Exception {
-        Option startServerOption = new Option("s", "server", false, "start a HTTP REST API server on port 8080. Has to be terminated by Ctrl+C.");
         Option repositoryPathOption = new Option("p", "path", true, "use given path as repository path");
         Option serviceTemplatesOnlyOption = new Option("so", "servicetemplatesonly", false, "checks service templates instead of the whole repository");
         Option checkDocumentationOption = new Option("cd", "checkdocumentation", false, "check existence of README.md and LICENSE. Default: No check");
@@ -56,7 +52,6 @@ public class WineryCli {
         Option helpOption = new Option("h", "help", false, "prints this help");
 
         Options options = new Options();
-        options.addOption(startServerOption);
         options.addOption(repositoryPathOption);
         options.addOption(serviceTemplatesOnlyOption);
         options.addOption(checkDocumentationOption);
@@ -89,7 +84,7 @@ public class WineryCli {
                 Path file = Paths.get(outfile);
                 copybaraGenerator.generateCopybaraConfigFile(file);
             }
-            return;
+            System.exit(0);
         }
 
         if (repository instanceof FilebasedRepository) {
@@ -98,23 +93,7 @@ public class WineryCli {
             System.out.println("Using non-filebased repository");
         }
 
-        if (line.hasOption("s")) {
-            startServer();
-        } else {
-            doConsistencyCheck(line, repository);
-        }
-    }
-
-    private static void startServer() {
-        Server server = WineryUsingHttpServer.createHttpServer();
-        try {
-            server.start();
-            System.out.println("Winery HTTP-based REST API available at http://localhost:8080/winery\n");
-            server.join();
-        } catch (Exception e) {
-            e.printStackTrace();
-            System.exit(1);
-        }
+        doConsistencyCheck(line, repository);
     }
 
     private static void doConsistencyCheck(CommandLine line, IRepository repository) {
@@ -164,14 +143,14 @@ public class WineryCli {
 
                 ElementErrorList elementErrorList = qName.getValue();
 
-                if (Objects.nonNull(elementErrorList.getErrors())) {
+                if (!elementErrorList.getErrors().isEmpty()) {
                     System.out.println("\tErrors:");
                     for (String error : elementErrorList.getErrors()) {
                         System.out.println("\t\t" + error);
                     }
                 }
 
-                if (Objects.nonNull(elementErrorList.getWarnings())) {
+                if (!elementErrorList.getWarnings().isEmpty()) {
                     System.out.println("\n\tWarnings:");
                     for (String error : elementErrorList.getWarnings()) {
                         System.out.println("\t\t" + error);

--- a/org.eclipse.winery.repository.rest/pom.xml
+++ b/org.eclipse.winery.repository.rest/pom.xml
@@ -406,44 +406,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <minimizeJar>false</minimizeJar>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <finalName>${project.build.finalName}-rest-server</finalName>
-                            <transformers>
-                                <transformer
-                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.eclipse.winery.repository.rest.server.WineryUsingHttpServer
-                                    </mainClass>
-                                </transformer>
-                                <!-- hint by https://stackoverflow.com/a/33226176/873282 -->
-                                <transformer
-                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                            </transformers>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
@@ -505,6 +467,19 @@
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <!-- Spring Boot Maven Plugin
+                     https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html
+                     $ mvn package spring-boot:repackage
+                  -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.0.3.RELEASE</version>
+                <configuration>
+                    <executable>true</executable>
+                    <mainClass>org.eclipse.winery.repository.rest.server.WineryUsingHttpServer</mainClass>
+                </configuration>
             </plugin>
         </plugins>
         <finalName>winery</finalName>

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/server/WineryResourceConfig.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/server/WineryResourceConfig.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.server;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.Path;
+
+import com.sun.jersey.api.core.DefaultResourceConfig;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("unused")
+public class WineryResourceConfig extends DefaultResourceConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WineryResourceConfig.class);
+
+    private static Set<Class<?>> classes = scan("org.eclipse.winery.repository.rest.resources");
+
+    public WineryResourceConfig() {
+        super(classes);
+    }
+
+    private static Set<Class<?>> scan(String... packages) {
+        Set<Class<?>> classes = new HashSet<>();
+        for (String p : packages) {
+            Reflections r = new Reflections(p);
+            r.getTypesAnnotatedWith(Path.class)
+                .parallelStream()
+                .forEach((clazz) -> {
+                    LOGGER.info("New resource registered: " + clazz.getName());
+                    classes.add(clazz);
+                });
+        }
+        return classes;
+    }
+}


### PR DESCRIPTION
We want to be able to run the Winery backend by simply executing the war file from a command prompt. The easiest way is to utilize the `spring-boot-maven-plugin`. Therefore, I modified the build process a bit. We actually don't want to build an executable and self-contained war archive by default since the repackage command bundles additional Spring libraries into the war file. These libraries are not yet approved by Eclipse to be used in Winery. So, if one needs an executable war, the following commands have to be triggered manually:

```
mvn clean install -pl org.eclipse.winery.repository.rest -am -DskipTests
cd org.eclipse.winery.repository.rest
mvn package -DskipTests spring-boot:repackage
```

Changelog:
- Removed "server" option of Winery CLI
- Replaced maven-shaded-plugin with spring-boot-maven-plugin
- Added slightly different configuration approach to start the resource endpoints properly (due to classpath scanning issues)

---

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders