### PR TITLE
Unify commons-configuration usage, fixes OpenTOSCA/winery#118

### DIFF
--- a/org.eclipse.winery.repository.client/pom.xml
+++ b/org.eclipse.winery.repository.client/pom.xml
@@ -93,18 +93,6 @@
             <version>1.19.3</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-            <version>1.9</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>commons-logging</artifactId>
-                    <groupId>commons-logging</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <!--  use jackson-jaxrs-json-provider instead of jersey-json as suggested by http://stackoverflow.com/a/17006866/873282 -->
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/org.eclipse.winery.repository.configuration/pom.xml
+++ b/org.eclipse.winery.repository.configuration/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.2</version>
+            <version>${org.apache.commons.configuration}</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/org.eclipse.winery.repository.rest/pom.xml
+++ b/org.eclipse.winery.repository.rest/pom.xml
@@ -235,9 +235,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-            <version>1.9</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>${org.apache.commons.configuration}</version>
             <scope>compile</scope>
             <exclusions>
                 <!-- provided by jcl-over-slf4j to enable logging via logback -->
@@ -246,6 +246,13 @@
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- previously included transitively through commons-configuration -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/AbstractAdminResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/AbstractAdminResource.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.admin;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.eclipse.winery.common.ids.admin.AdminId;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.rest.RestUtils;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/reqandcapdefs/RequirementOrCapabilityDefinitionsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/reqandcapdefs/RequirementOrCapabilityDefinitionsResource.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.nodetypes.reqandcapdefs;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.winery.model.tosca.TCapabilityDefinition;
 import org.eclipse.winery.model.tosca.TRequirementDefinition;
 import org.eclipse.winery.repository.rest.RestUtils;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/yaml/YAMLParserResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/yaml/YAMLParserResource.java
@@ -17,7 +17,7 @@ import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataParam;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.eclipse.winery.yaml.converter.Converter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,7 @@ public class YAMLParserResource {
         } catch (Exception e) {
 
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(
-                StringEscapeUtils.escapeHtml(e.getMessage().trim())
+                StringEscapeUtils.escapeHtml4(e.getMessage().trim())
             ).type("text/plain").build();
         }
         return Response.noContent().build();

--- a/org.eclipse.winery.repository/pom.xml
+++ b/org.eclipse.winery.repository/pom.xml
@@ -119,9 +119,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-            <version>1.9</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>${org.apache.commons.configuration}</version>
             <scope>compile</scope>
             <exclusions>
                 <!-- provided by jcl-over-slf4j to enable logging via logback -->

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/AbstractRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/AbstractRepository.java
@@ -27,7 +27,7 @@ import org.eclipse.winery.model.tosca.Definitions;
 import org.eclipse.winery.repository.Constants;
 import org.eclipse.winery.repository.JAXBSupport;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.io.IOUtils;
 import org.apache.tika.mime.MediaType;
 import org.slf4j.Logger;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.eclipse.winery.common.RepositoryFileReference;
 import org.eclipse.winery.common.ids.GenericId;
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/NamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/NamespaceManager.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend;
 
