### PR TITLE
Fix ellipsis in components

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/PropertiesDefinitionResourceApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/PropertiesDefinitionResourceApiData.java
@@ -33,7 +33,7 @@ public class PropertiesDefinitionResourceApiData {
         this.propertiesDefinition = propertiesDefinition;
         this.winerysPropertiesDefinition = winerysPropertiesDefinition;
 
-        if ((winerysPropertiesDefinition != null) && (winerysPropertiesDefinition.getIsDerivedFromXSD() == null)) {
+        if ((winerysPropertiesDefinition != null) && (winerysPropertiesDefinition.getIsDerivedFromXSD() == null) && winerysPropertiesDefinition.getPropertyDefinitionKVList() != null) {
             this.selectedValue = PropertiesDefinitionEnum.Custom;
         } else if ((this.propertiesDefinition != null) && (this.propertiesDefinition.getElement() != null)) {
             this.selectedValue = PropertiesDefinitionEnum.Element;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/properties/PropertiesDefinitionResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/properties/PropertiesDefinitionResource.java
@@ -52,8 +52,7 @@ import org.slf4j.LoggerFactory;
  * <li>Winery's KV properties (in the subresource "winery")</li>
  * </ol>
  * <p>
- * This class does not have "KV" in its name, because it models
- * {@link TEntityType.PropertiesDefinition}
+ * This class does not have "KV" in its name, because it models {@link TEntityType.PropertiesDefinition}
  */
 public class PropertiesDefinitionResource {
 
@@ -65,7 +64,6 @@ public class PropertiesDefinitionResource {
     // we assume that this class is created at each request
     // therefore, we can have "wpd" final
     private final WinerysPropertiesDefinition wpd;
-
 
     public PropertiesDefinitionResource(EntityTypeResource res) {
         this.parentRes = res;

--- a/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entity.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entity.component.html
@@ -18,8 +18,13 @@
         <img *ngIf="imageUrl" src="{{ imageUrl }}" class="nodeTypeImageIconInList">
     </div>
     <div class="center" [style.width.px]="maxWidth">
-        <div class="{{ containerSizeClass + ' informationContainer '}}">
+        <div *ngIf="data.id" class="{{ containerSizeClass + ' informationContainer '}}">
             <div *ngIf="data.id" class="name">{{ data.name }}</div>
+            <div *ngIf="data.id" class="version">Version: {{ data?.version?.toReadableString() }}</div>
+            <div [ngClass]="{'name': !data.id, 'namespace': data.id}">{{ data.namespace }}</div>
+        </div>
+        <div *ngIf="!data.id" class="{{ containerSizeClass + ' informationContainer '}}">
+            <div class="name">{{ data.name }}</div>
             <div [ngClass]="{'name': !data.id, 'namespace': data.id}">{{ data.namespace }}</div>
         </div>
         <div *ngIf="!data.id" class="badge numberOfComponentInstances">{{ data.count }}</div>

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
@@ -31,6 +31,7 @@ import { KeyValueItem } from '../model/keyValueItem';
 import { ConfigurationService } from '../instance/admin/accountability/configuration/configuration.service';
 import { AccountabilityService } from '../instance/admin/accountability/accountability.service';
 import { FileProvenanceElement } from '../model/provenance';
+import { WineryVersion } from '../model/wineryVersion';
 
 const showAll = 'Show all Items';
 const showGrouped = 'Group by Namespace';
@@ -212,7 +213,14 @@ export class SectionComponent implements OnInit, OnDestroy {
 
         resources.forEach(item => {
             const container = new SectionData();
+            item.version = new WineryVersion(item.version.componentVersion,
+                item.version.wineryVersion, item.version.workInProgressVersion, item.version.currentVersion,
+                item.version.latestVersion, item.version.releasable, item.version.editable);
+            item.name = Utils.getNameWithoutVersion(item.name);
+
             container.createContainerCopy(item);
+
+
 
             if (this.componentData.length === 0) {
                 this.componentData.push(container);

--- a/org.eclipse.winery.repository.ui/src/app/section/sectionData.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/sectionData.ts
@@ -18,6 +18,7 @@ import { WineryVersion } from '../model/wineryVersion';
  * Type definition for data returned by the section service.
  */
 export class SectionData {
+
     id?: string;
     name?: string;
     namespace: string;
@@ -30,7 +31,9 @@ export class SectionData {
         this.id = Utils.getNameWithoutVersion(original.id);
         this.name = Utils.getNameWithoutVersion(original.name);
         this.namespace = original.namespace;
-        this.version = original.version;
+        this.version = new WineryVersion(original.version.componentVersion,
+            original.version.wineryVersion, original.version.workInProgressVersion, original.version.currentVersion,
+            original.version.latestVersion, original.version.releasable, original.version.editable);
         this.versionInstances = [original];
 
         return this;

--- a/org.eclipse.winery.repository.ui/src/css/wineryRepository.css
+++ b/org.eclipse.winery.repository.ui/src/css/wineryRepository.css
@@ -295,6 +295,7 @@ div.serviceTemplate div.bottom {
 div.mainContentContainer.relationshipType div.top {
     background: url('../assets/img/containers/rt/rt-FrameTopLarge.jpg');
 }
+
 div.mainContentContainer.relationshipType div.top.twolines {
     height: 208px;
 }
@@ -541,7 +542,7 @@ div.entityContainer > div.right {
 }
 
 div.entityContainer > div.center > div.informationContainer {
-    margin-top: 25px;
+    margin-top: 15px;
     height: 45px;
     color: #787878;
     font-family: arial, sans-serif;
@@ -559,7 +560,18 @@ div.entityContainer > div.center > div.informationContainer > div.name {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-    direction: rtl;
+    direction: ltr;
+    text-align: left;
+}
+
+div.entityContainer > div.center > div.informationContainer > div.name:hover {
+    color: #00c2ff;
+}
+
+div.entityContainer > div.center > div.informationContainer > div.version {
+    font-size: 14px;
+    height: 18px;
+    direction: ltr;
     text-align: left;
 }
 


### PR DESCRIPTION
`...rtOrchestra_Mosquitto2OneM2M_1-w1-wip1` is not much readable.
Therefore, it was changed to `SmartrtOrchestra_Mosquitt...` and show whole name on hover.

![skizze 1](https://user-images.githubusercontent.com/40024030/49993977-819d3980-ff88-11e8-983e-773e2a58605e.png)

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
