### PR TITLE
Generate standard lifecycle interface and IAs for Relationship Types

### DIFF
--- a/org.eclipse.winery.generators.ia/src/main/resources/template/project/pom.xml
+++ b/org.eclipse.winery.generators.ia/src/main/resources/template/project/pom.xml
@@ -16,6 +16,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>IA_PACKAGE</groupId>
     <artifactId>IA_CLASS_NAME</artifactId>
     <packaging>war</packaging>
@@ -25,7 +26,11 @@
     <repositories>
         <repository>
             <id>opentosca</id>
-            <url>https://opentosca.github.io/mvn-repo/</url>
+            <url>https://raw.github.com/OpenTOSCA/mvn-repo/ustutt/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
         </repository>
     </repositories>
 
@@ -33,10 +38,10 @@
         <run.HttpPort>9090</run.HttpPort>
         <winery.upload.url>IA_ARTIFACT_TEMPLATE_UPLOAD_URL</winery.upload.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cxf.version>2.7.6</cxf.version>
-        <highlevelrestapi.version>2.0.0-SNAPSHOT</highlevelrestapi.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <cxf.version>2.7.6</cxf.version>
+        <highlevelrestapi.version>2.0.0-SNAPSHOT</highlevelrestapi.version>
     </properties>
 
     <dependencies>
@@ -44,7 +49,6 @@
 
 
         <!-- END - LIBRARIES ADDED FOR IMPLEMENTATION ARTIFACT IMPLEMENTATION -->
-
         <dependency>
             <groupId>org.eclipse.winery</groupId>
             <artifactId>org.eclipse.winery.highlevelrestapi</artifactId>
@@ -82,6 +86,7 @@
             <version>${cxf.version}</version>
         </dependency>
     </dependencies>
+
     <build>
         <finalName>IA_CLASS_NAME</finalName>
         <plugins>
@@ -90,7 +95,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-eclipse-plugin</artifactId>
@@ -100,7 +104,6 @@
                     <downloadJavadocs>true</downloadJavadocs>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-java2ws-plugin</artifactId>
@@ -133,7 +136,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -142,7 +144,6 @@
                     <webXml>src/main/webapp/WEB-INF/web.xml</webXml>
                 </configuration>
             </plugin>
-
             <!-- Inspired by: http://giallone.blogspot.de/2013/02/post-file-to-web-page-as-part-of-maven.html -->
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
@@ -205,17 +206,15 @@
                                 def response = httpclient.execute(post)
                                 def status = response.getStatusLine()
                                 if (!(status ==~ /.*201.*/))
-                                    fail("IA upload to Winery FAILED, please upload manually. (HTTP status code: $status)")
+                                fail("IA upload to Winery FAILED, please upload manually. (HTTP status code: $status)")
                                 else
-                                    println "IA upload finished sucessfully (HTTP status code $status)"
+                                println "IA upload finished sucessfully (HTTP status code $status)"
                             </source>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
-
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -231,7 +230,6 @@
                         <useTestClasspath>false</useTestClasspath>
                     </configuration>
                 </plugin>
-
                 <!-- Disable default install phase, because we don't install into maven
                     repo but into Winery (during deploy phase). -->
                 <plugin>
@@ -244,7 +242,6 @@
                         </execution>
                     </executions>
                 </plugin>
-
                 <!-- Disable default deploy phase, because we don't deploy into remote
                     maven repo but into remote Winery. -->
                 <plugin>
@@ -259,6 +256,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
     </build>
+
 </project>

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/artifacts/GenericArtifactsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/artifacts/GenericArtifactsResource.java
@@ -13,40 +13,19 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.artifacts;
 
