### PR TITLE
Fix Write to OutputStream

### DIFF
--- a/org.eclipse.winery.repository.ui/package-lock.json
+++ b/org.eclipse.winery.repository.ui/package-lock.json
@@ -5871,9 +5871,8 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/ng-diff-match-patch/-/ng-diff-match-patch-3.0.1.tgz",
             "integrity": "sha512-BhZLbewh6tLPAcrcgLg20n55RPJ6jyBLwMHacJeYz31LmiNfVFKO7rQmdVDbTXLtA6vwKWFxAxXbPry94vY3JA==",
-            "dev": true,
             "requires": {
-                "tslib": "1.9.2"
+                "tslib": "^1.9.0"
             }
         },
         "ng2-file-upload": {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/JAXBSupport.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/JAXBSupport.java
@@ -104,7 +104,10 @@ public class JAXBSupport {
     }
 
     /**
-     * Creates a marshaller
+     * Creates a marshaller.
+     *
+     * IMPORTANT: always create a new instance and do not reuse the marhaller, otherwise the input-stream will throw a
+     * NullPointerException! see https://stackoverflow.com/questions/11114665/org-xml-sax-saxparseexception-premature-end-of-file-for-valid-xml
      *
      * @throws IllegalStateException if marshaller could not be instantiated
      */

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/entries/DefinitionsBasedCsarEntry.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/entries/DefinitionsBasedCsarEntry.java
@@ -37,19 +37,11 @@ public class DefinitionsBasedCsarEntry implements CsarEntry {
         this.definitions = definitions;
     }
 
-    private static Marshaller getMarshaller() {
-        if (marshaller == null) {
-            marshaller = JAXBSupport.createMarshaller(true);
-        }
-
-        return marshaller;
-    }
-
     @Override
     public InputStream getInputStream() throws IOException {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         try {
-            getMarshaller().marshal(definitions, byteArrayOutputStream);
+            JAXBSupport.createMarshaller(true).marshal(definitions, byteArrayOutputStream);
             return new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
         } catch (JAXBException e) {
             throw new IOException(e);
@@ -59,10 +51,9 @@ public class DefinitionsBasedCsarEntry implements CsarEntry {
     @Override
     public void writeToOutputStream(OutputStream outputStream) throws IOException {
         try {
-            getMarshaller().marshal(definitions, outputStream);
+            JAXBSupport.createMarshaller(true).marshal(definitions, outputStream);
         } catch (JAXBException e) {
             throw new IOException(e);
         }
     }
-
 }


### PR DESCRIPTION
Because of the reuse of the JAXB marshaller, the input-stream of the file caused a NullPointerException.