### PR TITLE
Fix Issue of Sticky Selected Items in Winery Tables

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/wineryTableModule/wineryTable.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryTableModule/wineryTable.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2017 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -28,7 +28,10 @@
                     [disabled]="rows.length === 0 || !currentSelected">
                 Remove
             </button>
-            <button class="rightbutton btn btn-primary btn-xs" (click)="onAddClick($event);">Add</button>
+            <button class="rightbutton btn btn-primary btn-xs"
+                    (click)="onAddClick($event);">
+                Add
+            </button>
             <button *ngIf="enableIOButton"
                     class="rightbutton btn btn-info btn-xs"
                     (click)="onIOClick($event)"
@@ -67,7 +70,7 @@
                     (numPages)="numPages = $event">
         </pagination>
         <div style="float: right; margin-top: 20px;">
-            <span>Show</span>
+            <span>Show </span>
             <div class="table-component-select-wrap">
                 <select #itemsPerPageSelect [value]="itemsPerPage"
                         (change)="onItemsPerPageChange($event, itemsPerPageSelect);" class="form-control">
@@ -77,7 +80,7 @@
                     <option value="100">100</option>
                 </select>
             </div>
-            <span>entries</span>
+            <span> entries</span>
         </div>
     </div>
 </div>

--- a/org.eclipse.winery.repository.ui/src/app/wineryTableModule/wineryTable.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryTableModule/wineryTable.component.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,7 +12,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 import { Component, DoCheck, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
-import {isNullOrUndefined} from 'util';
+import { isNullOrUndefined } from 'util';
 
 /**
  * This component provides an easy and fast way to use the ng2-table with further modifications
@@ -21,9 +21,9 @@ import {isNullOrUndefined} from 'util';
  * <p>
  *     In order to use this component, the {@link WineryTableModule} must be imported in the corresponding
  *     module. Afterwards, it can be included in the template by inserting the `<winery-table></winery-table>` tag.
- *     Inputs, which must be passed to the component in order for the table to work, are <code>columns</code> and <code>data</code>.
- *     The <code>columns</code> array must contain objects of type {@link WineryTableColumn}.
- *     The <code>data</code> can be an array of any kind of objects.
+ *     Inputs, which must be passed to the component in order for the table to work, are <code>columns</code> and
+ * <code>data</code>. The <code>columns</code> array must contain objects of type {@link WineryTableColumn}. The
+ * <code>data</code> can be an array of any kind of objects.
  * </p>
  *
  * <label>Inputs</label>
@@ -73,11 +73,14 @@ import {isNullOrUndefined} from 'util';
  * <ul>
  *     <li><code>cellSelected</code> emits the selected cell in the table. Contains the data of the whole selected row.
  *     </li>
- *     <li><code>removeBtnClicked</code> emits the selected cell in the table. Contains the data of the whole selected row.
+ *     <li><code>removeBtnClicked</code> emits the selected cell in the table. Contains the data of the whole selected
+ * row.
  *     </li>
- *     <li><code>addBtnClicked</code> emits the selected cell in the table. Contains the data of the whole selected row.
+ *     <li><code>addBtnClicked</code> emits the selected cell in the table. Contains the data of the whole selected
+ * row.
  *     </li>
- *     <li><code>editBtnClicked</code> emits the selected cell in the table. Contains the data of the whole selected row.
+ *     <li><code>editBtnClicked</code> emits the selected cell in the table. Contains the data of the whole selected
+ * row.
  *     </li>
  *     <li><code>ioBtnClicked</code> emits the selected cell in the table. Contains the data of the whole selected row.
  *     </li>
@@ -162,6 +165,9 @@ export class WineryTableComponent implements OnInit, DoCheck {
     // region #######Table events and functions######
 
     public onChangeTable(config: any, page: any = { page: this.page, itemsPerPage: this.itemsPerPage }): any {
+        this.currentSelected = null;
+        this.refreshRowHighlighting();
+
         if (config.filtering) {
             Object.assign(this.config.filtering, config.filtering);
         }
@@ -252,16 +258,15 @@ export class WineryTableComponent implements OnInit, DoCheck {
     onCellClick(data: WineryRowData) {
         this.cellSelected.emit(data);
         this.currentSelected = data.row;
-        this.highlightSelectedRow(data.row);
+        this.refreshRowHighlighting();
     }
 
-    private highlightSelectedRow(selectedRow: any): void {
-        const rowNumber: number = selectedRow ? this.rows.findIndex(row => row === selectedRow) : -1;
+    private refreshRowHighlighting(): void {
+        const rowNumber: number = this.currentSelected ? this.rows.findIndex(row => row === this.currentSelected) : -1;
         const tableRows = this.tableContainer.nativeElement.children[0].children[0].children[1].children;
-        if (rowNumber !== -1) {
-            for (let i = 0; i < tableRows.length; i++) {
-                tableRows[i].className = (i === rowNumber) ? 'active-row' : '';
-            }
+
+        for (let i = 0; i < tableRows.length; i++) {
+            tableRows[i].className = (i === rowNumber) ? 'active-row' : '';
         }
     }
 


### PR DESCRIPTION
The selected (highlighted) item of any WineryTable is now deselected as soon as the table is
updated, e.g., a filter term is entered, the sorting is changed, or the selected page is changed.

Signed-off-by: Ghareeb Falazi <ghareeb.falazi@hotmail.com>

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