-import io.swagger.annotations.ApiOperation;
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.winery.common.Util;
-import org.eclipse.winery.common.ids.Namespace;
-import org.eclipse.winery.common.ids.XmlId;
-import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
-import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
-import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
-import org.eclipse.winery.common.ids.definitions.NodeTypeId;
-import org.eclipse.winery.generators.ia.Generator;
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.model.tosca.TEntityTemplate.Properties;
-import org.eclipse.winery.model.tosca.TImplementationArtifacts.ImplementationArtifact;
-import org.eclipse.winery.model.tosca.constants.QNames;
-import org.eclipse.winery.repository.backend.BackendUtils;
-import org.eclipse.winery.repository.backend.IRepository;
-import org.eclipse.winery.repository.backend.RepositoryFactory;
-import org.eclipse.winery.repository.backend.filebased.FileUtils;
-import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateSourceDirectoryId;
-import org.eclipse.winery.repository.datatypes.ids.elements.DirectoryId;
-import org.eclipse.winery.repository.rest.RestUtils;
-import org.eclipse.winery.repository.rest.resources._support.AbstractComponentInstanceResource;
-import org.eclipse.winery.repository.rest.resources._support.INodeTemplateResourceOrNodeTypeImplementationResourceOrRelationshipTypeImplementationResource;
-import org.eclipse.winery.repository.rest.resources._support.collections.withid.EntityWithIdCollectionResource;
-import org.eclipse.winery.repository.rest.resources.apiData.GenerateArtifactApiData;
-import org.eclipse.winery.repository.rest.resources.entitytemplates.artifacttemplates.ArtifactTemplateResource;
-import org.eclipse.winery.repository.rest.resources.servicetemplates.topologytemplates.NodeTemplateResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Text;
-import org.xml.sax.InputSource;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.SortedSet;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -60,14 +39,53 @@ import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
-import java.io.StringReader;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
+
+import org.eclipse.winery.common.Util;
+import org.eclipse.winery.common.ids.Namespace;
+import org.eclipse.winery.common.ids.XmlId;
+import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
+import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.common.ids.definitions.EntityTypeId;
+import org.eclipse.winery.common.ids.definitions.NodeTypeId;
+import org.eclipse.winery.common.ids.definitions.RelationshipTypeId;
+import org.eclipse.winery.generators.ia.Generator;
+import org.eclipse.winery.model.tosca.TArtifactTemplate;
+import org.eclipse.winery.model.tosca.TArtifactType;
+import org.eclipse.winery.model.tosca.TDeploymentArtifact;
+import org.eclipse.winery.model.tosca.TEntityTemplate.Properties;
+import org.eclipse.winery.model.tosca.TImplementationArtifacts.ImplementationArtifact;
+import org.eclipse.winery.model.tosca.TInterface;
+import org.eclipse.winery.model.tosca.TNodeType;
+import org.eclipse.winery.model.tosca.TRelationshipType;
+import org.eclipse.winery.model.tosca.constants.QNames;
+import org.eclipse.winery.repository.backend.BackendUtils;
+import org.eclipse.winery.repository.backend.IRepository;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.backend.filebased.FileUtils;
+import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateSourceDirectoryId;
+import org.eclipse.winery.repository.datatypes.ids.elements.DirectoryId;
+import org.eclipse.winery.repository.rest.RestUtils;
+import org.eclipse.winery.repository.rest.resources._support.AbstractComponentInstanceResource;
+import org.eclipse.winery.repository.rest.resources._support.INodeTemplateResourceOrNodeTypeImplementationResourceOrRelationshipTypeImplementationResource;
+import org.eclipse.winery.repository.rest.resources._support.collections.withid.EntityWithIdCollectionResource;
+import org.eclipse.winery.repository.rest.resources.apiData.GenerateArtifactApiData;
+import org.eclipse.winery.repository.rest.resources.entitytemplates.artifacttemplates.ArtifactTemplateResource;
+import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.nodetypeimplementations.NodeTypeImplementationResource;
+import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.nodetypeimplementations.NodeTypeImplementationsResource;
+import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.relationshiptypeimplementations.RelationshipTypeImplementationResource;
+import org.eclipse.winery.repository.rest.resources.entitytypeimplementations.relationshiptypeimplementations.RelationshipTypeImplementationsResource;
+import org.eclipse.winery.repository.rest.resources.servicetemplates.topologytemplates.NodeTemplateResource;
+
+import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jdt.annotation.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Text;
+import org.xml.sax.InputSource;
 
 /**
  * Resource handling both deployment and implementation artifacts
@@ -78,20 +96,18 @@ public abstract class GenericArtifactsResource<ArtifactResource extends GenericA
 
     protected final INodeTemplateResourceOrNodeTypeImplementationResourceOrRelationshipTypeImplementationResource resWithNamespace;
 
-    public GenericArtifactsResource(Class<ArtifactResource> entityResourceTClazz, Class<ArtifactT> entityTClazz, List<ArtifactT> list, INodeTemplateResourceOrNodeTypeImplementationResourceOrRelationshipTypeImplementationResource res) {
+    public GenericArtifactsResource(Class<ArtifactResource> entityResourceTClazz, Class<ArtifactT> entityTClazz,
+                                    List<ArtifactT> list, INodeTemplateResourceOrNodeTypeImplementationResourceOrRelationshipTypeImplementationResource res) {
         super(entityResourceTClazz, entityTClazz, list, GenericArtifactsResource.getAbstractComponentInstanceResource(res));
         this.resWithNamespace = res;
     }
-
-    // @formatter:off
 
     /**
      * @return TImplementationArtifact | TDeploymentArtifact (XML) | URL of generated IA zip (in case of autoGenerateIA)
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Creates a new implementation/deployment artifact. " +
-        "If an implementation artifact with the same name already exists, it is <em>overridden</em>.")
+    @ApiOperation(value = "Creates a new implementation/deployment artifact. If an implementation artifact with the same name already exists, it is <em>overridden</em>.")
     @SuppressWarnings("unchecked")
     public Response generateArtifact(GenerateArtifactApiData apiData, @Context UriInfo uriInfo) {
         // we assume that the parent ComponentInstance container exists
@@ -261,15 +277,11 @@ public abstract class GenericArtifactsResource<ArtifactResource extends GenericA
             resultingArtifact = (ArtifactT) a;
         }
 
-        Response persistResponse = RestUtils.persist(super.res);
-        // TODO: check for error and in case one found return that
+        // TODO: Check for error, and in case one found return it
+        RestUtils.persist(super.res);
 
         if (StringUtils.isEmpty(apiData.autoGenerateIA)) {
-            // no IA generation
-            // we include an XML for the data table
-
-//			String implOrDeplArtifactXML = Utils.getXMLAsString(resultingArtifact);
-
+            // No IA generation
             return Response.created(RestUtils.createURI(Util.URLencode(apiData.artifactName))).entity(resultingArtifact).build();
         } else {
             // after everything was created, we fire up the artifact generation
@@ -281,13 +293,13 @@ public abstract class GenericArtifactsResource<ArtifactResource extends GenericA
      * Generates a unique and valid name to be used for the generated maven project name, java project name, class name,
      * port type name.
      */
