### PR TITLE
Advance javadoc plugin patch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>


### PR DESCRIPTION
This fixes the build not working on certain java versions, cf https://issues.apache.org/jira/browse/MJAVADOC-517

That error manifests as the following message:

>  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:jar (attach-javadocs) on project org.eclipse.winery.cli: Execution attach-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:jar failed.: NullPointerException