### PR TITLE
check compliance based on all compliance rules stored under the same parent namespace

### DIFF
--- a/org.eclipse.winery.compliance/src/main/java/org/eclipse/winery/compliance/checking/ServiceTemplateComplianceRuleRuleChecker.java
+++ b/org.eclipse.winery.compliance/src/main/java/org/eclipse/winery/compliance/checking/ServiceTemplateComplianceRuleRuleChecker.java
@@ -86,7 +86,7 @@ public class ServiceTemplateComplianceRuleRuleChecker {
         List<ComplianceRuleId> complianceRules = Lists.newArrayList();
         Namespace namespace = new Namespace(serviceTemplate.getTargetNamespace(), false);
         Collection<Namespace> componentsNamespaces = RepositoryFactory.getRepository().getComponentsNamespaces(ComplianceRuleId.class);
-        List<Namespace> relevantNamespaces = componentsNamespaces.stream().filter(ns -> namespace.getDecoded().startsWith(ns.getDecoded())).collect(Collectors.toList());
+        List<Namespace> relevantNamespaces = componentsNamespaces.stream().filter(ns -> namespace.getDecoded().startsWith(ns.getDecoded().split("/compliancerules")[0])).collect(Collectors.toList());
 
         for (Namespace space : relevantNamespaces) {
             complianceRules.addAll((Collection<? extends ComplianceRuleId>) ((FilebasedRepository) RepositoryFactory.getRepository()).getAllIdsInNamespace(ComplianceRuleId.class, space));


### PR DESCRIPTION
check compliance of a topologytemplate based on all compliance rules stored under the same parent namespace

e.g., opentosca.org/servicetemplates against opentosca.org/compliancerules

