### PR TITLE
Add bouncy-castle and web3j to ignored packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,21 +244,6 @@
                                         <artifacts>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.accountability:${project.version}
-                                                </id>
-                                                <source>true</source>
-                                                <transitive>true</transitive>
-                                                <excludes>
-                                                    <exclude>org.eclipse.winery*</exclude>
-                                                    <exclude>com.github.jnr:*:::</exclude>
-                                                </excludes>
-                                                <instructions>
-                                                    <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.accountability.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
-                                                </instructions>
-                                            </artifact>
-                                            <artifact>
-                                                <id>
                                                     org.eclipse.winery:org.eclipse.winery.model.bpmn4tosca:${project.version}
                                                 </id>
                                                 <source>true</source>
@@ -266,6 +251,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -281,6 +268,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -296,6 +285,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -310,6 +301,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -325,6 +318,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -355,6 +350,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -370,6 +367,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -397,6 +396,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <transitive>true</transitive>
                                                 <instructions>
@@ -413,6 +414,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>
@@ -431,6 +434,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -444,6 +449,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -457,6 +464,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -471,6 +480,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -486,6 +497,8 @@
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
@@ -494,17 +507,19 @@
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.provenance:${project.version}
+                                                    org.eclipse.winery:org.eclipse.winery.accountability:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>true</transitive>
+                                                <transitive>false</transitive>
                                                 <excludes>
                                                     <exclude>org.eclipse.winery*</exclude>
                                                     <exclude>com.github.jnr:*:::</exclude>
+                                                    <exclude>org.web3j:*</exclude>
+                                                    <exclude>org.bouncycastle</exclude>
                                                 </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.provenance.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.accountability.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <!-- 


### PR DESCRIPTION
This fixes the generation of the winery-feature for OSGI exporting.