-    private String generateName(NodeTypeId nodeTypeId, String interfaceName) {
-        String name = Util.namespaceToJavaPackage(nodeTypeId.getNamespace().getDecoded());
+    private String generateName(EntityTypeId typeId, String interfaceName) {
+        String name = Util.namespaceToJavaPackage(typeId.getNamespace().getDecoded());
         name += Util.FORBIDDEN_CHARACTER_REPLACEMENT;
 
         // Winery already ensures that this is a valid NCName
         // getName() returns the id of the nodeType: A nodeType carries the "id" attribute only (and no name attribute)
-        name += nodeTypeId.getXmlId().getDecoded();
+        name += typeId.getXmlId().getDecoded();
 
         // Two separators to distinguish node type and interface part
         name += Util.FORBIDDEN_CHARACTER_REPLACEMENT;
@@ -300,37 +312,17 @@ public abstract class GenericArtifactsResource<ArtifactResource extends GenericA
     }
 
     /**
-     * Generates the implementation artifact using the implementation artifact generator. Also sets the proeprties
+     * Generates the implementation artifact using the implementation artifact generator. Also sets the properties
      * according to the requirements of OpenTOSCA.
-     * <p>
-     * DOES NOT WORK FOR RELATION SHIP TYPE IMPLEMENTATIONS
-     *
-     * @param artifactTemplateResource the resource associated with the artifactTemplateId. If null, the object is
-     *                                 created in this method
      */
-    private Response generateImplementationArtifact(String interfaceNameStr, String javapackage, UriInfo uriInfo, ArtifactTemplateId artifactTemplateId) {
-        TInterface iface;
+    private Response generateImplementationArtifact(String interfaceName, String javaPackage, UriInfo uriInfo, ArtifactTemplateId artifactTemplateId) {
 
         assert (this instanceof ImplementationArtifactsResource);
+        IRepository repository = RepositoryFactory.getRepository();
 
         QName type = RestUtils.getType(this.res);
-        NodeTypeId typeId;
-        // required for IA Generation
-        typeId = new NodeTypeId(type);
-        final IRepository repository = RepositoryFactory.getRepository();
-        TNodeType nodeType = repository.getElement(typeId);
-
-        List<TInterface> interfaces = nodeType.getInterfaces().getInterface();
-        Iterator<TInterface> it = interfaces.iterator();
-        do {
-            iface = it.next();
-            if (iface.getName().equals(interfaceNameStr)) {
-                break;
-            }
-        } while (it.hasNext());
-        // iface now contains the right interface
-
-        ArtifactTemplateSourceDirectoryId sourceDirectoryId = new ArtifactTemplateSourceDirectoryId(artifactTemplateId);
+        EntityTypeId typeId = getTypeId(type).orElseThrow(IllegalStateException::new);
+        TInterface i = findInterface(typeId, interfaceName).orElseThrow(IllegalStateException::new);
 
         Path workingDir;
         try {
@@ -340,7 +332,7 @@ public abstract class GenericArtifactsResource<ArtifactResource extends GenericA
             return Response.serverError().entity("Could not create temporary directory").build();
         }
 
-        URI artifactTemplateFilesUri = uriInfo.getBaseUri().resolve(RestUtils.getAbsoluteURL(artifactTemplateId)).resolve("files/");
+        URI artifactTemplateFilesUri = uriInfo.getBaseUri().resolve(RestUtils.getAbsoluteURL(artifactTemplateId)).resolve("files");
         URL artifactTemplateFilesUrl;
         try {
             artifactTemplateFilesUrl = artifactTemplateFilesUri.toURL();
@@ -349,8 +341,8 @@ public abstract class GenericArtifactsResource<ArtifactResource extends GenericA
             return Response.serverError().entity("Could not convert URI to URL").build();
         }
 
-        String name = this.generateName(typeId, interfaceNameStr);
-        Generator gen = new Generator(iface, javapackage, artifactTemplateFilesUrl, name, workingDir.toFile());
+        String name = this.generateName(typeId, interfaceName);
+        Generator gen = new Generator(i, javaPackage, artifactTemplateFilesUrl, name, workingDir.toFile());
         Path targetPath;
         try {
             targetPath = gen.generateProject();
@@ -366,13 +358,54 @@ public abstract class GenericArtifactsResource<ArtifactResource extends GenericA
             throw new WebApplicationException(e);
         }
 
-        // cleanup dir
+        // clean up
         FileUtils.forceDelete(workingDir);
 
         this.storeProperties(artifactTemplateId, typeId, name);
 
         URI url = uriInfo.getBaseUri().resolve(Util.getUrlPath(artifactTemplateId));
         return Response.created(url).build();
+    }
+
+    private Optional<EntityTypeId> getTypeId(QName type) {
+        if (this.res instanceof NodeTypeImplementationResource
+            || this.res instanceof NodeTypeImplementationsResource) {
+            return Optional.of(new NodeTypeId(type));
+        } else if (this.res instanceof RelationshipTypeImplementationResource
+            || this.res instanceof RelationshipTypeImplementationsResource) {
+            return Optional.of(new RelationshipTypeId(type));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<TInterface> findInterface(EntityTypeId id, String interfaceName) {
+        TInterface i = null;
+        List<TInterface> interfaces = new ArrayList<>();
+        IRepository repository = RepositoryFactory.getRepository();
+        if (this.res instanceof NodeTypeImplementationResource
+            || this.res instanceof NodeTypeImplementationsResource) {
+            TNodeType nodeType = repository.getElement((NodeTypeId) id);
+            if (nodeType.getInterfaces() != null) {
+                interfaces.addAll(nodeType.getInterfaces().getInterface());
+            }
+        } else if (this.res instanceof RelationshipTypeImplementationResource
+            || this.res instanceof RelationshipTypeImplementationsResource) {
+            TRelationshipType relationshipType = repository.getElement((RelationshipTypeId) id);
+            if (relationshipType.getSourceInterfaces() != null) {
+                interfaces.addAll(relationshipType.getSourceInterfaces().getInterface());
+            }
+            if (relationshipType.getTargetInterfaces() != null) {
+                interfaces.addAll(relationshipType.getTargetInterfaces().getInterface());
+            }
+        }
+        Iterator<TInterface> it = interfaces.iterator();
+        do {
+            i = it.next();
+            if (i.getName().equals(interfaceName)) {
+                return Optional.of(i);
+            }
+        } while (it.hasNext());
+        return Optional.empty();
     }
 
     private void storeProperties(ArtifactTemplateId artifactTemplateId, DefinitionsChildId typeId, String name) {

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/interfaces/InterfacesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/interfaces/InterfacesResource.java
@@ -59,8 +59,6 @@ public class InterfacesResource {
                     return Response.status(Response.Status.BAD_REQUEST).entity("No operation provided!").build();
                 }
             }
-        } else {
-            return Response.status(Response.Status.BAD_REQUEST).entity("No interface provided!").build();
         }
 
         if (this.res instanceof RelationshipTypeResource) {

--- a/org.eclipse.winery.repository.ui/src/app/wineryComponentExists/wineryComponentExists.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryComponentExists/wineryComponentExists.component.html
@@ -35,7 +35,7 @@
             </ng-template>
             <div class="form-group">
                 <label for="finalName" class="control-label">Final name</label>
-                <input id="finalName" class="form-control" type="text" disabled [value]="generateData.name + '_-w1-wip1'">
+                <input id="finalName" class="form-control" type="text" disabled [value]="generateData.name + '_w1-wip1'">
             </div>
             <!-- pattern parameter is required to enable form validation -->
             <winery-namespace-selector name="artifactNamespace"


### PR DESCRIPTION
Add possibility to generate IAs for Relationship Type Implementations
- Generify backend being able to generate IAs for both, Node Types and Relationship types
- Enhance UI to generate a standard lifecycle interface for Source and Target interfaces
- Fix bug to save interfaces if one deletes all interface definitions
- Fix Maven repository URL in IA project template
- Fix to proper rename Artifact Template by backend

---

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
