### PR TITLE
Ignore com.github.jnr artifacts for packing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -262,7 +263,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -276,7 +278,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -289,7 +292,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -303,7 +307,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -315,10 +320,11 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
                                                     <!-- Export-Package specification is incorrect, 
                                                          see https://github.com/SQiShER/java-object-diff/issues/205 -->
                                                     <exclude>de.danielbechler:java-object-diff:${de.danielbechler.java-object-diff}</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -331,7 +337,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -345,7 +352,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -359,7 +367,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -370,7 +379,8 @@
                                                 <id>org.eclipse.winery:org.eclipse.winery.repository:${project.version}</id>
                                                 <source>true</source>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery:::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <transitive>true</transitive>
                                                 <instructions>
@@ -385,7 +395,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>
@@ -402,7 +413,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -414,7 +426,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -426,7 +439,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -439,7 +453,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -453,7 +468,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -467,7 +483,8 @@
                                                 <source>true</source>
                                                 <transitive>true</transitive>
                                                 <excludes>
-                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <exclude>org.eclipse.winery*</exclude>
+                                                    <exclude>com.github.jnr:*:::</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>


### PR DESCRIPTION
This removes com.github.jnr:jffi from the dependency chain. More specifically
it removes the native pom from the dependency chain that resulted in the
p2-maven-plugin declaring a dependency to a plugin that doesn't exist.

This especially means that downstream artifacts for now must not enter the codepaths on provenance that use jnr artifacts. As it stands, this is the preferrable solution to rewriting the packed feature.xml generated by the p2-maven-plugin.

Unfortunately the plugin doesn't allow excluding based on an artifact qualifier.
Therefore all com.github.jnr artifacts have been removed. The plugin also does not support the usual maven-exclusion behaviour that is pruning dependency trees. Instead it requires explicit specification of all excluded dependencies.

The "correct" fix (one that would also allow us to exclude all transitive dependencies for provenance) is pending a rework of the p2-maven-plugin incorporating the removal of aether as resolution provider that has been performed in maven 3.5.0. So a "proper" fix would involve submitting an accepted patch to @reficio/p2-maven-plugin.

There is an issue at reficio/p2-maven-plugin#110 that requests exactly the feature we need. Interestingly one of the forks of the abandoned eclipse aether has a pull-request that adds the functionality we'd need. https://github.com/jvanzyl/aether-core/pull/1. It might be possible to adapt the plugin using the code from the PR above