### PR TITLE
Replace org.apache.compress with java.util.zip

### DIFF
--- a/org.eclipse.winery.repository/pom.xml
+++ b/org.eclipse.winery.repository/pom.xml
@@ -53,18 +53,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.6</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.tukaani</groupId>
-                    <artifactId>xz</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <!-- Version 1.3 is approved by Eclipse, Version 1.4 is not -->
             <groupId>org.tukaani</groupId>
             <artifactId>xz</artifactId>

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyChecker.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyChecker.java
@@ -66,7 +66,6 @@ import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.exceptions.RepositoryCorruptException;
 import org.eclipse.winery.repository.export.CsarExporter;
 
-import org.apache.commons.compress.archivers.ArchiveException;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
@@ -421,10 +420,6 @@ public class ConsistencyChecker {
         try (OutputStream outputStream = Files.newOutputStream(tempCsar, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
             try {
                 exporter.writeCsar(RepositoryFactory.getRepository(), id, outputStream, exportConfiguration);
-            } catch (ArchiveException e) {
-                LOGGER.debug("Error during checking ZIP", e);
-                printAndAddError(id, "Invalid zip file: " + e.getMessage());
-                return;
             } catch (JAXBException e) {
                 LOGGER.debug("Error during checking ZIP", e);
                 printAndAddError(id, "Some XML could not be parsed: " + e.getMessage() + " " + e.toString());

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/export/CsarExporterTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/export/CsarExporterTest.java
@@ -33,7 +33,7 @@ import org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes;
 import org.eclipse.winery.repository.TestWithGitBackedRepository;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.eclipse.virgo.util.parser.manifest.ManifestContents;
 import org.eclipse.virgo.util.parser.manifest.RecoveringManifestParser;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This change removes ArchiveException from the compress library from the public API of
CsarExporter. That way downstream consumers do not need to explicitly rely on that library.

This also allows us to drop the commons-compress dependency from org.eclipse.winery.repository.

N.B. that this is a blocker for introducing the winery-model in OpenTOSCA/container. Currently the export of CSARs is not implemented with the winery model, apache commons-compress is not acting nicely with OSGI, it was easier to remove it by replacing it with standard-library than dumping a few hours on fixing the OSGI configuration there. Please update ustutt after merging