### PR TITLE
Fix Proprietary.txt License File Missing When Loading the License Page

### DIFF
--- a/org.eclipse.winery.repository.ui/.gitignore
+++ b/org.eclipse.winery.repository.ui/.gitignore
@@ -12,4 +12,5 @@ npm-debug.log
 /doc/
 /dist/
 /src/assets/built-codeEdit15_1
-/src/assets/licenses/
+/src/assets/licenses/*
+!/src/assets/licenses/Proprietary.txt

--- a/org.eclipse.winery.repository.ui/src/assets/licenses/Proprietary.txt
+++ b/org.eclipse.winery.repository.ui/src/assets/licenses/Proprietary.txt
@@ -1,0 +1,1 @@
+proprietary


### PR DESCRIPTION
Excluded the file Proprietary.txt from the .gitignore list of the repository.ui project as it is not fetched at build time (like the other contents of the assets/licenses folder).

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
