### PR TITLE
Fix heap issues while uploading files

### DIFF
--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/HashingUtil.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/HashingUtil.java
@@ -14,19 +14,19 @@
 package org.eclipse.winery.common;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class HashingUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HashingUtil.class);
-    
+
     public static String getHashForFile(String absolutePath, String algorithm) {
         try {
             File file = new File(absolutePath);
@@ -49,6 +49,18 @@ public class HashingUtil {
     }
 
     public static String getChecksum(File file, String algorithm) throws IOException, NoSuchAlgorithmException {
-        return getChecksum(IOUtils.toByteArray(file.toURI()), algorithm);
+        FileInputStream fileInputStream = new FileInputStream(file);
+        MessageDigest digest = MessageDigest.getInstance(algorithm);
+
+        // buffer with a size of 1MB
+        byte[] buffer = new byte[1048576];
+        int bufferLength = 0;
+
+        while ((bufferLength = fileInputStream.read(buffer)) != -1) {
+            digest.update(buffer, 0, bufferLength);
+        }
+
+        return new BigInteger(1, digest.digest())
+            .toString(16);
     }
 }

--- a/org.eclipse.winery.common/src/test/java/org/eclipse/winery/common/TestUtil.java
+++ b/org.eclipse.winery.common/src/test/java/org/eclipse/winery/common/TestUtil.java
@@ -13,45 +13,55 @@
  *******************************************************************************/
 package org.eclipse.winery.common;
 
-import org.junit.Assert;
+import java.io.File;
+
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestUtil {
 
     @Test
     public void testNamespaceToJavaPackageFullURL() {
-        Assert.assertEquals("org.example.www.tosca.nodetypes", Util.namespaceToJavaPackage("http://www.example.org/tosca/nodetypes"));
+        assertEquals("org.example.www.tosca.nodetypes", Util.namespaceToJavaPackage("http://www.example.org/tosca/nodetypes"));
     }
 
     @Test
     public void testNamespaceToJavaPackageURLWithHostOnly() {
-        Assert.assertEquals("org.example.www", Util.namespaceToJavaPackage("http://www.example.org/"));
+        assertEquals("org.example.www", Util.namespaceToJavaPackage("http://www.example.org/"));
     }
 
     @Test
     public void testNamespaceToJavaPackageURLWithHostOnlyAndNoFinalSlash() {
-        Assert.assertEquals("org.example.www", Util.namespaceToJavaPackage("http://www.example.org"));
+        assertEquals("org.example.www", Util.namespaceToJavaPackage("http://www.example.org"));
     }
 
     @Test
     public void testNamespaceToJavaPackageURLWithNoHost() {
-        Assert.assertEquals("plainNCname", Util.namespaceToJavaPackage("plainNCname"));
+        assertEquals("plainNCname", Util.namespaceToJavaPackage("plainNCname"));
     }
 
     @Test
     public void testNCNameFromURL() {
-        Assert.assertEquals("http___www.example.org", Util.makeNCName("http://www.example.org"));
+        assertEquals("http___www.example.org", Util.makeNCName("http://www.example.org"));
     }
 
     @Test
     public void testNCNameFromNCName() {
-        Assert.assertEquals("NCName", Util.makeNCName("NCName"));
+        assertEquals("NCName", Util.makeNCName("NCName"));
     }
 
     @Test
     public void testGetChecksum() throws Exception {
         String text = "my super content of any file which will be hashed using a SHA-256 hash.";
-        Assert.assertEquals("c0af55785d21197a9fe4c5e9435fa77bb763f386810909e97f646eba7c827df7",
+        assertEquals("c0af55785d21197a9fe4c5e9435fa77bb763f386810909e97f646eba7c827df7",
             HashingUtil.getChecksum(text.getBytes(), "SHA-256"));
+    }
+
+    @Test
+    public void testGetChecksumOfFile() throws Exception {
+        File file = new File(ClassLoader.getSystemClassLoader().getResource("org/eclipse/winery/common/invalid.xml").getFile());
+        assertEquals("4406bff97249955ef46ea3ae590f9813fd44dcd769b8204cbb702ee6767173b0",
+            HashingUtil.getChecksum(file, "SHA-256"));
     }
 }

--- a/org.eclipse.winery.repository.rest/src/main/webapp/WEB-INF/web.xml
+++ b/org.eclipse.winery.repository.rest/src/main/webapp/WEB-INF/web.xml
@@ -90,6 +90,12 @@
             <param-value>com.sun.jersey.api.container.filter.LoggingFilter</param-value>
         </init-param>
 
+        <!-- Disables the logging of the request body - could be enabled for debugging purposes -->
+        <init-param>
+            <param-name>com.sun.jersey.config.feature.logging.DisableEntitylogging</param-name>
+            <param-value>true</param-value>
+        </init-param>
+
         <!-- enables @Consumes(MediaType.APPLICATION_JSON) and @Produces(MediaType.APPLICATION_JSON), see https://jersey.java.net/nonav/documentation/1.7/json.html -->
         <init-param>
             <param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/ToscaExportUtil.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/ToscaExportUtil.java
@@ -414,12 +414,14 @@ public class ToscaExportUtil {
             absolutePath = repo.ref2AbsolutePath(ref).toString();
         }
 
-        String hash = HashingUtil.getHashForFile(absolutePath, TOSCAMetaFileAttributes.HASH);
-        CsarContentProperties fileProperties = new CsarContentProperties(pathInsideRepo, hash);
+        if (this.exportConfiguration.containsKey(CsarExportConfiguration.INCLUDE_HASHES.name())) {
+            String hash = HashingUtil.getHashForFile(absolutePath, TOSCAMetaFileAttributes.HASH);
+            this.referencesToPathInCSARMap.put(ref, new CsarContentProperties(pathInsideRepo, hash));
+        }
 
         // put mapping reference to path into global map
         // the path is the same as put in "synchronizeReferences"
-        this.referencesToPathInCSARMap.put(ref, fileProperties);
+        this.referencesToPathInCSARMap.put(ref, new CsarContentProperties(pathInsideRepo));
     }
 
     private void addVisualAppearanceToCSAR(IRepository repository, TopologyGraphElementEntityTypeId id) {


### PR DESCRIPTION
This fixes the issue that an upload of huge files (sometimes even >100MB) caused the Java VM to crash because of a heap overflow.

1. the log was logging the whole content of the request which caused the problem during upload.
2. when hashing the contents of a file, the heap tended to overflow also since the whole file was loaded into memory.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