-import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -76,8 +75,6 @@ public interface NamespaceManager {
      * Removes all namespace mappings
      */
     void clear();
-
-    void saveToOutputStream(OutputStream outputStream) throws Exception;
 
     boolean isPatternNamespace(String namespace);
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/AutoSaveListener.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/AutoSaveListener.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.commons.configuration.event.ConfigurationEvent;
-import org.apache.commons.configuration.event.ConfigurationListener;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.event.ConfigurationEvent;
+import org.apache.commons.configuration2.event.EventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +32,7 @@ import java.nio.file.StandardOpenOption;
  * {@link org.apache.commons.configuration.builder.AutoSaveListener}, because
  * ConfigurationListener is not aware of such things
  */
-class AutoSaveListener implements ConfigurationListener {
+class AutoSaveListener implements EventListener<ConfigurationEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AutoSaveListener.class);
 
@@ -52,7 +52,7 @@ class AutoSaveListener implements ConfigurationListener {
     }
 
     @Override
-    public void configurationChanged(ConfigurationEvent event) {
+    public void onEvent(ConfigurationEvent event) {
         if (!event.isBeforeUpdate()) {
             try {
                 if (!Files.exists(this.path.getParent())) {
@@ -64,7 +64,7 @@ class AutoSaveListener implements ConfigurationListener {
             }
             try (OutputStream out = Files.newOutputStream(this.path, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
                 OutputStreamWriter writer = new OutputStreamWriter(out);
-                this.configuration.save(writer);
+                this.configuration.write(writer);
             } catch (ConfigurationException | IOException ce) {
                 LOGGER.error("Could not update properties file", ce);
             }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManager.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
-import java.io.OutputStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,9 +24,7 @@ import java.util.Set;
 import org.eclipse.winery.model.tosca.constants.Namespaces;
 import org.eclipse.winery.repository.backend.AbstractNamespaceManager;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.Configuration;
 
 @Deprecated
 public class ConfigurationBasedNamespaceManager extends AbstractNamespaceManager {
@@ -153,14 +150,6 @@ public class ConfigurationBasedNamespaceManager extends AbstractNamespaceManager
     public NamespaceProperties getNamespaceProperties(String namespace) {
         String prefix = this.getPrefix(namespace);
         return new NamespaceProperties(namespace, prefix);
-    }
-
-    @Override
-    public void saveToOutputStream(OutputStream outputStream) throws ConfigurationException {
-        if (this.configuration instanceof PropertiesConfiguration) {
-            PropertiesConfiguration config = (PropertiesConfiguration) this.configuration;
-            config.save(outputStream);
-        }
     }
 
     @Override

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/JsonBasedNamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/JsonBasedNamespaceManager.java
@@ -14,10 +14,8 @@
 
 package org.eclipse.winery.repository.backend.filebased;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -166,14 +164,6 @@ public class JsonBasedNamespaceManager extends AbstractNamespaceManager {
     public void replaceAll(Map<String, NamespaceProperties> map) {
         this.namespaceProperties = map;
         this.save();
-    }
-
-    @Override
-    public void saveToOutputStream(OutputStream outputStream) throws IOException {
-        // This workaround is necessary to avoid an IOException since the OutputStream must not be closed by the ObjectMapper.
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        this.objectMapper.writeValue(stream, this.namespaceProperties);
-        outputStream.write(stream.toByteArray());
     }
 
     @Override

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
@@ -14,6 +14,7 @@
 package org.eclipse.winery.repository.importing;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -107,8 +108,8 @@ import org.eclipse.winery.repository.datatypes.ids.elements.SelfServiceMetaDataI
 import org.eclipse.winery.repository.datatypes.ids.elements.VisualAppearanceId;
 import org.eclipse.winery.repository.export.CsarExporter;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.tika.mime.MediaType;
 import org.slf4j.Logger;
@@ -303,11 +304,11 @@ public class CsarImporter {
             NamespaceManager localNamespaceManager;
 
             if (Files.exists(properties)) {
-                PropertiesConfiguration pconf;
-                try {
-                    pconf = new PropertiesConfiguration(properties.toFile());
+                PropertiesConfiguration pconf = new PropertiesConfiguration();
+                try (final BufferedReader propertyReader = Files.newBufferedReader(properties)) {
+                    pconf.read(propertyReader);
                     localNamespaceManager = new ConfigurationBasedNamespaceManager(pconf);
-                } catch (ConfigurationException e) {
+                } catch (IOException | ConfigurationException e) {
                     CsarImporter.LOGGER.debug(e.getMessage(), e);
                     return;
                 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
-import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration2.BaseConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,11 @@
         <!-- versions of all used libraries -->
         <ch.qos.logback.logback-classic.version>1.2.3</ch.qos.logback.logback-classic.version>
         <com.fasterxml.jackson.core.jackson-annotations>2.8.0</com.fasterxml.jackson.core.jackson-annotations>
+        <de.danielbechler.java-object-diff>0.95</de.danielbechler.java-object-diff>
         <io.github.adr.e-adr.version>1.0.0</io.github.adr.e-adr.version>
+        <org.apache.commons.configuration>2.3</org.apache.commons.configuration>
         <org.eclipse.jdt.annotation>2.1.0</org.eclipse.jdt.annotation>
         <org.mockito.moickito-core.version>2.19.0</org.mockito.moickito-core.version>
-        <de.danielbechler.java-object-diff>0.95</de.danielbechler.java-object-diff>
 
         <!-- grouped libraries -->
         <org.slf4j>1.7.25</org.slf4j>


### PR DESCRIPTION
This upgrades commons-configuration to the latest version (2.3) across winery.
In addition the unused method `NamespaceManager#saveToOutputStream` is dropped.
The commons-configuration dependency in `org.eclipse.winery.repository.client` was unused and is dropped.
`org.eclipse.winery.repository.rest` had some explicit dependency on commons-lang that were made explicit and also upgraded to the version in use across the codebase (3.7).

The first change simplifies the dependency setup and helps avoid subtle classpath issues for downstream consumers.
The second change is one of convenience in implementation as well as one of simplification. The Implementation burden has increased a bit with commons-configuration2, because it doesn't expose write methods operating on OutputStream anymore. Keeping the method would necessitate writing explicit writing and IO handling code. Since the method was unused across the codebase, it seems appropriate to drop it instead.