### PR TITLE
Add support to anntoate and respect patterns at Node Templates

### DIFF
--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ids/definitions/TopologyGraphElementEntityTypeId.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/ids/definitions/TopologyGraphElementEntityTypeId.java
@@ -34,5 +34,4 @@ public abstract class TopologyGraphElementEntityTypeId extends EntityTypeId {
     public TopologyGraphElementEntityTypeId(QName type) {
         super(type);
     }
-
 }

--- a/org.eclipse.winery.common/src/main/resources/TOSCA-v1.0.xsd
+++ b/org.eclipse.winery.common/src/main/resources/TOSCA-v1.0.xsd
@@ -13,8 +13,13 @@
    See https://github.com/eclipse/winery/issues/71 for a discussion.
  - `processContents="lax"` was added to Properties at Boundary definitions.
  - Make "Types" in "<Definitions>" valid as the only nested element in "<Definitions>"
- - Add "PatternRefinementModels"
- - Add "ComplianceRule"
+ - Add "PatternRefinementModels" as tPatternRefinementModel
+   - tRelationMapping
+   - tDirection
+   - tPrmPropertyMapping
+   - tPrmPropertyMappingType
+ - Add "ComplianceRules" as tComplianceRule
+ - Add tPolicies to Relationship Templates
 -->
 <xs:schema targetNamespace="http://docs.oasis-open.org/tosca/ns/2011/12" elementFormDefault="qualified"
            attributeFormDefault="unqualified" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12"
@@ -368,6 +373,13 @@
           <xs:attribute name="constraintType" type="xs:anyURI" use="required"/>
          </xs:complexType>
         </xs:element>
+       </xs:sequence>
+      </xs:complexType>
+     </xs:element>
+     <xs:element name="Policies" minOccurs="0">
+      <xs:complexType>
+       <xs:sequence>
+        <xs:element name="Policy" type="tPolicy" maxOccurs="unbounded"/>
        </xs:sequence>
       </xs:complexType>
      </xs:element>
@@ -808,6 +820,13 @@
        </xs:sequence>
       </xs:complexType>
      </xs:element>
+     <xs:element name="PropertyMappings">
+      <xs:complexType>
+       <xs:sequence>
+        <xs:element name="PropertyMapping" type="tPrmPropertyMapping" maxOccurs="unbounded"/>
+       </xs:sequence>
+      </xs:complexType>
+     </xs:element>
     </xs:sequence>
     <xs:attribute name="name" type="xs:string" use="optional"/>
     <xs:attribute name="targetNamespace" type="xs:anyURI"/>
@@ -822,10 +841,24 @@
   <xs:attribute name="direction" type="tDirection" use="required"/>
   <xs:attribute name="validSourceOrTarget" type="xs:QName"/>
  </xs:complexType>
+ <xs:complexType name="tPrmPropertyMapping">
+  <xs:attribute name="id" type="xs:ID" use="required"/>
+  <xs:attribute name="detectorNode" type="xs:string" use="required"/>
+  <xs:attribute name="refinementNode" type="xs:string" use="required"/>
+  <xs:attribute name="type" type="tPrmPropertyMappingType" use="required"/>
+  <xs:attribute name="detectorProperty" type="xs:string" use="optional"/>
+  <xs:attribute name="refinementProperty" type="xs:string" use="optional"/>
+ </xs:complexType>
  <xs:simpleType name="tDirection">
   <xs:restriction base="xs:string">
    <xs:enumeration value="ingoing"/>
    <xs:enumeration value="outgoing"/>
+  </xs:restriction>
+ </xs:simpleType>
+ <xs:simpleType name="tPrmPropertyMappingType">
+  <xs:restriction base="xs:string">
+   <xs:enumeration value="all"/>
+   <xs:enumeration value="selective"/>
   </xs:restriction>
  </xs:simpleType>
  <xs:simpleType name="tBoolean">

--- a/org.eclipse.winery.compliance/src/main/java/org/eclipse/winery/compliance/checking/ServiceTemplateComplianceRuleRuleChecker.java
+++ b/org.eclipse.winery.compliance/src/main/java/org/eclipse/winery/compliance/checking/ServiceTemplateComplianceRuleRuleChecker.java
@@ -66,7 +66,7 @@ public class ServiceTemplateComplianceRuleRuleChecker {
                         for (GraphMapping mapping : graphMappings) {
                             Map<ToscaNode, ToscaNode> resultMap = checker.getSubGraphMappingAsMap(mapping, checker.getIdentifierGraph());
                             checkingResult.append(System.lineSeparator());
-                            checkingResult.append(resultMap.values().stream().map(node -> node.getNodeTemplate().getIdFromIdOrNameField()).collect(Collectors.joining(";", "NodeTemplateIds: ", "")));
+                            checkingResult.append(resultMap.values().stream().map(node -> node.getTemplate().getIdFromIdOrNameField()).collect(Collectors.joining(";", "NodeTemplateIds: ", "")));
                         }
                     } else {
                         result.getSatisfied().add(ruleId.getQName());

--- a/org.eclipse.winery.compliance/src/main/java/org/eclipse/winery/compliance/checking/ToscaComplianceRuleMatcher.java
+++ b/org.eclipse.winery.compliance/src/main/java/org/eclipse/winery/compliance/checking/ToscaComplianceRuleMatcher.java
@@ -46,9 +46,9 @@ public class ToscaComplianceRuleMatcher implements IToscaMatcher {
     }
 
     public boolean isPoliciesCompatible(ToscaNode left, ToscaNode right) {
-        if (left.getNodeTemplate().getPolicies() != null) {
-            if (right.getNodeTemplate().getPolicies() != null) {
-                return mapToStringList(right.getNodeTemplate().getPolicies().getPolicy()).containsAll(mapToStringList(left.getNodeTemplate().getPolicies().getPolicy()));
+        if (left.getTemplate().getPolicies() != null) {
+            if (right.getTemplate().getPolicies() != null) {
+                return mapToStringList(right.getTemplate().getPolicies().getPolicy()).containsAll(mapToStringList(left.getTemplate().getPolicies().getPolicy()));
             } else {
                 return false;
             }
@@ -61,10 +61,10 @@ public class ToscaComplianceRuleMatcher implements IToscaMatcher {
     }
 
     public boolean isPropertiesCompatible(ToscaNode left, ToscaNode right) {
-        if (left.getNodeTemplate().getProperties() != null) {
-            if (right.getNodeTemplate().getProperties() != null) {
-                for (Entry<String, String> leftEntry : left.getNodeTemplate().getProperties().getKVProperties().entrySet()) {
-                    if (!isPropertyCompatible(leftEntry, right.getNodeTemplate().getProperties().getKVProperties())) {
+        if (left.getTemplate().getProperties() != null) {
+            if (right.getTemplate().getProperties() != null) {
+                for (Entry<String, String> leftEntry : left.getTemplate().getProperties().getKVProperties().entrySet()) {
+                    if (!isPropertyCompatible(leftEntry, right.getTemplate().getProperties().getKVProperties())) {
                         return false;
                     }
                 }
@@ -94,7 +94,7 @@ public class ToscaComplianceRuleMatcher implements IToscaMatcher {
     }
 
     public boolean isLeftSubtypeOfRight(ToscaEntity left, ToscaEntity right) {
-        return left.getTypes().stream().filter(lType -> equals(lType, right.getActualType())).findAny().isPresent();
+        return left.getTypes().stream().anyMatch(lType -> equals(lType, right.getActualType()));
     }
 
     public boolean isTEntityTypesCompatible(ToscaEntity left, ToscaEntity right) {

--- a/org.eclipse.winery.compliance/src/test/java/org/eclipse/winery/compliance/ToscaModelHelper.java
+++ b/org.eclipse.winery.compliance/src/test/java/org/eclipse/winery/compliance/ToscaModelHelper.java
@@ -91,7 +91,7 @@ public class ToscaModelHelper {
     public static ToscaNode createTOSCANodeOnlyProperties(ToscaModelPropertiesBuilder bldr) {
         ToscaNode node = new ToscaNode();
         node.setNodeTemplate(new TNodeTemplate());
-        node.getNodeTemplate().setProperties(bldr.build());
+        node.getTemplate().setProperties(bldr.build());
         return node;
     }
 

--- a/org.eclipse.winery.compliance/src/test/java/org/eclipse/winery/model/tosca/utils/ModelUtilitiesTest.java
+++ b/org.eclipse.winery.compliance/src/test/java/org/eclipse/winery/model/tosca/utils/ModelUtilitiesTest.java
@@ -14,7 +14,13 @@
 
 package org.eclipse.winery.model.tosca.utils;
 
+import java.util.HashMap;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.model.tosca.TEntityType;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TNodeType;
 import org.eclipse.winery.repository.TestWithGitBackedRepository;
 
 import org.junit.jupiter.api.Test;
@@ -40,4 +46,24 @@ public class ModelUtilitiesTest extends TestWithGitBackedRepository {
         assertTrue(ModelUtilities.getTargetLabel(nodeTemplate).isPresent());
         assertEquals("targetlabel", ModelUtilities.getTargetLabel(nodeTemplate).get());
     }
+
+    // region ********** isOfType **********
+
+    @Test
+    void isOfType() {
+        TEntityType.DerivedFrom derivedFrom = new TEntityType.DerivedFrom();
+        derivedFrom.setType(QName.valueOf("{https://ex.org/nt}parent"));
+
+        TNodeType nt1 = new TNodeType();
+        nt1.setDerivedFrom(derivedFrom);
+
+        HashMap<QName, TEntityType> map = new HashMap<>();
+        map.put(QName.valueOf("{http://ex.org/nt}child"), nt1);
+
+        assertTrue(
+            ModelUtilities.isOfType(QName.valueOf("{https://ex.org/nt}parent"), QName.valueOf("{http://ex.org/nt}child"), map)
+        );
+    }
+
+    // endregion
 }

--- a/org.eclipse.winery.model.substitution/src/main/java/org/eclipse/winery/model/substitution/SubstitutionUtils.java
+++ b/org.eclipse.winery.model.substitution/src/main/java/org/eclipse/winery/model/substitution/SubstitutionUtils.java
@@ -34,14 +34,16 @@ import org.eclipse.winery.repository.backend.RepositoryFactory;
 public class SubstitutionUtils {
 
     /**
-     * This method collects all templates of the given <code>templates</code> which are abstract and must be substituted.
-     * Additionally, all children of the template's type are included as a list of trees.
+     * This method collects all templates of the given <code>templates</code> which are abstract and must be
+     * substituted. Additionally, all children of the template's type are included as a list of trees.
      *
      * @param templates the list of TOSCA templates which have to examied whether they must be substituted
-     * @param types     the map of all types of the same kind (e.g. Node Templates and Node Types) identified by their corresponding <code>DefinitionsChildId</code>
+     * @param types     the map of all types of the same kind (e.g. Node Templates and Node Types) identified by their
+     *                  corresponding <code>DefinitionsChildId</code>
      * @param <R>       the class of the templates
      * @param <T>       the class of the types
-     * @return a map containing a mapping between substitutable templates and their available sub types which can be used during the substitution
+     * @return a map containing a mapping between substitutable templates and their available sub types which can be
+     * used during the substitution
      */
     public static <R extends HasType, T extends HasInheritance> Map<R, List<Subtypes<T>>> collectSubstitutableTemplates(List<R> templates, Map<QName, T> types) {
         Map<R, List<Subtypes<T>>> substitutableTypes = new HashMap<>();
@@ -58,7 +60,8 @@ public class SubstitutionUtils {
     }
 
     /**
-     * This method collects all elements of the given class <code>T</code> which are derived from the <b>abstract</b> <code>parent</code>.
+     * This method collects all elements of the given class <code>T</code> which are derived from the <b>abstract</b>
+     * <code>parent</code>.
      *
      * @param <T>    a TOSCA definitions type which has inheritance
      * @param types  all available types of the specified class <code>T</code>
@@ -90,7 +93,16 @@ public class SubstitutionUtils {
         return topologyNodes.stream()
             .anyMatch(nodeTemplate -> {
                 TNodeType tNodeType = nodeTypes.get(nodeTemplate.getType());
-                return namespaceManager.isPatternNamespace(tNodeType.getTargetNamespace());
+                boolean isPattern = namespaceManager.isPatternNamespace(tNodeType.getTargetNamespace());
+
+                boolean isAnnotatedByPattern = false;
+                if (Objects.nonNull(nodeTemplate.getPolicies())) {
+                    isAnnotatedByPattern = nodeTemplate.getPolicies().getPolicy()
+                        .stream()
+                        .anyMatch(tPolicy -> namespaceManager.isPatternNamespace(tPolicy.getPolicyType().getNamespaceURI()));
+                }
+
+                return isPattern || isAnnotatedByPattern;
             });
     }
 }

--- a/org.eclipse.winery.model.substitution/src/main/java/org/eclipse/winery/model/substitution/pattern/refinement/PatternRefinementCandidate.java
+++ b/org.eclipse.winery.model.substitution/src/main/java/org/eclipse/winery/model/substitution/pattern/refinement/PatternRefinementCandidate.java
@@ -66,7 +66,7 @@ public class PatternRefinementCandidate {
         ArrayList<String> ids = new ArrayList<>();
 
         this.detectorGraph.vertexSet().forEach(toscaNode ->
-            ids.add(graphMapping.getVertexCorrespondence(toscaNode, false).getNodeTemplate().getId())
+            ids.add(graphMapping.getVertexCorrespondence(toscaNode, false).getTemplate().getId())
         );
 
         return ids;

--- a/org.eclipse.winery.model.substitution/src/test/java/org/eclipse/winery/model/substitution/SubstitutionUtilsTestWithGitBackedRepository.java
+++ b/org.eclipse.winery.model.substitution/src/test/java/org/eclipse/winery/model/substitution/SubstitutionUtilsTestWithGitBackedRepository.java
@@ -42,10 +42,13 @@ class SubstitutionUtilsTestWithGitBackedRepository extends TestWithGitBackedRepo
             "ServiceTemplateWithTwoNodeTemplates_w1-wip2", false);
         ServiceTemplateId st2 = new ServiceTemplateId("http://plain.winery.org/pattern-based/servicetemplates",
             "ServiceTemplateContainingAbstractNodeTemplates_w2-wip1", false);
+        ServiceTemplateId st3 = new ServiceTemplateId("http://winery.opentosca.org/test/servicetemplates",
+            "NodeTemplateAnnotedWithPattern_w1-wip1", false);
 
         return Stream.of(
             Arguments.of(st1, false, "expecting no patterns in the topology"),
-            Arguments.of(st2, true, "expecting patterns in the topology")
+            Arguments.of(st2, true, "expecting patterns in the topology"),
+            Arguments.of(st3, true, "expecting patterns as annotation in the topology")
         );
     }
 }

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/HasPolicies.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/HasPolicies.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.model.tosca;
+
+public interface HasPolicies {
+
+    TPolicies getPolicies();
+
+    void setPolicies(TPolicies policies);
+}

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TBoundaryDefinitions.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TBoundaryDefinitions.java
@@ -50,7 +50,7 @@ public class TBoundaryDefinitions implements Serializable {
     @XmlElement(name = "Capabilities")
     protected TBoundaryDefinitions.Capabilities capabilities;
     @XmlElement(name = "Policies")
-    protected TBoundaryDefinitions.Policies policies;
+    protected TPolicies policies;
     @XmlElement(name = "Interfaces")
     protected TBoundaryDefinitions.Interfaces interfaces;
 
@@ -117,11 +117,11 @@ public class TBoundaryDefinitions implements Serializable {
         this.capabilities = value;
     }
 
-    public TBoundaryDefinitions.@Nullable Policies getPolicies() {
+    public @Nullable TPolicies getPolicies() {
         return policies;
     }
 
-    public void setPolicies(TBoundaryDefinitions.@Nullable Policies value) {
+    public void setPolicies(@Nullable TPolicies value) {
         this.policies = value;
     }
 
@@ -170,24 +170,6 @@ public class TBoundaryDefinitions implements Serializable {
                 _interface = new ArrayList<TExportedInterface>();
             }
             return this._interface;
-        }
-    }
-
-    @XmlAccessorType(XmlAccessType.FIELD)
-    @XmlType(name = "", propOrder = {
-        "policy"
-    })
-    public static class Policies implements Serializable {
-
-        @XmlElement(name = "Policy", required = true)
-        protected List<TPolicy> policy;
-
-        @NonNull
-        public List<TPolicy> getPolicy() {
-            if (policy == null) {
-                policy = new ArrayList<TPolicy>();
-            }
-            return this.policy;
         }
     }
 
@@ -284,7 +266,7 @@ public class TBoundaryDefinitions implements Serializable {
         private PropertyConstraints propertyConstraints;
         private Requirements requirements;
         private Capabilities capabilities;
-        private Policies policies;
+        private TPolicies policies;
         private Interfaces interfaces;
 
         public Builder() {
@@ -311,7 +293,7 @@ public class TBoundaryDefinitions implements Serializable {
             return this;
         }
 
-        public Builder setPolicies(Policies policies) {
+        public Builder setPolicies(TPolicies policies) {
             this.policies = policies;
             return this;
         }
@@ -321,7 +303,7 @@ public class TBoundaryDefinitions implements Serializable {
             return this;
         }
 
-        public Builder addPolicies(TBoundaryDefinitions.Policies policies) {
+        public Builder addPolicies(TPolicies policies) {
             if (policies == null || policies.getPolicy().isEmpty()) {
                 return this;
             }
@@ -339,7 +321,7 @@ public class TBoundaryDefinitions implements Serializable {
                 return this;
             }
 
-            TBoundaryDefinitions.Policies tmp = new TBoundaryDefinitions.Policies();
+            TPolicies tmp = new TPolicies();
             tmp.getPolicy().addAll(policies);
             return this.addPolicies(tmp);
         }
@@ -349,7 +331,7 @@ public class TBoundaryDefinitions implements Serializable {
                 return this;
             }
 
-            TBoundaryDefinitions.Policies tmp = new TBoundaryDefinitions.Policies();
+            TPolicies tmp = new TPolicies();
             tmp.getPolicy().add(policies);
             return this.addPolicies(tmp);
         }

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
@@ -49,13 +49,14 @@ import org.eclipse.jdt.annotation.Nullable;
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
     property = "fakeJacksonType")
-public class TNodeTemplate extends RelationshipSourceOrTarget {
+public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPolicies {
+
     @XmlElement(name = "Requirements")
     protected TNodeTemplate.Requirements requirements;
     @XmlElement(name = "Capabilities")
     protected TNodeTemplate.Capabilities capabilities;
     @XmlElement(name = "Policies")
-    protected TNodeTemplate.Policies policies;
+    protected TPolicies policies;
     @XmlElement(name = "DeploymentArtifacts")
     protected TDeploymentArtifacts deploymentArtifacts;
     @XmlAttribute(name = "name")
@@ -126,11 +127,11 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
         this.capabilities = value;
     }
 
-    public TNodeTemplate.@Nullable Policies getPolicies() {
+    public @Nullable TPolicies getPolicies() {
         return policies;
     }
 
-    public void setPolicies(TNodeTemplate.@Nullable Policies value) {
+    public void setPolicies(@Nullable TPolicies value) {
         this.policies = value;
     }
 
@@ -179,8 +180,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
     }
 
     /**
-     * In the JSON, also output this direct child of the node template object.
-     * Therefore, no JsonIgnore annotation.
+     * In the JSON, also output this direct child of the node template object. Therefore, no JsonIgnore annotation.
      */
     @XmlTransient
     @Nullable
@@ -190,7 +190,8 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
     }
 
     /**
-     * Sets the top coordinate of a {@link TNodeTemplate}. When receiving the JSON, this method ensures that (i) the "y" property can be handled and (ii) the Y coordinate is written correctly in the extension namespace.
+     * Sets the top coordinate of a {@link TNodeTemplate}. When receiving the JSON, this method ensures that (i) the "y"
+     * property can be handled and (ii) the Y coordinate is written correctly in the extension namespace.
      *
      * @param x the value of the x-coordinate to be set
      */
@@ -201,8 +202,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
     }
 
     /**
-     * In the JSON, also output this direct child of the node template object.
-     * Therefore, no JsonIgnore annotation.
+     * In the JSON, also output this direct child of the node template object. Therefore, no JsonIgnore annotation.
      */
     @XmlTransient
     @Nullable
@@ -212,7 +212,8 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
     }
 
     /**
-     * Sets the top coordinate of a {@link TNodeTemplate}. When receiving the JSON, this method ensures that (i) the "y" property can be handled and (ii) the Y coordinate is written correctly in the extension namespace.
+     * Sets the top coordinate of a {@link TNodeTemplate}. When receiving the JSON, this method ensures that (i) the "y"
+     * property can be handled and (ii) the Y coordinate is written correctly in the extension namespace.
      *
      * @param y the value of the coordinate to be set
      */
@@ -238,10 +239,9 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
          * Gets the value of the capability property.
          * <p>
          * <p>
-         * This accessor method returns a reference to the live list,
-         * not a snapshot. Therefore any modification you make to the
-         * returned list will be present inside the JAXB object.
-         * This is why there is not a <CODE>set</CODE> method for the capability property.
+         * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you
+         * make to the returned list will be present inside the JAXB object. This is why there is not a <CODE>set</CODE>
+         * method for the capability property.
          * <p>
          * <p>
          * For example, to add a new item, do as follows:
@@ -251,8 +251,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
          * <p>
          * <p>
          * <p>
-         * Objects of the following type(s) are allowed in the list
-         * {@link TCapability }
+         * Objects of the following type(s) are allowed in the list {@link TCapability }
          */
         @NonNull
         public List<TCapability> getCapability() {
@@ -277,37 +276,6 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
 
         public void accept(Visitor visitor) {
             visitor.visit(this);
-        }
-    }
-
-    @XmlAccessorType(XmlAccessType.FIELD)
-    @XmlType(name = "", propOrder = {
-        "policy"
-    })
-    public static class Policies implements Serializable {
-
-        @XmlElement(name = "Policy", required = true)
-        protected List<TPolicy> policy;
-
-        @NonNull
-        public List<TPolicy> getPolicy() {
-            if (policy == null) {
-                policy = new ArrayList<>();
-            }
-            return this.policy;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Policies policies = (Policies) o;
-            return Objects.equals(policy, policies.policy);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(policy);
         }
     }
 
@@ -349,7 +317,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
     public static class Builder extends RelationshipSourceOrTarget.Builder<Builder> {
         private Requirements requirements;
         private Capabilities capabilities;
-        private Policies policies;
+        private TPolicies policies;
         private TDeploymentArtifacts deploymentArtifacts;
         private String name;
         private Integer minInstances;
@@ -373,7 +341,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
             return this;
         }
 
-        public Builder setPolicies(TNodeTemplate.Policies policies) {
+        public Builder setPolicies(TPolicies policies) {
             this.policies = policies;
             return this;
         }
@@ -464,7 +432,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
             return addCapabilities(tmp);
         }
 
-        public Builder addPolicies(TNodeTemplate.Policies policies) {
+        public Builder addPolicies(TPolicies policies) {
             if (policies == null) {
                 return this;
             }
@@ -482,7 +450,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
                 return this;
             }
 
-            TNodeTemplate.Policies tmp = new TNodeTemplate.Policies();
+            TPolicies tmp = new TPolicies();
             tmp.getPolicy().addAll(policies);
             return addPolicies(tmp);
         }
@@ -492,7 +460,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
                 return this;
             }
 
-            TNodeTemplate.Policies tmp = new TNodeTemplate.Policies();
+            TPolicies tmp = new TPolicies();
             tmp.getPolicy().add(policies);
             return addPolicies(tmp);
         }

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPatternRefinementModel.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPatternRefinementModel.java
@@ -28,6 +28,7 @@ import javax.xml.bind.annotation.XmlType;
 import org.eclipse.winery.model.tosca.visitor.Visitor;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tPatternRefinementModel")
@@ -48,6 +49,9 @@ public class TPatternRefinementModel extends TExtensibleElements implements HasN
 
     @XmlElement(name = "RelationMappings")
     private TRelationMappings relationMappings;
+
+    @XmlElement(name = "PrmPropertyMappings")
+    private TPrmPropertyMappings propertyMappings;
 
     @Override
     public String getName() {
@@ -121,11 +125,39 @@ public class TPatternRefinementModel extends TExtensibleElements implements HasN
         }
     }
 
+    @Nullable
     public TRelationMappings getRelationMappings() {
         return relationMappings;
     }
 
     public void setRelationMappings(TRelationMappings relationMappings) {
         this.relationMappings = relationMappings;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+        "propertyMapping"
+    })
+    public static class TPrmPropertyMappings implements Serializable {
+
+        @XmlElement(name = "PropertyMapping")
+        protected List<TPrmPropertyMapping> propertyMapping;
+
+        @NonNull
+        public List<TPrmPropertyMapping> getPropertyMapping() {
+            if (Objects.isNull(this.propertyMapping)) {
+                this.propertyMapping = new ArrayList<>();
+            }
+            return this.propertyMapping;
+        }
+    }
+
+    @Nullable
+    public TPrmPropertyMappings getPropertyMappings() {
+        return propertyMappings;
+    }
+
+    public void setPropertyMappings(TPrmPropertyMappings propertyMappings) {
+        this.propertyMappings = propertyMappings;
     }
 }

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPolicies.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPolicies.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.model.tosca;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Policies", propOrder = {
+    "policy"
+})
+public class TPolicies implements Serializable {
+
+    @XmlElement(name = "Policy", required = true)
+    protected List<TPolicy> policy;
+
+    @NonNull
+    public List<TPolicy> getPolicy() {
+        if (policy == null) {
+            policy = new ArrayList<>();
+        }
+        return this.policy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TPolicies policies = (TPolicies) o;
+        return Objects.equals(policy, policies.policy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(policy);
+    }
+}

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPrmPropertyMapping.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPrmPropertyMapping.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.model.tosca;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlIDREF;
+import javax.xml.bind.annotation.XmlSchemaType;
+
+import org.eclipse.winery.model.tosca.visitor.Visitor;
+
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class TPrmPropertyMapping extends HasId implements Serializable {
+
+    @JsonIdentityReference(alwaysAsId = true)
+    @XmlAttribute(name = "detectorNode", required = true)
+    @XmlIDREF
+    @XmlSchemaType(name = "IDREF")
+    @NonNull
+    private TNodeTemplate detectorNode;
+
+    @JsonIdentityReference(alwaysAsId = true)
+    @XmlAttribute(name = "refinementNode", required = true)
+    @XmlIDREF
+    @XmlSchemaType(name = "IDREF")
+    @NonNull
+    private TNodeTemplate refinementNode;
+    
+    @XmlAttribute(name = "type")
+    private TPrmPropertyMappingType type;
+    
+    @XmlAttribute(name = "detectorProperty")
+    @Nullable
+    private String detectorProperty;
+    
+    @XmlAttribute(name = "refinementProperty")
+    @Nullable
+    private String refinementProperty;
+
+    public TNodeTemplate getDetectorNode() {
+        return detectorNode;
+    }
+
+    public void setDetectorNode(TNodeTemplate detectorNode) {
+        this.detectorNode = detectorNode;
+    }
+
+    public TNodeTemplate getRefinementNode() {
+        return refinementNode;
+    }
+
+    public void setRefinementNode(TNodeTemplate refinementNode) {
+        this.refinementNode = refinementNode;
+    }
+
+    public TPrmPropertyMappingType getType() {
+        return type;
+    }
+
+    public void setType(TPrmPropertyMappingType type) {
+        this.type = type;
+    }
+
+    public String getDetectorProperty() {
+        return detectorProperty;
+    }
+
+    public void setDetectorProperty(String detectorProperty) {
+        this.detectorProperty = detectorProperty;
+    }
+
+    public String getRefinementProperty() {
+        return refinementProperty;
+    }
+
+    public void setRefinementProperty(String refinementProperty) {
+        this.refinementProperty = refinementProperty;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TPrmPropertyMapping that = (TPrmPropertyMapping) o;
+        return getId().equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPrmPropertyMappingType.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPrmPropertyMappingType.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.model.tosca;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlEnumValue;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+public enum TPrmPropertyMappingType implements Serializable {
+    
+    @XmlEnumValue("all")
+    ALL("all"),
+    @XmlEnumValue("selective")
+    SELECTIVE("selective");
+    
+    private final String value;
+
+    TPrmPropertyMappingType(String value) {
+        this.value = value;
+    }
+    
+    @NonNull
+    public static TPrmPropertyMappingType fromValue(String v) {
+        for (TPrmPropertyMappingType c : TPrmPropertyMappingType.values()) {
+            if (c.value.equalsIgnoreCase(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+    
+    @Nullable
+    public String value() {
+        return this.value;
+    }
+}

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationMapping.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationMapping.java
@@ -24,15 +24,14 @@ import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 
+import org.eclipse.winery.model.tosca.visitor.Visitor;
+
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import org.eclipse.jdt.annotation.NonNull;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tRelationMapping")
-public class TRelationMapping implements Serializable {
-
-    @XmlAttribute(name = "id")
-    private String id;
+public class TRelationMapping extends HasId implements Serializable {
 
     @JsonIdentityReference(alwaysAsId = true)
     @XmlAttribute(name = "detectorNode", required = true)
@@ -97,17 +96,14 @@ public class TRelationMapping implements Serializable {
         this.validSourceOrTarget = validSourceOrTarget;
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
     @Override
     public boolean equals(Object obj) {
         return obj instanceof TRelationMapping
-            && id.equals(((TRelationMapping) obj).id);
+            && getId().equals(((TRelationMapping) obj).getId());
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipTemplate.java
@@ -43,21 +43,22 @@ import org.w3c.dom.Element;
 @XmlType(name = "tRelationshipTemplate", propOrder = {
     "sourceElement",
     "targetElement",
-    "relationshipConstraints"
+    "relationshipConstraints",
+    "policies"
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
-public class TRelationshipTemplate extends TEntityTemplate {
+public class TRelationshipTemplate extends TEntityTemplate implements HasPolicies {
 
     @XmlElement(name = "SourceElement", required = true)
     // AD: We need to combine source or target due to multi-inheritance
     protected TRelationshipTemplate.@NonNull SourceOrTargetElement sourceElement;
-
     @XmlElement(name = "TargetElement", required = true)
     protected TRelationshipTemplate.@NonNull SourceOrTargetElement targetElement;
-
     @XmlElement(name = "RelationshipConstraints")
     protected TRelationshipTemplate.RelationshipConstraints relationshipConstraints;
+    @XmlElement(name = "Policies")
+    protected TPolicies policies;
 
     @XmlAttribute(name = "name")
     protected String name;
@@ -137,7 +138,7 @@ public class TRelationshipTemplate extends TEntityTemplate {
         return name;
     }
 
-    public void setName(@Nullable  String value) {
+    public void setName(@Nullable String value) {
         this.name = value;
     }
 
@@ -274,6 +275,14 @@ public class TRelationshipTemplate extends TEntityTemplate {
         public int hashCode() {
             return Objects.hash(ref);
         }
+    }
+
+    public TPolicies getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(TPolicies policies) {
+        this.policies = policies;
     }
 
     public static class Builder extends TEntityTemplate.Builder<Builder> {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/utils/ModelUtilities.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/utils/ModelUtilities.java
@@ -557,11 +557,8 @@ public class ModelUtilities {
     }
 
     /**
-     * Target label is not present if
-     * - empty string
-     * - undefined
-     * - null
-     * Target Label is not case sensitive -> always lower case.
+     * Target label is not present if - empty string - undefined - null Target Label is not case sensitive -> always
+     * lower case.
      */
     public static Optional<String> getTargetLabel(TNodeTemplate nodeTemplate) {
         if (nodeTemplate == null) {
@@ -725,5 +722,17 @@ public class ModelUtilities {
                 }
             }
         }
+    }
+
+    public static boolean isOfType(QName requiredType, QName givenType, Map<QName, ? extends TEntityType> elements) {
+        if (!givenType.equals(requiredType)) {
+            TEntityType entityType = elements.get(givenType);
+            if (Objects.isNull(entityType) || Objects.isNull(entityType.getDerivedFrom())) {
+                return false;
+            } else {
+                return isOfType(requiredType, entityType.getDerivedFrom().getTypeAsQName(), elements);
+            }
+        }
+        return true;
     }
 }

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/utils/RemoveEmptyLists.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/utils/RemoveEmptyLists.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.utils;
 
+import org.eclipse.winery.model.tosca.TPolicies;
 import org.eclipse.winery.model.tosca.TDeploymentArtifacts;
 import org.eclipse.winery.model.tosca.TEntityTemplate;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
@@ -23,9 +24,9 @@ import org.eclipse.winery.model.tosca.visitor.Visitor;
 import io.github.adr.embedded.ADR;
 
 /**
- * This class removes empty lists. For instance, if a node template has a list of policies and this list is empty, it is removed.
- * This is important for XSD validation.
- * 
+ * This class removes empty lists. For instance, if a node template has a list of policies and this list is empty, it is
+ * removed. This is important for XSD validation.
+ *
  * Use it by calling <code>removeEmptyLists(topologyTemplate)</code>
  *
  * TODO: Extend this for all model elements
@@ -60,7 +61,7 @@ public class RemoveEmptyLists extends Visitor {
         if ((deploymentArtifacts != null) && deploymentArtifacts.getDeploymentArtifact().isEmpty()) {
             nodeTemplate.setDeploymentArtifacts(null);
         }
-        final TNodeTemplate.Policies policies = nodeTemplate.getPolicies();
+        final TPolicies policies = nodeTemplate.getPolicies();
         if ((policies != null) && policies.getPolicy().isEmpty()) {
             nodeTemplate.setPolicies(null);
         }

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/visitor/Visitor.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/visitor/Visitor.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import javax.xml.namespace.QName;
 
 import org.eclipse.winery.model.tosca.HasId;
+import org.eclipse.winery.model.tosca.TPolicies;
 import org.eclipse.winery.model.tosca.RelationshipSourceOrTarget;
 import org.eclipse.winery.model.tosca.TBoundaryDefinitions;
 import org.eclipse.winery.model.tosca.TCapability;
@@ -55,13 +56,16 @@ import org.eclipse.jdt.annotation.NonNull;
  * Visitor with a default visit order to go from top of a definitions to the bottom. No follow up across TDefinitions.
  * In other words: The nesting is followed.
  *
- * In general, for all elements in the hierarchy, a visit method is implemented. This visit method visits all children (in the TOSCA graph meta model).
- * In case an element in the hierarchy has no children in the TOSCA graph meta model and no children in the inheritance hierarchy, it is omitted.
+ * In general, for all elements in the hierarchy, a visit method is implemented. This visit method visits all children
+ * (in the TOSCA graph meta model). In case an element in the hierarchy has no children in the TOSCA graph meta model
+ * and no children in the inheritance hierarchy, it is omitted.
  *
- * This class intentionally defines all default methods not as abstract to keep the children simple and to avoid unnecessary lines of code.
+ * This class intentionally defines all default methods not as abstract to keep the children simple and to avoid
+ * unnecessary lines of code.
  *
  * For more information on options on implementing visitors see
- * <a href="https://dspace.library.uu.nl/handle/1874/2558">Bravenboer, M., & Visser, E. (2001). Guiding visitors: Separating navigation from computation.</a>
+ * <a href="https://dspace.library.uu.nl/handle/1874/2558">Bravenboer, M., & Visser, E. (2001). Guiding visitors:
+ * Separating navigation from computation.</a>
  *
  * TODO: Implement it for all DefinitionsChildren (NodeType, NodeTypeImplementation, ...)
  */
@@ -176,7 +180,7 @@ public abstract class Visitor {
                 deploymentArtifact.accept(this);
             }
         }
-        final TNodeTemplate.Policies policies = nodeTemplate.getPolicies();
+        final TPolicies policies = nodeTemplate.getPolicies();
         if (policies != null) {
             for (TPolicy policy : policies.getPolicy()) {
                 policy.accept(this);
@@ -294,7 +298,7 @@ public abstract class Visitor {
     }
 
     private void acceptBoundaryDefinitionsPolicies(@NonNull TBoundaryDefinitions boundaryDefinitions) {
-        final TBoundaryDefinitions.Policies policies = boundaryDefinitions.getPolicies();
+        final TPolicies policies = boundaryDefinitions.getPolicies();
         if (policies != null) {
             for (TPolicy policy : policies.getPolicy()) {
                 policy.accept(this);

--- a/org.eclipse.winery.model.tosca/src/test/java/org/eclipse/winery/model/tosca/utils/RemoveEmptyListsTest.java
+++ b/org.eclipse.winery.model.tosca/src/test/java/org/eclipse/winery/model/tosca/utils/RemoveEmptyListsTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.winery.model.tosca.utils;
 
+import org.eclipse.winery.model.tosca.TPolicies;
 import org.eclipse.winery.model.tosca.TEntityTemplate;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
@@ -33,7 +34,7 @@ public class RemoveEmptyListsTest {
         topologyTemplate.getNodeTemplateOrRelationshipTemplate().add(nodeTemplate);
 
         nodeTemplate.setProperties(new TEntityTemplate.Properties());
-        nodeTemplate.setPolicies(new TNodeTemplate.Policies());
+        nodeTemplate.setPolicies(new TPolicies());
 
         assertNotNull(((TNodeTemplate) topologyTemplate.getNodeTemplateOrRelationshipTemplate().get(0)).getPolicies());
         assertNotNull(((TNodeTemplate) topologyTemplate.getNodeTemplateOrRelationshipTemplate().get(0)).getProperties());

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/RestUtils.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/RestUtils.java
@@ -94,7 +94,6 @@ import org.eclipse.winery.repository.rest.resources.apiData.QNameWithTypeApiData
 import org.eclipse.winery.repository.rest.resources.apiData.converter.QNameConverter;
 import org.eclipse.winery.repository.rest.resources.entitytemplates.artifacttemplates.ArtifactTemplateResource;
 import org.eclipse.winery.repository.rest.resources.entitytemplates.artifacttemplates.ArtifactTemplatesResource;
-import org.eclipse.winery.repository.rest.resources.entitytypes.TopologyGraphElementEntityTypeResource;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
 import org.eclipse.winery.yaml.common.exception.MultiException;
 import org.eclipse.winery.yaml.converter.Converter;
@@ -855,18 +854,14 @@ public class RestUtils {
      * @param content the data to write
      * @return a JAX-RS Response containing the result. NOCONTENT if successful, InternalSeverError otherwise
      */
-    public static Response putContentToFile(RepositoryFileReference ref, String content, @SuppressWarnings("SameParameterValue") org.apache.tika.mime.MediaType mediaType) {
+    public static Response putContentToFile(RepositoryFileReference ref, String content, MediaType mediaType) {
         try {
-            RepositoryFactory.getRepository().putContentToFile(ref, content, mediaType);
+            RepositoryFactory.getRepository().putContentToFile(ref, content, org.apache.tika.mime.MediaType.parse(mediaType.toString()));
         } catch (IOException e) {
             LOGGER.error(e.getMessage(), e);
             return Response.serverError().entity(e.getMessage()).build();
         }
         return Response.noContent().build();
-    }
-
-    public static Response putContentToFile(RepositoryFileReference ref, String content, @SuppressWarnings("SameParameterValue") MediaType mediaType) {
-        return putContentToFile(ref, content, org.apache.tika.mime.MediaType.parse(mediaType.toString()));
     }
 
     public static Response putContentToFile(RepositoryFileReference ref, InputStream inputStream, org.apache.tika.mime.MediaType mediaType) {
@@ -890,7 +885,7 @@ public class RestUtils {
      * @param qname           the QName of the color attribute
      * @param otherAttributes the plain "XML" attributes. They are used to check
      */
-    public static String getColor(String name, QName qname, Map<QName, String> otherAttributes, TopologyGraphElementEntityTypeResource res) {
+    public static String getColor(String name, QName qname, Map<QName, String> otherAttributes) {
         String colorStr = otherAttributes.get(qname);
         if (colorStr == null) {
             colorStr = ModelUtilities.getColor(name);

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/GenericVisualAppearanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/GenericVisualAppearanceResource.java
@@ -33,10 +33,8 @@ import org.eclipse.winery.common.Util;
 import org.eclipse.winery.common.ids.elements.ToscaElementId;
 import org.eclipse.winery.repository.backend.constants.Filename;
 import org.eclipse.winery.repository.configuration.Environment;
-import org.eclipse.winery.repository.datatypes.ids.elements.VisualAppearanceId;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources.apiData.VisualsApiData;
-import org.eclipse.winery.repository.rest.resources.entitytypes.TopologyGraphElementEntityTypeResource;
 
 import com.sun.jersey.multipart.FormDataBodyPart;
 import com.sun.jersey.multipart.FormDataParam;
@@ -53,14 +51,14 @@ import com.sun.jersey.multipart.FormDataParam;
 public abstract class GenericVisualAppearanceResource {
 
     protected final Map<QName, String> otherAttributes;
-    protected final TopologyGraphElementEntityTypeResource res;
+    protected final AbstractComponentInstanceResource res;
     protected final ToscaElementId id;
 
     /**
      * @param otherAttributes the other attributes of the node/relationship type
      * @param id              the id of this subresource required for storing the images
      */
-    public GenericVisualAppearanceResource(TopologyGraphElementEntityTypeResource res, Map<QName, String> otherAttributes, VisualAppearanceId id) {
+    public GenericVisualAppearanceResource(AbstractComponentInstanceResource res, Map<QName, String> otherAttributes, ToscaElementId id) {
         this.id = id;
         this.res = res;
         this.otherAttributes = otherAttributes;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/VisualAppearanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/VisualAppearanceResource.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources._support;
+
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.repository.datatypes.ids.elements.VisualAppearanceId;
+import org.eclipse.winery.repository.rest.resources.apiData.VisualsApiData;
+
+public class VisualAppearanceResource extends GenericVisualAppearanceResource {
+
+    /**
+     * @param otherAttributes the other attributes of the node/relationship type
+     * @param id              the id of this subresource required for storing the images
+     */
+    public VisualAppearanceResource(AbstractComponentInstanceResource res, Map<QName, String> otherAttributes, DefinitionsChildId id) {
+        super(res, otherAttributes, new VisualAppearanceId(id));
+    }
+
+    public String getColor() {
+        return null;
+    }
+
+    @Override
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public VisualsApiData getJsonData() {
+        return new VisualsApiData(this);
+    }
+}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/AbstractPrmMappingElement.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/AbstractPrmMappingElement.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources.apiData;
+
+public abstract class AbstractPrmMappingElement {
+
+    public String detectorNode;
+    public String id;
+    public String refinementNode;
+
+    public AbstractPrmMappingElement() {
+    }
+}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/PrmPropertyMappingApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/PrmPropertyMappingApiData.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources.apiData;
+
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TPrmPropertyMapping;
+import org.eclipse.winery.model.tosca.TPrmPropertyMappingType;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class PrmPropertyMappingApiData extends AbstractPrmMappingElement {
+
+    public TPrmPropertyMappingType type;
+    public String detectorProperty;
+    public String refinementProperty;
+
+    public PrmPropertyMappingApiData() {
+    }
+    
+    @JsonIgnore
+    public TPrmPropertyMapping createTPrmPropertyMapping(TNodeTemplate detectorNodeTemplate, TNodeTemplate refinementNodeTemplate) {
+        TPrmPropertyMapping mapping = new TPrmPropertyMapping();
+        mapping.setId(this.id);
+        mapping.setDetectorNode(detectorNodeTemplate);
+        mapping.setRefinementNode(refinementNodeTemplate);
+        mapping.setType(this.type);
+        mapping.setDetectorProperty(this.detectorProperty);
+        mapping.setRefinementProperty(this.refinementProperty);
+        
+        return mapping;
+    }
+}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/PropertiesDefinitionResourceApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/PropertiesDefinitionResourceApiData.java
@@ -33,7 +33,7 @@ public class PropertiesDefinitionResourceApiData {
         this.propertiesDefinition = propertiesDefinition;
         this.winerysPropertiesDefinition = winerysPropertiesDefinition;
 
-        if ((winerysPropertiesDefinition != null) && (winerysPropertiesDefinition.getIsDerivedFromXSD() == null) && winerysPropertiesDefinition.getPropertyDefinitionKVList() != null) {
+        if ((winerysPropertiesDefinition != null) && (winerysPropertiesDefinition.getIsDerivedFromXSD() == null)) {
             this.selectedValue = PropertiesDefinitionEnum.Custom;
         } else if ((this.propertiesDefinition != null) && (this.propertiesDefinition.getElement() != null)) {
             this.selectedValue = PropertiesDefinitionEnum.Element;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/RelationMappingApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/RelationMappingApiData.java
@@ -22,11 +22,8 @@ import org.eclipse.winery.model.tosca.TRelationMapping;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public class RelationMappingApiData {
+public class RelationMappingApiData extends AbstractPrmMappingElement {
 
-    public String detectorNode;
-    public String id;
-    public String refinementNode;
     public TRelationDirection direction;
     public QName relationType;
     public QName validSourceOrTarget;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/policytemplates/PolicyTemplateResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/policytemplates/PolicyTemplateResource.java
@@ -23,6 +23,7 @@ import org.eclipse.winery.model.tosca.TPolicyTemplate;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.AbstractComponentInstanceResource;
 import org.eclipse.winery.repository.rest.resources._support.IHasName;
+import org.eclipse.winery.repository.rest.resources._support.VisualAppearanceResource;
 import org.eclipse.winery.repository.rest.resources.entitytemplates.IEntityTemplateResource;
 import org.eclipse.winery.repository.rest.resources.entitytemplates.PropertiesResource;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.boundarydefinitions.PropertyConstraintsResource;
@@ -82,5 +83,10 @@ public final class PolicyTemplateResource extends AbstractComponentInstanceResou
             this.getPolicyTemplate().setPropertyConstraints(constraints);
         }
         return new PropertyConstraintsResource(constraints, this);
+    }
+
+    @Path("appearance")
+    public VisualAppearanceResource getVisualAppearanceResource() {
+        return new VisualAppearanceResource(this, this.getElement().getOtherAttributes(), this.id);
     }
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/policytemplates/PolicyTemplatesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/policytemplates/PolicyTemplatesResource.java
@@ -13,22 +13,46 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytemplates.policytemplates;
 
-import io.swagger.annotations.Api;
-import org.eclipse.winery.repository.rest.resources._support.AbstractComponentsWithTypeReferenceResource;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
 
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.winery.common.ids.definitions.PolicyTemplateId;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.rest.resources._support.AbstractComponentsResource;
+import org.eclipse.winery.repository.rest.resources._support.AbstractComponentsWithTypeReferenceResource;
+import org.eclipse.winery.repository.rest.resources.apiData.VisualsApiData;
+
+import io.swagger.annotations.Api;
 
 /**
- * Manages all policy types in all available namespaces.
- * The actual implementation is done in the
+ * Manages all policy types in all available namespaces. The actual implementation is done in the
  * AbstractComponentsWithTypeReferenceResource
  */
 @Api(tags = "Policy Templates")
 public class PolicyTemplatesResource extends AbstractComponentsWithTypeReferenceResource<PolicyTemplateResource> {
+
     @Path("{namespace}/{id}/")
     public PolicyTemplateResource getComponentInstanceResource(@PathParam("namespace") String namespace, @PathParam("id") String id) {
         return this.getComponentInstanceResource(namespace, id, true);
     }
 
+    @GET
+    @Path("allvisualappearancedata")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<VisualsApiData> getVisualAppearanceList() {
+        SortedSet<PolicyTemplateId> policyTemplateIds = RepositoryFactory.getRepository().getAllDefinitionsChildIds(PolicyTemplateId.class);
+        return policyTemplateIds.stream()
+            .map(id -> {
+                PolicyTemplateResource res = (PolicyTemplateResource) AbstractComponentsResource.getComponentInstanceResource(id);
+                return res.getVisualAppearanceResource().getJsonData();
+            })
+            .collect(Collectors.toList());
+    }
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/NodeTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/NodeTypeResource.java
@@ -99,7 +99,7 @@ public class NodeTypeResource extends TopologyGraphElementEntityTypeResource {
         return new CapabilityDefinitionsResource(this, definitions.getCapabilityDefinition());
     }
 
-    @Path("visualappearance/")
+    @Path("appearance")
     public VisualAppearanceResource getVisualAppearanceResource() {
         return new VisualAppearanceResource(this, this.getElement().getOtherAttributes(), (NodeTypeId) this.id);
     }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/VisualAppearanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/VisualAppearanceResource.java
@@ -46,7 +46,7 @@ public class VisualAppearanceResource extends GenericVisualAppearanceResource {
     @GET
     @Path("bordercolor")
     public String getColor() {
-        return RestUtils.getColor(this.getId().getParent().getXmlId().getDecoded(), QNames.QNAME_BORDER_COLOR, this.otherAttributes, this.res);
+        return RestUtils.getColor(this.getId().getParent().getXmlId().getDecoded(), QNames.QNAME_BORDER_COLOR, this.otherAttributes);
     }
 
     @PUT

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypeResource.java
@@ -19,6 +19,7 @@ import org.eclipse.winery.model.tosca.TExtensibleElements;
 import org.eclipse.winery.model.tosca.TPolicyType;
 import org.eclipse.winery.repository.exceptions.RepositoryCorruptException;
 import org.eclipse.winery.repository.rest.datatypes.select2.Select2OptGroup;
+import org.eclipse.winery.repository.rest.resources._support.VisualAppearanceResource;
 import org.eclipse.winery.repository.rest.resources.entitytypes.EntityTypeResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,4 +76,8 @@ public final class PolicyTypeResource extends EntityTypeResource {
         return new TemplatesOfOnePolicyTypeResource((PolicyTypeId) this.id);
     }
 
+    @Path("appearance")
+    public VisualAppearanceResource getVisualAppearanceResource() {
+        return new VisualAppearanceResource(this, this.getElement().getOtherAttributes(), this.id);
+    }
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypesResource.java
@@ -13,21 +13,46 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.policytypes;
 
-import io.swagger.annotations.Api;
-import org.eclipse.winery.repository.rest.resources._support.AbstractComponentsWithoutTypeReferenceResource;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
 
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.winery.common.ids.definitions.PolicyTypeId;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.rest.resources._support.AbstractComponentsResource;
+import org.eclipse.winery.repository.rest.resources._support.AbstractComponentsWithoutTypeReferenceResource;
+import org.eclipse.winery.repository.rest.resources.apiData.VisualsApiData;
+
+import io.swagger.annotations.Api;
 
 /**
- * Manages all policy types in all available namespaces.
- * The actual implementation is done in the AbstractComponentsResource
+ * Manages all policy types in all available namespaces. The actual implementation is done in the
+ * AbstractComponentsResource
  */
 @Api(tags = "Policy Types")
 public class PolicyTypesResource extends AbstractComponentsWithoutTypeReferenceResource<PolicyTypeResource> {
+
     @Path("{namespace}/{id}/")
     public PolicyTypeResource getComponentInstanceResource(@PathParam("namespace") String namespace, @PathParam("id") String id) {
         return this.getComponentInstanceResource(namespace, id, true);
     }
 
+    @GET
+    @Path("allvisualappearancedata")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<VisualsApiData> getVisualAppearanceList() {
+        SortedSet<PolicyTypeId> policyTypeIds = RepositoryFactory.getRepository().getAllDefinitionsChildIds(PolicyTypeId.class);
+        return policyTypeIds.stream()
+            .map(id -> {
+                PolicyTypeResource res = (PolicyTypeResource) AbstractComponentsResource.getComponentInstanceResource(id);
+                return res.getVisualAppearanceResource().getJsonData();
+            })
+            .collect(Collectors.toList());
+    }
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/properties/PropertiesDefinitionResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/properties/PropertiesDefinitionResource.java
@@ -52,7 +52,8 @@ import org.slf4j.LoggerFactory;
  * <li>Winery's KV properties (in the subresource "winery")</li>
  * </ol>
  * <p>
- * This class does not have "KV" in its name, because it models {@link TEntityType.PropertiesDefinition}
+ * This class does not have "KV" in its name, because it models
+ * {@link TEntityType.PropertiesDefinition}
  */
 public class PropertiesDefinitionResource {
 
@@ -64,6 +65,7 @@ public class PropertiesDefinitionResource {
     // we assume that this class is created at each request
     // therefore, we can have "wpd" final
     private final WinerysPropertiesDefinition wpd;
+
 
     public PropertiesDefinitionResource(EntityTypeResource res) {
         this.parentRes = res;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResource.java
@@ -59,7 +59,7 @@ public class RelationshipTypeResource extends TopologyGraphElementEntityTypeReso
         return RestUtils.getAllElementsReferencingGivenType(NodeTypeImplementationId.class, this.id.getQName());
     }
 
-    @Path("visualappearance/")
+    @Path("appearance")
     public VisualAppearanceResource getVisualAppearanceResource() {
         return new VisualAppearanceResource(this, this.getElement().getOtherAttributes(), (RelationshipTypeId) this.id);
     }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/VisualAppearanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/VisualAppearanceResource.java
@@ -109,7 +109,7 @@ public class VisualAppearanceResource extends GenericVisualAppearanceResource {
     /* * * color * * */
 
     public String getColor() {
-        return RestUtils.getColor(this.getId().getParent().getXmlId().getDecoded(), QNames.QNAME_COLOR, this.otherAttributes, this.res);
+        return RestUtils.getColor(this.getId().getParent().getXmlId().getDecoded(), QNames.QNAME_COLOR, this.otherAttributes);
     }
 
     public String getHoverColor() {

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/AbstractPrmMappingsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/AbstractPrmMappingsResource.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources.patternrefinementmodels;
+
+import java.util.List;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.winery.model.tosca.HasId;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.repository.rest.RestUtils;
+
+import com.sun.jersey.api.NotFoundException;
+
+public abstract class AbstractPrmMappingsResource {
+
+    protected final PatternRefinementModelResource res;
+    protected List<? extends HasId> mappings;
+
+    public AbstractPrmMappingsResource(PatternRefinementModelResource res) {
+        this.res = res;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<? extends HasId> get() {
+        return this.mappings;
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<? extends HasId> removePatternRefinement(@PathParam("id") String id) {
+        this.mappings.removeIf(mapping -> mapping.getId().equals(id));
+        RestUtils.persist(this.res);
+        return this.mappings;
+    }
+
+    protected TNodeTemplate getDetectorNodeTemplate(String id) {
+        return getNodeTemplate(this.res.getDetector().getComponentInstanceJSON().getNodeTemplates(), id);
+    }
+
+    protected TNodeTemplate getRefinementNodeTemplate(String id) {
+        return getNodeTemplate(this.res.getRefinementStructure().getComponentInstanceJSON().getNodeTemplates(), id);
+    }
+
+    private TNodeTemplate getNodeTemplate(List<TNodeTemplate> nodeTemplates, String id) {
+        return nodeTemplates.stream()
+            .filter(nodeTemplate -> nodeTemplate.getId().equals(id))
+            .findFirst()
+            .orElseThrow(NotFoundException::new);
+    }
+
+    public List<? extends HasId> addMapping(HasId mapping) {
+        // to update an element, just remove the old one from the list and add it again
+        this.mappings.remove(mapping);
+        ((List<HasId>) this.mappings).add(mapping);
+        RestUtils.persist(this.res);
+        return mappings;
+    }
+}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/PatternRefinementModelResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/PatternRefinementModelResource.java
@@ -68,6 +68,18 @@ public class PatternRefinementModelResource extends AbstractComponentInstanceRes
 
         return new RelationMappingsResource(this, relationMappings);
     }
+    
+    @Path("propertymappings")
+    public PrmPropertyMappingsResource getPropertyMappings() {
+        TPatternRefinementModel.TPrmPropertyMappings propertyMappings = this.getTPatternRefinementModel().getPropertyMappings();
+        
+        if (Objects.isNull(propertyMappings)) {
+            propertyMappings = new TPatternRefinementModel.TPrmPropertyMappings();
+            this.getTPatternRefinementModel().setPropertyMappings(propertyMappings);
+        }
+        
+        return new PrmPropertyMappingsResource(this, propertyMappings);
+    }
 
     @Override
     public String getName() {

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/PrmPropertyMappingsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/PrmPropertyMappingsResource.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources.patternrefinementmodels;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TPatternRefinementModel;
+import org.eclipse.winery.model.tosca.TPrmPropertyMapping;
+import org.eclipse.winery.repository.rest.resources.apiData.PrmPropertyMappingApiData;
+
+public class PrmPropertyMappingsResource extends AbstractPrmMappingsResource {
+
+    public PrmPropertyMappingsResource(PatternRefinementModelResource res, TPatternRefinementModel.TPrmPropertyMappings propertyMappings) {
+        super(res);
+        this.mappings = propertyMappings.getPropertyMapping();
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<TPrmPropertyMapping> addPropertyMappingFromApi(PrmPropertyMappingApiData mapping) {
+        TNodeTemplate detectorNode = this.getDetectorNodeTemplate(mapping.detectorNode);
+        TNodeTemplate refinementNode = this.getRefinementNodeTemplate(mapping.refinementNode);
+        return (List<TPrmPropertyMapping>) this.addMapping(mapping.createTPrmPropertyMapping(detectorNode, refinementNode));
+    }
+}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/RelationMappingsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/RelationMappingsResource.java
@@ -17,36 +17,20 @@ package org.eclipse.winery.repository.rest.resources.patternrefinementmodels;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TPatternRefinementModel;
 import org.eclipse.winery.model.tosca.TRelationMapping;
-import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources.apiData.RelationMappingApiData;
 
-import com.sun.jersey.api.NotFoundException;
-
-public class RelationMappingsResource {
-
-    private final PatternRefinementModelResource res;
-    private List<TRelationMapping> relationMappings;
+public class RelationMappingsResource extends AbstractPrmMappingsResource {
 
     public RelationMappingsResource(PatternRefinementModelResource res, TPatternRefinementModel.TRelationMappings relationMappings) {
-        this.res = res;
-        this.relationMappings = relationMappings.getRelationMapping();
-    }
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    public List<TRelationMapping> get() {
-        return this.relationMappings;
+        super(res);
+        this.mappings = relationMappings.getRelationMapping();
     }
 
     @PUT
@@ -57,34 +41,8 @@ public class RelationMappingsResource {
       Therefore, we do it manually.
      */
     public List<TRelationMapping> addRelationMappingFromApi(RelationMappingApiData mapping) {
-        TNodeTemplate detectorNode = this.res.getDetector().getComponentInstanceJSON().getNodeTemplates()
-            .stream()
-            .filter(nodeTemplate -> nodeTemplate.getId().equals(mapping.detectorNode))
-            .findFirst()
-            .orElseThrow(NotFoundException::new);
-        TNodeTemplate refinementNode = this.res.getRefinementStructure().getComponentInstanceJSON().getNodeTemplates()
-            .stream()
-            .filter(nodeTemplate -> nodeTemplate.getId().equals(mapping.refinementNode))
-            .findFirst()
-            .orElseThrow(NotFoundException::new);
-
-        return this.addRelationMapping(mapping.createTRelationMapping(detectorNode, refinementNode));
-    }
-
-    @DELETE
-    @Path("{id}")
-    @Produces(MediaType.APPLICATION_JSON)
-    public List<TRelationMapping> removePatternRefinement(@PathParam("id") String id) {
-        this.relationMappings.removeIf(mapping -> mapping.getId().equals(id));
-        RestUtils.persist(this.res);
-        return this.relationMappings;
-    }
-
-    public List<TRelationMapping> addRelationMapping(TRelationMapping mapping) {
-        // to update an element, just remove the old one from the list and add it again
-        this.relationMappings.remove(mapping);
-        this.relationMappings.add(mapping);
-        RestUtils.persist(this.res);
-        return this.relationMappings;
+        TNodeTemplate detectorNode = this.getDetectorNodeTemplate(mapping.detectorNode);
+        TNodeTemplate refinementNode = this.getRefinementNodeTemplate(mapping.refinementNode);
+        return (List<TRelationMapping>) this.addMapping(mapping.createTRelationMapping(detectorNode, refinementNode));
     }
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/BoundaryDefinitionsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/boundarydefinitions/BoundaryDefinitionsResource.java
@@ -26,10 +26,10 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import org.eclipse.winery.model.tosca.TPolicies;
 import org.eclipse.winery.model.tosca.TBoundaryDefinitions;
 import org.eclipse.winery.model.tosca.TBoundaryDefinitions.Capabilities;
 import org.eclipse.winery.model.tosca.TBoundaryDefinitions.Interfaces;
-import org.eclipse.winery.model.tosca.TBoundaryDefinitions.Policies;
 import org.eclipse.winery.model.tosca.TBoundaryDefinitions.Properties;
 import org.eclipse.winery.model.tosca.TBoundaryDefinitions.Properties.PropertyMappings;
 import org.eclipse.winery.model.tosca.TBoundaryDefinitions.Requirements;
@@ -124,9 +124,9 @@ public class BoundaryDefinitionsResource {
 
     @Path("policies/")
     public PoliciesResource getPoliciesResource() {
-        Policies policies = this.boundaryDefinitions.getPolicies();
+        TPolicies policies = this.boundaryDefinitions.getPolicies();
         if (policies == null) {
-            policies = new Policies();
+            policies = new TPolicies();
             this.boundaryDefinitions.setPolicies(policies);
         }
         return new PoliciesResource(policies.getPolicy(), this.serviceTemplateResource);

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/PlansResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/PlansResource.java
@@ -39,7 +39,6 @@ import org.eclipse.winery.model.tosca.TPlan.PlanModelReference;
 import org.eclipse.winery.model.tosca.constants.Namespaces;
 import org.eclipse.winery.repository.Constants;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
-import org.eclipse.winery.repository.backend.constants.MediaTypes;
 import org.eclipse.winery.repository.configuration.Environment;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.collections.EntityCollectionResource;
@@ -146,7 +145,7 @@ public class PlansResource extends EntityWithIdCollectionResource<PlanResource, 
                 fileName = tPlan.getId() + Constants.SUFFIX_BPMN4TOSCA;
                 RepositoryFileReference ref = new RepositoryFileReference(planId, fileName);
                 // Errors are ignored in the following call
-                RestUtils.putContentToFile(ref, "{}", MediaTypes.MEDIATYPE_APPLICATION_JSON);
+                RestUtils.putContentToFile(ref, "{}", MediaType.APPLICATION_JSON_TYPE);
             } else {
                 // We use the filename also as local file name. Alternatively, we could use the xml id
                 // With URL encoding, this should not be an issue

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytemplates/policytemplates/PolicyTemplateResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytemplates/policytemplates/PolicyTemplateResourceTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources.entitytemplates.policytemplates;
+
+import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
+
+import org.junit.Test;
+
+public class PolicyTemplateResourceTest extends AbstractResourceTest {
+    
+    @Test
+    public void getVisualAppearanceData() throws Exception {
+        this.setRevisionTo("origin/plain");
+        this.assertGet("policytemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fpolicytemplates/PolicyTemplateWithoutProperties/appearance",
+            "entitytemplates/policytemplates/visualappearance.json");
+    }
+    
+    @Test
+    public void getIcon() throws Exception {
+        this.setRevisionTo("4656a0abe19b8720c28273461c84d2ddd09ef868");
+        this.assertGet("policytemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fpolicytemplates/PolicyWithIcon_w1-wip1/appearance",
+            "entitytemplates/policytemplates/visualappearance_icon.json");
+    }
+}

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytemplates/policytemplates/PolicyTemplatesResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytemplates/policytemplates/PolicyTemplatesResourceTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources.entitytemplates.policytemplates;
+
+import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
+
+import org.junit.Test;
+
+public class PolicyTemplatesResourceTest extends AbstractResourceTest {
+    
+    @Test
+    public void getAllVisualAppearanceData() throws Exception {
+        this.setRevisionTo("4656a0abe19b8720c28273461c84d2ddd09ef868");
+        this.assertGet("policytemplates/allvisualappearancedata",
+            "entitytemplates/policytemplates/allvisualappearance.json");
+    }
+
+}

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
@@ -39,27 +39,27 @@ public class NodeTypeResourceTest extends AbstractResourceTest {
     @Test
     public void baobabVisualAppearance() throws Exception {
         this.setRevisionTo("9c486269f6280e0eb14730d01554e7e4553a3d60");
-        this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/visualappearance/",
+        this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/appearance",
             "entitytypes/nodetypes/baobab_visual_appearance.json");
     }
 
     @Test
     public void patternNodeTypeVisualAppearance() throws Exception {
         this.setRevisionTo("origin/plain");
-        this.assertGet("nodetypes/http%253A%252F%252Fplain.winery.opentosca.org%252Fpatterns/Infrastructure-As-A-Service_w1/visualappearance/",
+        this.assertGet("nodetypes/http%253A%252F%252Fplain.winery.opentosca.org%252Fpatterns/Infrastructure-As-A-Service_w1/appearance",
             "entitytypes/nodetypes/Infrasctrucure_As-A-Service_visual_appearance.json");
     }
 
     @Test
     public void baobabAdd50x50Image() throws Exception {
         this.setRevisionTo("9c486269f6280e0eb14730d01554e7e4553a3d60");
-        this.assertUploadBinary("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/visualappearance/50x50", "entitytypes/nodetypes/bigIcon.png");
+        this.assertUploadBinary("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/appearance/50x50", "entitytypes/nodetypes/bigIcon.png");
     }
 
     @Test
     public void baobabAdd16x16Image() throws Exception {
         this.setRevisionTo("9c486269f6280e0eb14730d01554e7e4553a3d60");
-        this.assertUploadBinary("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/visualappearance/16x16",
+        this.assertUploadBinary("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/appearance/16x16",
             "entitytypes/nodetypes/bigIcon.png");
     }
 
@@ -146,7 +146,7 @@ public class NodeTypeResourceTest extends AbstractResourceTest {
     @Test
     public void baobabHasNoImage() throws Exception {
         this.setRevisionTo("5b5ad1106a3a428020b6bc5d2f154841acb5f779");
-        this.assertNotFound("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/visualappearance/50x50");
+        this.assertNotFound("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/appearance/50x50");
     }
 
     @Test

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypesResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/PolicyTypesResourceTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources.entitytypes.policytypes;
+
+import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
+
+import org.junit.Test;
+
+public class PolicyTypesResourceTest extends AbstractResourceTest {
+
+    @Test
+    public void getAllVisualAppearance() throws Exception {
+        this.setRevisionTo("4656a0abe19b8720c28273461c84d2ddd09ef868");
+        this.assertGet("policytypes/allvisualappearancedata",
+            "entitytypes/policytypes/allvisualappearance.json");
+    }
+}

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResourceTest.java
@@ -46,16 +46,16 @@ public class RelationshipTypeResourceTest extends AbstractResourceTest {
     @Test
     public void kiwiVisualAppearance() throws Exception {
         this.setRevisionTo("d71de5e3c4c8bd117d035602ffbae115eff981d8");
-        this.assertGet("relationshiptypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypes%252Ffruits/kiwi/visualappearance/",
+        this.assertGet("relationshiptypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypes%252Ffruits/kiwi/appearance",
             "entitytypes/relationshiptypes/kiwi_visualAppearance.json");
     }
 
     @Test
     public void kiwiPutVisualAppearance() throws Exception {
         this.setRevisionTo("d71de5e3c4c8bd117d035602ffbae115eff981d8");
-        this.assertPut("relationshiptypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypes%252Ffruits/kiwi/visualappearance/",
+        this.assertPut("relationshiptypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypes%252Ffruits/kiwi/appearance",
             "entitytypes/relationshiptypes/kiwi_visualAppearance_put.json");
-        this.assertGet("relationshiptypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypes%252Ffruits/kiwi/visualappearance/", 
+        this.assertGet("relationshiptypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Frelationshiptypes%252Ffruits/kiwi/appearance", 
             "entitytypes/relationshiptypes/kiwi_visualAppearance.json");
     }
 

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/PatternRefinementModelResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/patternrefinementmodels/PatternRefinementModelResourceTest.java
@@ -33,4 +33,11 @@ public class PatternRefinementModelResourceTest extends AbstractResourceTest {
         this.assertGet("patternrefinementmodels/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fconcrete%252Fpatternrefinementmodels/myExample_w1-wip1/",
             "patternrefinementmodels/first_patternrefinementmodel.xml");
     }
+
+    @Test
+    public void getPrmWithPropertyMapping() throws Exception {
+        this.setRevisionTo("origin/plain");
+        this.assertGet("patternrefinementmodels/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fpatternrefinementmodels/PropertyMappingsTest_w1-wip1/propertymappings",
+            "patternrefinementmodels/prmRelationMappings.json");
+    }
 }

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/policytemplates/allvisualappearance.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/policytemplates/allvisualappearance.json
@@ -1,0 +1,19 @@
+[
+    {
+        "pattern": false,
+        "typeId": "{http://plain.winery.opentosca.org/policytemplates}PolicyTemplateWithTwoKvProperties"
+    },
+    {
+        "pattern": false,
+        "typeId": "{http://plain.winery.opentosca.org/policytemplates}PolicyTemplateWithXmlElementProperty-PolicyTypeWithXmlElementProperty"
+    },
+    {
+        "pattern": false,
+        "typeId": "{http://plain.winery.opentosca.org/policytemplates}PolicyTemplateWithoutProperties"
+    },
+    {
+        "imageUrl": "http://localhost:8080/winery/policytemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fpolicytemplates/PolicyWithIcon_w1-wip1/appearance/50x50",
+        "pattern": false,
+        "typeId": "{http://plain.winery.opentosca.org/policytemplates}PolicyWithIcon_w1-wip1"
+    }
+]

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/policytemplates/visualappearance.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/policytemplates/visualappearance.json
@@ -1,0 +1,4 @@
+{
+    "pattern": false,
+    "typeId": "{http://plain.winery.opentosca.org/policytemplates}PolicyTemplateWithoutProperties"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/policytemplates/visualappearance_icon.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/policytemplates/visualappearance_icon.json
@@ -1,0 +1,5 @@
+{
+    "imageUrl": "http://localhost:8080/winery/policytemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fpolicytemplates/PolicyWithIcon_w1-wip1/appearance/50x50",
+    "pattern": false,
+    "typeId": "{http://plain.winery.opentosca.org/policytemplates}PolicyWithIcon_w1-wip1"
+}

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/policytypes/allvisualappearance.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/policytypes/allvisualappearance.json
@@ -1,0 +1,14 @@
+[
+    {
+        "pattern": false,
+        "typeId": "{http://plain.winery.opentosca.org/policytypes}PolicyTypeWithTwoKvProperties"
+    },
+    {
+        "pattern": false,
+        "typeId": "{http://plain.winery.opentosca.org/policytypes}PolicyTypeWithXmlElementProperty"
+    },
+    {
+        "pattern": false,
+        "typeId": "{http://plain.winery.opentosca.org/policytypes}PolicyTypeWithoutProperties"
+    }
+]

--- a/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/first_patternrefinementmodel.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/first_patternrefinementmodel.json
@@ -111,14 +111,25 @@
             "relationMappings": {
                 "relationMapping": [
                     {
+                        "documentation": [
+                        ],
+                        "any": [
+                        ],
+                        "otherAttributes": {
+                        },
                         "id": "mapping0",
                         "detectorNode": "Infrastructure-As-A-Service_w1",
                         "refinementNode": "NodeTypeWith5Versions_0.3.4-w3-wip3",
                         "relationType": "{http://plain.winery.opentosca.org/relationshiptypes}RelationshipTypeWithTwoKvPropertie",
-                        "direction": "INGOING",
-                        "validSourceOrTarget": null
+                        "direction": "INGOING"
                     },
                     {
+                        "documentation": [
+                        ],
+                        "any": [
+                        ],
+                        "otherAttributes": {
+                        },
                         "id": "mapping1",
                         "detectorNode": "Infrastructure-As-A-Service_w1",
                         "refinementNode": "NodeTypeWith5Versions_0.3.0-w2",

--- a/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/prmRelationMappings.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/prmRelationMappings.json
@@ -1,0 +1,28 @@
+[
+    {
+        "documentation": [
+        ],
+        "any": [
+        ],
+        "otherAttributes": {
+        },
+        "id": "propMap0",
+        "detectorNode": "NodeTypeWithTwoKVProperties",
+        "refinementNode": "NodeTypeWithTwoKVProperties",
+        "type": "SELECTIVE",
+        "detectorProperty": "key1",
+        "refinementProperty": "key2"
+    },
+    {
+        "documentation": [
+        ],
+        "any": [
+        ],
+        "otherAttributes": {
+        },
+        "id": "propMap1",
+        "detectorNode": "NodeTypeWithTwoKVProperties_2",
+        "refinementNode": "NodeTypeWithTwoKVProperties_2",
+        "type": "ALL"
+    }
+]

--- a/org.eclipse.winery.repository.ui/src/app/instance/instance.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instance.component.ts
@@ -69,7 +69,7 @@ export class InstanceComponent implements OnDestroy {
                         && this.toscaComponent.toscaType !== ToscaTypes.Imports
                         && this.toscaComponent.toscaType !== ToscaTypes.Admin) {
                         if (this.toscaComponent.toscaType === ToscaTypes.NodeType) {
-                            const img = backendBaseURL + this.service.path + '/visualappearance/50x50';
+                            const img = backendBaseURL + this.service.path + '/appearance/50x50';
                             this.existService.check(img)
                                 .subscribe(
                                     () => this.imageUrl = img,

--- a/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
@@ -43,7 +43,7 @@ export class InstanceService {
 
         switch (this.toscaComponent.toscaType) {
             case ToscaTypes.NodeType:
-                subMenu = ['README', 'LICENSE', 'Visual Appearance', 'Instance States', 'Interfaces', 'Implementations', 'Tags',
+                subMenu = ['README', 'LICENSE', 'Appearance', 'Instance States', 'Interfaces', 'Implementations', 'Tags',
                     'Requirement Definitions', 'Capability Definitions', 'Properties Definition',
                     'Inheritance', 'Documentation', 'XML'];
                 break;
@@ -52,7 +52,7 @@ export class InstanceService {
                     'Boundary Definitions', 'Tags', 'Constraint Checking', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.RelationshipType:
-                subMenu = ['README', 'LICENSE', 'Visual Appearance', 'Instance States', 'Source Interfaces', 'Interfaces',
+                subMenu = ['README', 'LICENSE', 'Appearance', 'Instance States', 'Source Interfaces', 'Interfaces',
                     'Target Interfaces', 'Valid Sources and Targets', 'Implementations', 'Properties Definition',
                     'Inheritance', 'Documentation', 'XML'];
                 break;
@@ -75,10 +75,11 @@ export class InstanceService {
                 subMenu = ['README', 'LICENSE', 'Implementation Artifacts', 'Inheritance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.PolicyType:
-                subMenu = ['README', 'LICENSE', 'Language', 'Applies To', 'Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Language', 'Applies To', 'Properties Definition', 'Inheritance',
+                    'Templates', 'Appearance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.PolicyTemplate:
-                subMenu = ['README', 'LICENSE', 'Properties', 'Property Constraints', 'Documentation', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Properties', 'Property Constraints', 'Appearance', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.Imports:
                 subMenu = ['All Declared Elements Local Names', 'All Defined Types Local Names'];
@@ -87,7 +88,7 @@ export class InstanceService {
                 subMenu = ['README', 'LICENSE', 'Identifier', 'Required Structure', 'Tags', 'Documentation', 'XML'];
                 break;
             case ToscaTypes.PatternRefinementModel:
-                subMenu = ['README', 'LICENSE', 'Detector', 'Refinement Structure', 'Relation Mappings', 'XML'];
+                subMenu = ['README', 'LICENSE', 'Detector', 'Refinement Structure', 'Relation Mappings', 'Property Mappings', 'XML'];
                 break;
             default: // assume Admin
                 subMenu = ['Namespaces', 'Repository', 'Plan Languages', 'Plan Types', 'Constraint Types', 'Consistency Check', 'Accountability', 'Log'];

--- a/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/patternRefinementModels.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/patternRefinementModels.module.ts
@@ -1,4 +1,4 @@
-/********************************************************************************
+/*******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -12,16 +12,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 import { NgModule } from '@angular/core';
-import { WineryModalModule } from '../../../wineryModalModule/winery.modal.module';
+import { WineryModalModule } from '../../wineryModalModule/winery.modal.module';
 import { CommonModule } from '@angular/common';
-import { RelationMappingsComponent } from './relationMappings.component';
+import { RelationMappingsComponent } from './relationshipMappings/relationMappings.component';
 import { HttpClientModule } from '@angular/common/http';
-import { WineryNotificationModule } from '../../../wineryNotificationModule/wineryNotification.module';
-import { InstanceModule } from '../../instance.module';
+import { WineryNotificationModule } from '../../wineryNotificationModule/wineryNotification.module';
+import { InstanceModule } from '../instance.module';
 import { BrowserModule } from '@angular/platform-browser';
-import { WineryTableModule } from '../../../wineryTableModule/wineryTable.module';
-import { WineryLoaderModule } from '../../../wineryLoader/wineryLoader.module';
+import { WineryTableModule } from '../../wineryTableModule/wineryTable.module';
+import { WineryLoaderModule } from '../../wineryLoader/wineryLoader.module';
 import { SelectModule } from 'ng2-select';
+import { PrmPropertyMappingsComponent } from './propertyMappings/prmPropertyMappings.component';
 
 @NgModule({
     imports: [
@@ -36,11 +37,13 @@ import { SelectModule } from 'ng2-select';
         WineryLoaderModule,
     ],
     exports: [
-        RelationMappingsComponent
+        RelationMappingsComponent,
+        PrmPropertyMappingsComponent
     ],
     declarations: [
         RelationMappingsComponent,
+        PrmPropertyMappingsComponent
     ]
 })
-export class RelationMappingsModule {
+export class PatternRefinementModelsModule {
 }

--- a/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/prmMappings.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/prmMappings.service.ts
@@ -1,4 +1,4 @@
-/********************************************************************************
+/*******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -13,24 +13,23 @@
  *******************************************************************************/
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { RelationMapping } from './relationMapping';
-import { backendBaseURL } from '../../../configuration';
+import { RelationMapping } from './relationshipMappings/relationMapping';
+import { backendBaseURL } from '../../configuration';
 import { Injectable } from '@angular/core';
-import { InstanceService } from '../../instance.service';
-import { NodeTemplate } from '../../../model/wineryComponent';
-import { SelectData } from '../../../model/selectData';
+import { InstanceService } from '../instance.service';
+import { NodeTemplate } from '../../model/wineryComponent';
+import { SelectData } from '../../model/selectData';
+import { PrmPropertyMapping } from './propertyMappings/prmPropertyMapping';
+import { Utils } from '../../wineryUtils/utils';
+import { PropertiesDefinitionsResourceApiData } from '../sharedComponents/propertiesDefinition/propertiesDefinitionsResourceApiData';
 
 @Injectable()
-export class RelationMappingsService {
+export class PrmMappingsService {
 
     private readonly path: string;
 
     constructor(private http: HttpClient, private sharedData: InstanceService) {
         this.path = backendBaseURL + this.sharedData.path;
-    }
-
-    public getRelationshipMappings(): Observable<RelationMapping[]> {
-        return this.http.get<RelationMapping[]>(this.path + '/relationmappings');
     }
 
     public getDetectorNodeTemplates(): Observable<NodeTemplate[]> {
@@ -49,11 +48,33 @@ export class RelationMappingsService {
         return this.http.get<SelectData[]>(backendBaseURL + '/nodetypes/?grouped=angularSelect');
     }
 
+    public getRelationshipMappings(): Observable<RelationMapping[]> {
+        return this.http.get<RelationMapping[]>(this.path + '/relationmappings');
+    }
+
     public addRelationMapping(element: RelationMapping): Observable<RelationMapping[]> {
         return this.http.put<RelationMapping[]>(this.path + '/relationmappings', element);
     }
 
-    deleteRelationMapping(mapping: RelationMapping): Observable<RelationMapping[]> {
+    public deleteRelationMapping(mapping: RelationMapping): Observable<RelationMapping[]> {
         return this.http.delete<RelationMapping[]>(this.path + '/relationmappings/' + mapping.id);
+    }
+
+    getPropertyMappings(): Observable<PrmPropertyMapping[]> {
+        return this.http.get<PrmPropertyMapping[]>(this.path + '/propertymappings');
+    }
+
+    public addPrmPropertyMapping(element: PrmPropertyMapping): Observable<PrmPropertyMapping[]> {
+        return this.http.put<PrmPropertyMapping[]>(this.path + '/propertymappings', element);
+    }
+
+    public deletePrmPropertyMapping(element: PrmPropertyMapping): Observable<PrmPropertyMapping[]> {
+        return this.http.delete<PrmPropertyMapping[]>(this.path + '/propertymappings/' + element.id);
+    }
+
+    public getNodeTypeProperties(type: string): Observable<PropertiesDefinitionsResourceApiData> {
+        const qName = Utils.getNamespaceAndLocalNameFromQName(type);
+        const url = backendBaseURL + `/nodetypes/${encodeURIComponent(encodeURIComponent(qName.namespace))}/${qName.localName}/propertiesdefinition/`;
+        return this.http.get<PropertiesDefinitionsResourceApiData>(url);
     }
 }

--- a/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/propertyMappings/prmPropertyMapping.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/propertyMappings/prmPropertyMapping.ts
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+export enum PrmPropertyMappingType {
+    ALL = 'ALL',
+    SELECTIVE = 'SELECTIVE'
+}
+
+export class PrmPropertyMapping {
+
+    public static readonly idPrefix = 'propMap';
+
+    id: string;
+    detectorNode: string;
+    refinementNode: string;
+    detectorProperty: string;
+    refinementProperty: string;
+    type: PrmPropertyMappingType;
+
+    constructor(id: number) {
+        this.id = PrmPropertyMapping.idPrefix + id;
+    }
+
+}

--- a/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/propertyMappings/prmPropertyMappings.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/propertyMappings/prmPropertyMappings.component.html
@@ -1,0 +1,87 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ This program and the accompanying materials are made available under the
+  ~ terms of the Eclipse Public License 2.0 which is available at
+  ~ http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+  ~ which is available at https://www.apache.org/licenses/LICENSE-2.0.
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<winery-loader *ngIf="loading; else content"></winery-loader>
+<ng-template #content>
+    <winery-table [columns]="columns" [data]="propertyMappings"
+                  [disableButtons]="!sharedData.currentVersion.editable"
+                  (addBtnClicked)="onAddButtonClicked()" (removeBtnClicked)="onRemoveButtonClicked($event)">
+    </winery-table>
+</ng-template>
+
+<ng-template #addModal>
+    <winery-modal-header [modalRef]="addModalRef" [title]="'Add Property Mapping'">
+    </winery-modal-header>
+    <winery-modal-body>
+        <form>
+            <div class="form-group">
+                <span><b>Property Mapping Type</b></span>
+                <br>
+                <input type="radio" name="direction" id="all" (click)="propertyTypeSelected(propertyMappingTypes.ALL)">
+                <label for="all">All</label>
+                <br>
+                <input type="radio" name="direction" id="selective"
+                       (click)="propertyTypeSelected(propertyMappingTypes.SELECTIVE)">
+                <label for="selective">Selective</label>
+            </div>
+            <hr>
+
+            <div class="form-group">
+                <label for="detectorNode" class="control-label">Detector Node</label>
+                <ng-select id="detectorNode" [items]="detectorNodeTemplates" [textField]="'name'"
+                           (selected)="detectorNodeSelected($event)">
+                </ng-select>
+            </div>
+            <div class="from-group" *ngIf="detectorProperties">
+                <label for="detectorNodePropertiesDropdown" class="control-label">Detector Node Property</label>
+                <ng-select id="detectorNodePropertiesDropdown" [items]="detectorProperties" [textField]="'key'"
+                           [idField]="'key'"
+                           (selected)="mapping.detectorProperty = $event.id">
+                </ng-select>
+            </div>
+            <hr>
+
+            <div class="form-group">
+                <label for="refinementNode" class="control-label">Refinement Structure Node</label>
+                <ng-select id="refinementNode" [items]="refinementStructureNodeTemplates" [textField]="'name'"
+                           (selected)="refinementNodeSelected($event)">
+                </ng-select>
+            </div>
+            <div class="from-group" *ngIf="refinementProperties">
+                <label for="refinementNodePropertiesDropdown" class="control-label">Refinement Node Property</label>
+                <ng-select id="refinementNodePropertiesDropdown" [items]="refinementProperties" [textField]="'key'"
+                           [idField]="'key'"
+                           (selected)="mapping.refinementProperty = $event.id">
+                </ng-select>
+            </div>
+        </form>
+    </winery-modal-body>
+    <winery-modal-footer [modalRef]="addModalRef"
+                         [okButtonLabel]="'Add'"
+                         [disableOkButton]="(!mapping.type || !mapping.detectorNode ||
+                                            !mapping.refinementNode)"
+                         (onOk)="onAddPrmPropertyMapping()">
+    </winery-modal-footer>
+</ng-template>
+
+<ng-template #removeModal>
+    <winery-modal-header [modalRef]="removeModalRef" [title]="'Remove Property Mapping'">
+    </winery-modal-header>
+    <winery-modal-body>
+        <p>Are you sure you want to delete <b>{{ mapping.id }}</b>?</p>
+    </winery-modal-body>
+    <winery-modal-footer [modalRef]="removeModalRef"
+                         [okButtonLabel]="'Delete'"
+                         (onOk)="onRemovePrmPropertyMapping()">
+    </winery-modal-footer>
+</ng-template>

--- a/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/propertyMappings/prmPropertyMappings.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/propertyMappings/prmPropertyMappings.component.ts
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+import { PrmMappingsService } from '../prmMappings.service';
+import { WineryNotificationService } from '../../../wineryNotificationModule/wineryNotification.service';
+import { BsModalRef, BsModalService, ModalDirective } from 'ngx-bootstrap';
+import { WineryTableColumn } from '../../../wineryTableModule/wineryTable.component';
+import { PrmPropertyMapping, PrmPropertyMappingType } from './prmPropertyMapping';
+import { NodeTemplate } from '../../../model/wineryComponent';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { forkJoin } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { SelectData } from '../../../model/selectData';
+import {
+    PropertiesDefinitionKVElement, PropertiesDefinitionsResourceApiData
+} from '../../sharedComponents/propertiesDefinition/propertiesDefinitionsResourceApiData';
+import { InstanceService } from '../../instance.service';
+
+@Component({
+    templateUrl: 'prmPropertyMappings.component.html',
+    providers: [
+        PrmMappingsService
+    ]
+})
+export class PrmPropertyMappingsComponent implements OnInit {
+
+    readonly propertyMappingTypes = PrmPropertyMappingType;
+
+    loading = true;
+    columns: Array<WineryTableColumn> = [
+        { title: 'Id', name: 'id', sort: true },
+        { title: 'Detector Node', name: 'detectorNode', sort: true },
+        { title: 'Refinement Node', name: 'refinementNode', sort: true },
+        { title: 'Type', name: 'type', sort: true },
+        { title: 'Detector Node Property', name: 'detectorProperty', sort: true },
+        { title: 'Refinement Node Property', name: 'refinementProperty', sort: true },
+    ];
+
+    propertyMappings: PrmPropertyMapping[];
+    detectorNodeTemplates: NodeTemplate[];
+    detectorProperties: PropertiesDefinitionKVElement[];
+    refinementStructureNodeTemplates: NodeTemplate[];
+    refinementProperties: PropertiesDefinitionKVElement[];
+
+    @ViewChild('addModal') addModal: ModalDirective;
+    @ViewChild('removeModal') removeModal: ModalDirective;
+    addModalRef: BsModalRef;
+    removeModalRef: BsModalRef;
+
+    mapping: PrmPropertyMapping;
+    selectedDetectorNode: NodeTemplate;
+    selectedRefinementNode: NodeTemplate;
+    loadingRefinementProperties = false;
+    loadingDetectorProperties = false;
+
+    constructor(private service: PrmMappingsService,
+                private notify: WineryNotificationService,
+                private sharedData: InstanceService,
+                private modalService: BsModalService) {
+    }
+
+    ngOnInit(): void {
+        forkJoin(
+            this.service.getPropertyMappings(),
+            this.service.getDetectorNodeTemplates(),
+            this.service.getRefinementStructureNodeTemplates(),
+        ).subscribe(
+            data => this.handleData(data),
+            error => this.handleError(error)
+        );
+    }
+
+    // region ********** Table Callbacks **********
+    onAddButtonClicked() {
+        let id = 0;
+        this.propertyMappings.forEach(value => {
+            const number = Number(value.id.split(PrmPropertyMapping.idPrefix)[1]);
+            if (!isNaN(number) && number >= id) {
+                id = number;
+                if (number === id) {
+                    id++;
+                }
+            }
+        });
+
+        this.mapping = new PrmPropertyMapping(id);
+        this.cleanProperties();
+        this.addModalRef = this.modalService.show(this.addModal);
+    }
+
+    onRemoveButtonClicked(selected: PrmPropertyMapping) {
+        this.mapping = selected;
+        this.removeModalRef = this.modalService.show(this.removeModal);
+    }
+
+    // endregion
+
+    // region ********** Add Modal Callbacks **********
+    onAddPrmPropertyMapping() {
+        this.loading = true;
+        this.service.addPrmPropertyMapping(this.mapping)
+            .subscribe(
+                data => this.handleSave('Added', data),
+                error => this.handleError(error)
+            );
+    }
+
+    propertyTypeSelected(type: PrmPropertyMappingType) {
+        this.mapping.type = type;
+        if (type === PrmPropertyMappingType.ALL) {
+            this.cleanProperties();
+        }
+        this.getProperties();
+    }
+
+    detectorNodeSelected(node: SelectData) {
+        this.mapping.detectorNode = node.id;
+        this.selectedDetectorNode = this.detectorNodeTemplates
+            .find(value => value.id === node.id);
+        this.getProperties();
+    }
+
+    refinementNodeSelected(node: SelectData) {
+        this.mapping.refinementNode = node.id;
+        this.selectedRefinementNode = this.refinementStructureNodeTemplates
+            .find(value => value.id === node.id);
+        this.getProperties();
+    }
+
+    // endregion
+
+    // region ********** Remove Modal Callback **********
+    onRemovePrmPropertyMapping() {
+        this.service.deletePrmPropertyMapping(this.mapping)
+            .subscribe(
+                data => this.handleSave('Removed', data),
+                error => this.handleError(error)
+            );
+    }
+
+    // endregion
+
+    // region ********** Private Methods *********
+    private handleSave(type: string, data: PrmPropertyMapping[]) {
+        this.notify.success(type + ' Property Mapping ' + this.mapping.id);
+        this.propertyMappings = data;
+        this.loading = false;
+    }
+
+    private getProperties() {
+        if (this.mapping.type && this.mapping.type === PrmPropertyMappingType.SELECTIVE) {
+            if (this.selectedRefinementNode) {
+                this.loadingRefinementProperties = true;
+                this.service.getNodeTypeProperties(this.selectedRefinementNode.type)
+                    .subscribe(
+                        data => this.handleProperties(data),
+                        error => this.handleError(error)
+                    );
+            }
+            if (this.selectedDetectorNode) {
+                this.service.getNodeTypeProperties(this.selectedDetectorNode.type)
+                    .subscribe(
+                        data => this.handleProperties(data, true),
+                        error => this.handleError(error)
+                    );
+            }
+        }
+    }
+
+    private handleData(data: any) {
+        this.loading = false;
+        this.propertyMappings = data[0];
+        this.detectorNodeTemplates = data[1];
+        this.refinementStructureNodeTemplates = data[2];
+    }
+
+    private handleError(error: HttpErrorResponse) {
+        this.loading = false;
+        this.notify.error(error.message);
+    }
+
+    private handleProperties(data: PropertiesDefinitionsResourceApiData, isDetector = false) {
+        this.loadingRefinementProperties = false;
+        if (!data.winerysPropertiesDefinition) {
+            this.notify.error('Mapping of non-winery properties is currently not supported!', 'No Winery Properties Definitions!');
+        } else {
+            if (isDetector) {
+                this.detectorProperties = data.winerysPropertiesDefinition.propertyDefinitionKVList;
+            } else {
+                this.refinementProperties = data.winerysPropertiesDefinition.propertyDefinitionKVList;
+            }
+        }
+    }
+
+    private cleanProperties() {
+        delete this.mapping.detectorProperty;
+        delete this.mapping.refinementProperty;
+        delete this.refinementProperties;
+        delete this.detectorProperties;
+    }
+
+    // endregion
+}

--- a/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/relationshipMappings/relationMappings.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/relationshipMappings/relationMappings.component.html
@@ -15,6 +15,7 @@
 <winery-loader *ngIf="loading; else content"></winery-loader>
 <ng-template #content>
     <winery-table [columns]="columns" [data]="relationshipMappings"
+                  [disableButtons]="!sharedData.currentVersion.editable"
                   (addBtnClicked)="onAddButtonClicked()" (removeBtnClicked)="onRemoveButtonClicked($event)">
     </winery-table>
 </ng-template>
@@ -33,6 +34,7 @@
                 <input type="radio" name="direction" id="outgoing" (click)="mapping.direction = relDirections.OUTGOING">
                 <label for="outgoing">Outgoing</label>
             </div>
+            <hr>
 
             <div class="form-group">
                 <label for="detectorNode" class="control-label">Detector Node</label>
@@ -47,6 +49,7 @@
                            (selected)="mapping.refinementNode = $event.id">
                 </ng-select>
             </div>
+            <hr>
 
             <div class="form-group">
                 <label for="relationTypeSelect" class="control-label">Applicable Relationship Type</label>
@@ -54,7 +57,7 @@
                            (selected)="mapping.relationType = $event.id">
                 </ng-select>
             </div>
-
+            <hr>
             <div class="form-group">
                 <label for="nodeTypeSelect" class="control-label">Valid Endpoint Type</label>
                 <ng-select id="nodeTypeSelect" [items]="nodeTypes"

--- a/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/relationshipMappings/relationMappings.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/patternRefinementModels/relationshipMappings/relationMappings.component.ts
@@ -12,7 +12,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { RelationMappingsService } from './relationMappings.service';
+import { PrmMappingsService } from '../prmMappings.service';
 import { WineryNotificationService } from '../../../wineryNotificationModule/wineryNotification.service';
 import { RelationDirection, RelationMapping } from './relationMapping';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -21,11 +21,12 @@ import { WineryTableColumn } from '../../../wineryTableModule/wineryTable.compon
 import { NodeTemplate } from '../../../model/wineryComponent';
 import { SelectData } from '../../../model/selectData';
 import { BsModalRef, BsModalService, ModalDirective } from 'ngx-bootstrap';
+import { InstanceService } from '../../instance.service';
 
 @Component({
     templateUrl: 'relationMappings.component.html',
     providers: [
-        RelationMappingsService
+        PrmMappingsService
     ]
 })
 export class RelationMappingsComponent implements OnInit {
@@ -55,8 +56,9 @@ export class RelationMappingsComponent implements OnInit {
     addModalRef: BsModalRef;
     removeModalRef: BsModalRef;
 
-    constructor(private service: RelationMappingsService,
+    constructor(private service: PrmMappingsService,
                 private notify: WineryNotificationService,
+                private sharedData: InstanceService,
                 private modalService: BsModalService) {
     }
 

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.html
@@ -15,8 +15,8 @@
     <winery-loader></winery-loader>
 </div>
 <div class="content" *ngIf="!loading">
-    <h4>Colors</h4>
-    <div class="colorPickerArea" *ngIf="!loading && nodeTypeData != null">
+    <h4 *ngIf="isNodeType || isRelationshipType">Colors</h4>
+    <div class="colorPickerArea" *ngIf="!loading && isNodeType">
         <div class="floatContent">
             <b>Bordercolor:</b><br>
             <input class="colorInput" name="eventColor" type="color" [(ngModel)]="borderColorLocal" [disabled]="!sharedData?.currentVersion?.editable">

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.ts
@@ -19,6 +19,7 @@ import { RelationshipTypesVisualsApiData } from './relationshipTypesVisualsApiDa
 import { NodeTypesVisualsApiData } from './nodeTypesVisualsApiData';
 import { InstanceService } from '../../instance.service';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { ToscaTypes } from '../../../model/enums';
 
 @Component({
     templateUrl: 'visualAppearance.component.html',
@@ -34,7 +35,8 @@ export class VisualAppearanceComponent implements OnInit {
     loading = true;
     img16Path: string;
     img50Path: string;
-    isNodeType = true;
+    isRelationshipType = false;
+    isNodeType = false;
 
     constructor(public sharedData: InstanceService,
                 private service: VisualAppearanceService,
@@ -46,14 +48,13 @@ export class VisualAppearanceComponent implements OnInit {
         this.img16Path = this.service.getImg16x16Path();
         this.img50Path = this.service.getImg50x50Path();
 
-        if (this.service.path.includes('relationshiptypes')) {
-            this.isNodeType = false;
-        }
+        this.isRelationshipType = this.sharedData.toscaComponent.toscaType === ToscaTypes.RelationshipType;
+        this.isNodeType = this.sharedData.toscaComponent.toscaType === ToscaTypes.NodeType;
 
-        if (this.isNodeType) {
-            this.getNodeTypeData();
-        } else {
+        if (this.isRelationshipType) {
             this.getRelationshipData();
+        } else {
+            this.getNodeTypeData();
         }
     }
 
@@ -100,13 +101,13 @@ export class VisualAppearanceComponent implements OnInit {
     }
 
     saveToServer() {
-        if (this.isNodeType) {
-            this.service.saveVisuals(new NodeTypesVisualsApiData(this.nodeTypeData)).subscribe(
+        if (this.isRelationshipType) {
+            this.service.saveVisuals(new RelationshipTypesVisualsApiData(this.relationshipData, false)).subscribe(
                 data => this.handleResponse(data),
                 error => this.handleError(error)
             );
         } else {
-            this.service.saveVisuals(new RelationshipTypesVisualsApiData(this.relationshipData, false)).subscribe(
+            this.service.saveVisuals(new NodeTypesVisualsApiData(this.nodeTypeData)).subscribe(
                 data => this.handleResponse(data),
                 error => this.handleError(error)
             );
@@ -139,10 +140,10 @@ export class VisualAppearanceComponent implements OnInit {
 
     onUploadSuccess() {
         this.loading = true;
-        if (this.isNodeType) {
-            this.getNodeTypeData();
-        } else {
+        if (this.isRelationshipType) {
             this.getRelationshipData();
+        } else {
+            this.getNodeTypeData();
         }
     }
 

--- a/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/sharedComponents/visualAppearance/visualAppearance.service.ts
@@ -33,20 +33,16 @@ export class VisualAppearanceService {
     }
 
     getData() {
-        return this.http.get(backendBaseURL + this.route.url + '/');
+        return this.http.get(backendBaseURL + this.route.url);
     }
 
     saveVisuals(data: any): Observable<HttpResponse<string>> {
         const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
         return this.http
             .put(
-                backendBaseURL + this.route.url + '/',
+                backendBaseURL + this.route.url,
                 data,
                 { headers: headers, observe: 'response', responseType: 'text' }
             );
-    }
-
-    get path(): string {
-        return this.route.url;
     }
 }

--- a/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entity.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entity.component.html
@@ -18,13 +18,8 @@
         <img *ngIf="imageUrl" src="{{ imageUrl }}" class="nodeTypeImageIconInList">
     </div>
     <div class="center" [style.width.px]="maxWidth">
-        <div *ngIf="data.id" class="{{ containerSizeClass + ' informationContainer '}}">
+        <div class="{{ containerSizeClass + ' informationContainer '}}">
             <div *ngIf="data.id" class="name">{{ data.name }}</div>
-            <div *ngIf="data.id" class="version">Version: {{ data?.version?.toReadableString() }}</div>
-            <div [ngClass]="{'name': !data.id, 'namespace': data.id}">{{ data.namespace }}</div>
-        </div>
-        <div *ngIf="!data.id" class="{{ containerSizeClass + ' informationContainer '}}">
-            <div class="name">{{ data.name }}</div>
             <div [ngClass]="{'name': !data.id, 'namespace': data.id}">{{ data.namespace }}</div>
         </div>
         <div *ngIf="!data.id" class="badge numberOfComponentInstances">{{ data.count }}</div>

--- a/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entity.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entity.component.ts
@@ -57,7 +57,7 @@ export class EntityComponent implements OnInit {
             + encodeURIComponent(encodeURIComponent(this.data.namespace)) + '/' + this.data.id;
 
         if (this.toscaType === ToscaTypes.NodeType && this.data.id) {
-            const img = this.backendLink + '/visualappearance/50x50';
+            const img = this.backendLink + '/appearance/50x50';
 
             this.existService.check(img)
                 .subscribe(

--- a/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entityContainer.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/entityContainer/entityContainer.component.ts
@@ -53,7 +53,7 @@ export class EntityContainerComponent implements OnInit {
             const img = backendBaseURL + '/' + this.toscaType
                 + '/' + encodeURIComponent(encodeURIComponent(this.data.versionInstances[0].namespace))
                 + '/' + this.data.versionInstances[0].id
-                + '/visualappearance/50x50';
+                + '/appearance/50x50';
 
             this.existService.check(img)
                 .subscribe(

--- a/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/section.component.ts
@@ -31,7 +31,6 @@ import { KeyValueItem } from '../model/keyValueItem';
 import { ConfigurationService } from '../instance/admin/accountability/configuration/configuration.service';
 import { AccountabilityService } from '../instance/admin/accountability/accountability.service';
 import { FileProvenanceElement } from '../model/provenance';
-import { WineryVersion } from '../model/wineryVersion';
 
 const showAll = 'Show all Items';
 const showGrouped = 'Group by Namespace';
@@ -213,14 +212,7 @@ export class SectionComponent implements OnInit, OnDestroy {
 
         resources.forEach(item => {
             const container = new SectionData();
-            item.version = new WineryVersion(item.version.componentVersion,
-                item.version.wineryVersion, item.version.workInProgressVersion, item.version.currentVersion,
-                item.version.latestVersion, item.version.releasable, item.version.editable);
-            item.name = Utils.getNameWithoutVersion(item.name);
-
             container.createContainerCopy(item);
-
-
 
             if (this.componentData.length === 0) {
                 this.componentData.push(container);

--- a/org.eclipse.winery.repository.ui/src/app/section/sectionData.ts
+++ b/org.eclipse.winery.repository.ui/src/app/section/sectionData.ts
@@ -18,7 +18,6 @@ import { WineryVersion } from '../model/wineryVersion';
  * Type definition for data returned by the section service.
  */
 export class SectionData {
-
     id?: string;
     name?: string;
     namespace: string;
@@ -31,9 +30,7 @@ export class SectionData {
         this.id = Utils.getNameWithoutVersion(original.id);
         this.name = Utils.getNameWithoutVersion(original.name);
         this.namespace = original.namespace;
-        this.version = new WineryVersion(original.version.componentVersion,
-            original.version.wineryVersion, original.version.workInProgressVersion, original.version.currentVersion,
-            original.version.latestVersion, original.version.releasable, original.version.editable);
+        this.version = original.version;
         this.versionInstances = [original];
 
         return this;

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypes/nodeTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/nodeTypes/nodeTypeRouter.module.ts
@@ -43,7 +43,7 @@ const nodeTypeRoutes: Routes = [
         children: [
             { path: 'readme', component: WineryReadmeComponent },
             { path: 'license', component: WineryLicenseComponent },
-            { path: 'visualappearance', component: VisualAppearanceComponent },
+            { path: 'appearance', component: VisualAppearanceComponent },
             { path: 'instancestates', component: InstanceStatesComponent },
             { path: 'interfaces', component: InterfacesComponent },
             { path: 'implementations', component: ImplementationsComponent },

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/patternRefinementModels/patternRefinementModel.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/patternRefinementModels/patternRefinementModel.module.ts
@@ -18,7 +18,7 @@ import { InstanceModule } from '../../instance/instance.module';
 import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
 import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
 import { PatternRefinementModelRouterModule } from './patternRefinementModelRouter.module';
-import { RelationMappingsModule } from '../../instance/patternRefinementModels/relationshipMappings/relationMappings.module';
+import { PatternRefinementModelsModule } from '../../instance/patternRefinementModels/patternRefinementModels.module';
 
 @NgModule({
     imports: [
@@ -27,7 +27,7 @@ import { RelationMappingsModule } from '../../instance/patternRefinementModels/r
         TopologyTemplateModule,
         WineryReadmeModule,
         WineryLicenseModule,
-        RelationMappingsModule,
+        PatternRefinementModelsModule,
         PatternRefinementModelRouterModule,
     ]
 })

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/patternRefinementModels/patternRefinementModelRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/patternRefinementModels/patternRefinementModelRouter.module.ts
@@ -23,6 +23,7 @@ import { EditXMLComponent } from '../../instance/sharedComponents/editXML/editXM
 import { NgModule } from '@angular/core';
 import { RelationMappingsComponent } from '../../instance/patternRefinementModels/relationshipMappings/relationMappings.component';
 import { TopologyTemplateComponent } from '../../instance/sharedComponents/topologyTemplate/topologyTemplate.component';
+import { PrmPropertyMappingsComponent } from '../../instance/patternRefinementModels/propertyMappings/prmPropertyMappings.component';
 
 const toscaType = ToscaTypes.PatternRefinementModel;
 
@@ -39,6 +40,7 @@ const patternRefinementRoutes: Routes = [
             { path: 'detector', component: TopologyTemplateComponent },
             { path: 'refinementstructure', component: TopologyTemplateComponent },
             { path: 'relationmappings', component: RelationMappingsComponent },
+            { path: 'propertymappings', component: PrmPropertyMappingsComponent },
             { path: 'xml', component: EditXMLComponent },
             { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTemplates/policyTemplateRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTemplates/policyTemplateRouter.module.ts
@@ -24,6 +24,7 @@ import { PropertiesComponent } from '../../instance/sharedComponents/properties/
 import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
 import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 import { PropertyConstraintsComponent } from '../../instance/serviceTemplates/boundaryDefinitions/propertyConstraints/propertyConstraints.component';
+import { VisualAppearanceComponent } from '../../instance/sharedComponents/visualAppearance/visualAppearance.component';
 
 const toscaType = ToscaTypes.PolicyTemplate;
 
@@ -40,6 +41,7 @@ const policyTemplateRoutes: Routes = [
             { path: 'properties', component: PropertiesComponent },
             { path: 'propertyconstraints', component: PropertyConstraintsComponent },
             { path: 'documentation', component: DocumentationComponent },
+            { path: 'appearance', component: VisualAppearanceComponent },
             { path: 'xml', component: EditXMLComponent },
             { path: '', redirectTo: 'readme', pathMatch: 'full' }
         ]

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/policyTypes/policyTypeRouter.module.ts
@@ -11,43 +11,45 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-import {NgModule} from '@angular/core';
-import {RouterModule, Routes} from '@angular/router';
-import {SectionComponent} from '../../section/section.component';
-import {SectionResolver} from '../../section/section.resolver';
-import {InstanceComponent} from '../../instance/instance.component';
-import {InstanceResolver} from '../../instance/instance.resolver';
-import {EditXMLComponent} from '../../instance/sharedComponents/editXML/editXML.component';
-import {DocumentationComponent} from '../../instance/sharedComponents/documentation/documentation.component';
-import {ToscaTypes} from '../../model/enums';
-import {InheritanceComponent} from '../../instance/sharedComponents/inheritance/inheritance.component';
-import {PropertiesDefinitionComponent} from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
-import {LanguageComponent} from '../../instance/policyTypes/language/language.component';
-import {AppliesToComponent} from '../../instance/policyTypes/appliesTo/appliesTo.component';
-import {WineryReadmeComponent} from '../../wineryReadmeModule/wineryReadme.component';
-import {WineryLicenseComponent} from '../../wineryLicenseModule/wineryLicense.component';
-import {ImplementationsComponent} from '../../instance/sharedComponents/implementations/implementations.component';
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { SectionComponent } from '../../section/section.component';
+import { SectionResolver } from '../../section/section.resolver';
+import { InstanceComponent } from '../../instance/instance.component';
+import { InstanceResolver } from '../../instance/instance.resolver';
+import { EditXMLComponent } from '../../instance/sharedComponents/editXML/editXML.component';
+import { DocumentationComponent } from '../../instance/sharedComponents/documentation/documentation.component';
+import { ToscaTypes } from '../../model/enums';
+import { InheritanceComponent } from '../../instance/sharedComponents/inheritance/inheritance.component';
+import { PropertiesDefinitionComponent } from '../../instance/sharedComponents/propertiesDefinition/propertiesDefinition.component';
+import { LanguageComponent } from '../../instance/policyTypes/language/language.component';
+import { AppliesToComponent } from '../../instance/policyTypes/appliesTo/appliesTo.component';
+import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.component';
+import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
+import { ImplementationsComponent } from '../../instance/sharedComponents/implementations/implementations.component';
+import { VisualAppearanceComponent } from '../../instance/sharedComponents/visualAppearance/visualAppearance.component';
 
 const toscaType = ToscaTypes.PolicyType;
 
 const policyTypeRoutes: Routes = [
-    {path: toscaType, component: SectionComponent, resolve: {resolveData: SectionResolver}},
-    {path: toscaType + '/:namespace', component: SectionComponent, resolve: {resolveData: SectionResolver}},
+    { path: toscaType, component: SectionComponent, resolve: { resolveData: SectionResolver } },
+    { path: toscaType + '/:namespace', component: SectionComponent, resolve: { resolveData: SectionResolver } },
     {
         path: toscaType + '/:namespace/:localName',
         component: InstanceComponent,
-        resolve: {resolveData: InstanceResolver},
+        resolve: { resolveData: InstanceResolver },
         children: [
-            {path: 'readme', component: WineryReadmeComponent},
-            {path: 'license', component: WineryLicenseComponent},
-            {path: 'language', component: LanguageComponent},
-            {path: 'appliesto', component: AppliesToComponent},
-            {path: 'propertiesdefinition', component: PropertiesDefinitionComponent},
-            {path: 'inheritance', component: InheritanceComponent},
-            {path: 'documentation', component: DocumentationComponent},
-            {path: 'xml', component: EditXMLComponent},
-            {path: 'templates', component: ImplementationsComponent},
-            {path: '', redirectTo: 'readme', pathMatch: 'full'}
+            { path: 'readme', component: WineryReadmeComponent },
+            { path: 'license', component: WineryLicenseComponent },
+            { path: 'language', component: LanguageComponent },
+            { path: 'appliesto', component: AppliesToComponent },
+            { path: 'propertiesdefinition', component: PropertiesDefinitionComponent },
+            { path: 'inheritance', component: InheritanceComponent },
+            { path: 'appearance', component: VisualAppearanceComponent },
+            { path: 'documentation', component: DocumentationComponent },
+            { path: 'xml', component: EditXMLComponent },
+            { path: 'templates', component: ImplementationsComponent },
+            { path: '', redirectTo: 'readme', pathMatch: 'full' }
 
         ]
     }

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypes/relationshipTypeRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/relationshipTypes/relationshipTypeRouter.module.ts
@@ -42,7 +42,7 @@ const relationshipTypeRoutes: Routes = [
         children: [
             {path: 'readme', component: WineryReadmeComponent},
             {path: 'license', component: WineryLicenseComponent},
-            {path: 'visualappearance', component: VisualAppearanceComponent},
+            {path: 'appearance', component: VisualAppearanceComponent},
             {path: 'instancestates', component: InstanceStatesComponent},
             {path: 'sourceinterfaces', component: InterfacesComponent},
             {path: 'interfaces', component: InterfacesComponent},

--- a/org.eclipse.winery.repository.ui/src/css/wineryRepository.css
+++ b/org.eclipse.winery.repository.ui/src/css/wineryRepository.css
@@ -295,7 +295,6 @@ div.serviceTemplate div.bottom {
 div.mainContentContainer.relationshipType div.top {
     background: url('../assets/img/containers/rt/rt-FrameTopLarge.jpg');
 }
-
 div.mainContentContainer.relationshipType div.top.twolines {
     height: 208px;
 }
@@ -542,7 +541,7 @@ div.entityContainer > div.right {
 }
 
 div.entityContainer > div.center > div.informationContainer {
-    margin-top: 15px;
+    margin-top: 25px;
     height: 45px;
     color: #787878;
     font-family: arial, sans-serif;
@@ -560,18 +559,7 @@ div.entityContainer > div.center > div.informationContainer > div.name {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-    direction: ltr;
-    text-align: left;
-}
-
-div.entityContainer > div.center > div.informationContainer > div.name:hover {
-    color: #00c2ff;
-}
-
-div.entityContainer > div.center > div.informationContainer > div.version {
-    font-size: 14px;
-    height: 18px;
-    direction: ltr;
+    direction: rtl;
     text-align: left;
 }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IGenericRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IGenericRepository.java
@@ -57,6 +57,7 @@ import org.eclipse.winery.common.interfaces.IWineryRepositoryCommon;
 import org.eclipse.winery.model.tosca.Definitions;
 import org.eclipse.winery.model.tosca.HasInheritance;
 import org.eclipse.winery.model.tosca.HasType;
+import org.eclipse.winery.model.tosca.TPolicies;
 import org.eclipse.winery.model.tosca.TAppliesTo;
 import org.eclipse.winery.model.tosca.TArtifactTemplate;
 import org.eclipse.winery.model.tosca.TBoundaryDefinitions;
@@ -594,7 +595,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
 
         TBoundaryDefinitions boundaryDefs;
         if ((boundaryDefs = serviceTemplate.getBoundaryDefinitions()) != null) {
-            TBoundaryDefinitions.Policies policies = boundaryDefs.getPolicies();
+            TPolicies policies = boundaryDefs.getPolicies();
             if (policies != null) {
                 for (TPolicy policy : policies.getPolicy()) {
                     PolicyTypeId policyTypeId = new PolicyTypeId(policy.getPolicyType());
@@ -645,7 +646,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
                     }
 
                     // crawl through policies
-                    org.eclipse.winery.model.tosca.TNodeTemplate.Policies policies = n.getPolicies();
+                    TPolicies policies = n.getPolicies();
                     if (policies != null) {
                         for (TPolicy pol : policies.getPolicy()) {
                             QName type = pol.getPolicyType();
@@ -721,7 +722,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
                     }
 
                     // crawl through policies
-                    org.eclipse.winery.model.tosca.TNodeTemplate.Policies policies = n.getPolicies();
+                    TPolicies policies = n.getPolicies();
                     if (policies != null) {
                         for (TPolicy pol : policies.getPolicy()) {
                             QName type = pol.getPolicyType();
@@ -881,7 +882,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
     }
 
     default Collection<DefinitionsChildId> getReferencingDefinitionsChildIds(PolicyTemplateId id) {
-        // ServiceTemplates > BoundaryDefinitions > Policies
+        // ServiceTemplates > BoundaryDefinitions > TPolicies
         return new HashSet<>(this.getAllElementsReferencingGivenType(ServiceTemplateId.class, id.getQName()));
     }
 
@@ -892,7 +893,7 @@ public interface IGenericRepository extends IWineryRepositoryCommon {
         ids.addAll(this.getAllElementsReferencingGivenType(PolicyTemplateId.class, id.getQName()));
         // PolicyTypes
         ids.addAll(this.getAllElementsReferencingGivenType(PolicyTypeId.class, id.getQName()));
-        // ServiceTemplates > BoundaryDefinitions > Policies
+        // ServiceTemplates > BoundaryDefinitions > TPolicies
         // ids.addAll(this.getAllElementsReferencingGivenType(ServiceTemplateId.class, id.getQName()));
 
         return ids;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/constants/MediaTypes.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/constants/MediaTypes.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.constants;
 
-import org.apache.tika.mime.MediaType;
 import org.eclipse.winery.common.constants.MimeTypes;
+
+import org.apache.tika.mime.MediaType;
 
 /**
  * see also {@link org.eclipse.winery.common.constants.MimeTypes}
@@ -25,5 +26,4 @@ public class MediaTypes {
     public static final MediaType MEDIATYPE_APPLICATION_JSON = MediaType.parse("application/json");
     public static final MediaType MEDIATYPE_TEXT_XML = MediaType.parse("text/xml");
     public static final MediaType MEDIATYPE_XSD = MediaType.parse(MimeTypes.MIMETYPE_XSD);
-
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/datatypes/ids/elements/VisualAppearanceId.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/datatypes/ids/elements/VisualAppearanceId.java
@@ -14,17 +14,15 @@
 package org.eclipse.winery.repository.datatypes.ids.elements;
 
 import org.eclipse.winery.common.ids.XmlId;
-import org.eclipse.winery.common.ids.definitions.TopologyGraphElementEntityTypeId;
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
 import org.eclipse.winery.common.ids.elements.ToscaElementId;
 
 /**
- * ID for a pseudo-TOSCA-Element holding the data for the visual appearance
- * (e.g., icons for node types)
+ * ID for a pseudo-TOSCA-Element holding the data for the visual appearance (e.g., icons for node types)
  */
 public class VisualAppearanceId extends ToscaElementId {
 
-    public VisualAppearanceId(TopologyGraphElementEntityTypeId parent) {
+    public VisualAppearanceId(DefinitionsChildId parent) {
         super(parent, new XmlId("appearance", true));
     }
-
 }

--- a/org.eclipse.winery.topologygraph/pom.xml
+++ b/org.eclipse.winery.topologygraph/pom.xml
@@ -40,6 +40,44 @@
             <artifactId>org.eclipse.winery.repository</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.21.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit.platform.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${junit.jupiter.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-params</artifactId>
+                        <version>${junit.jupiter.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/matching/ToscaDefaultMatcher.java
+++ b/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/matching/ToscaDefaultMatcher.java
@@ -22,7 +22,7 @@ public class ToscaDefaultMatcher implements IToscaMatcher {
 
     @Override
     public boolean isCompatible(ToscaNode left, ToscaNode right) {
-        return StringUtils.equals(left.getNodeTemplate().getName(), right.getNodeTemplate().getName());
+        return StringUtils.equals(left.getTemplate().getName(), right.getTemplate().getName());
     }
 
     @Override

--- a/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/matching/ToscaPrmPropertyMatcher.java
+++ b/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/matching/ToscaPrmPropertyMatcher.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.topologygraph.matching;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.winery.model.tosca.HasPolicies;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TPolicy;
+import org.eclipse.winery.repository.backend.NamespaceManager;
+import org.eclipse.winery.topologygraph.model.ToscaEdge;
+import org.eclipse.winery.topologygraph.model.ToscaEntity;
+import org.eclipse.winery.topologygraph.model.ToscaNode;
+
+public class ToscaPrmPropertyMatcher extends ToscaTypeMatcher {
+
+    private List<TEntityTemplate> detectorElements;
+    private NamespaceManager namespaceManager;
+
+    public ToscaPrmPropertyMatcher(List<TEntityTemplate> detectorElements, NamespaceManager namespaceManager) {
+        this.detectorElements = detectorElements;
+        this.namespaceManager = namespaceManager;
+    }
+
+    @Override
+    public boolean isCompatible(ToscaNode left, ToscaNode right) {
+        return super.isCompatible(left, right)
+            && propertiesCompatible(left, right);
+    }
+
+    @Override
+    public boolean isCompatible(ToscaEdge left, ToscaEdge right) {
+        return super.isCompatible(left, right)
+            && propertiesCompatible(left, right);
+    }
+
+    public boolean propertiesCompatible(ToscaEntity left, ToscaEntity right) {
+        boolean propertiesCompatible = true;
+
+        TEntityTemplate[] templates = getTemplates(left, right);
+        TEntityTemplate detectorElement = templates[0];
+        TEntityTemplate candidate = templates[1];
+
+        if (Objects.nonNull(detectorElement.getProperties()) && Objects.nonNull(candidate.getProperties()) &&
+            // the implementation (currently) works for KV properties only
+            Objects.nonNull(detectorElement.getProperties().getKVProperties()) && Objects.nonNull(candidate.getProperties().getKVProperties())) {
+            Map<String, String> detectorProperties = detectorElement.getProperties().getKVProperties();
+            Map<String, String> candidateProperties = candidate.getProperties().getKVProperties();
+
+            propertiesCompatible = detectorProperties.entrySet().stream()
+                .allMatch(entry -> {
+                    if (Objects.nonNull(entry.getValue()) && !entry.getValue().isEmpty()) {
+                        String refProp = candidateProperties.get(entry.getKey());
+                        if (entry.getValue().equalsIgnoreCase("*")) {
+                            // if the detector defines a wildcard, the property must be set in the candidate
+                            return !refProp.isEmpty();
+                        } else {
+                            // if the detector defines a specific value, the candidate's property must match
+                            return entry.getValue().equalsIgnoreCase(refProp);
+                        }
+                    }
+
+                    return true;
+                });
+        }
+
+        return propertiesCompatible;
+    }
+
+    public boolean characterizingPatternsCompatible(ToscaEntity left, ToscaEntity right) {
+        boolean characterizingPatternsCompatible = true;
+
+        TEntityTemplate[] templates = getTemplates(left, right);
+
+        if (templates[0] instanceof HasPolicies && templates[1] instanceof HasPolicies) {
+            HasPolicies detectorElement = (HasPolicies) templates[0];
+            HasPolicies candidate = (HasPolicies) templates[1];
+
+            if (Objects.nonNull(detectorElement.getPolicies()) && Objects.nonNull(candidate.getPolicies())) {
+                List<TPolicy> candidatePolicies = candidate.getPolicies().getPolicy();
+                characterizingPatternsCompatible = detectorElement.getPolicies().getPolicy()
+                    .stream()
+                    .allMatch(detectorPolicy -> {
+                        if (this.namespaceManager.isPatternNamespace(detectorPolicy.getPolicyType().getNamespaceURI())) {
+                            return candidatePolicies.stream()
+                                .anyMatch(candidatePolicy -> {
+                                    boolean typeEquals = candidatePolicy.getPolicyType().equals(detectorPolicy.getPolicyType());
+
+                                    if (typeEquals && Objects.nonNull(detectorPolicy.getPolicyRef())) {
+                                        return Objects.nonNull(candidatePolicy.getPolicyRef())
+                                            && candidatePolicy.getPolicyRef().equals(detectorPolicy.getPolicyRef());
+                                    }
+
+                                    return typeEquals;
+                                });
+                        }
+
+                        return true;
+                    });
+            } else if (Objects.nonNull(detectorElement.getPolicies())) {
+                // only if there are patterns attached
+                characterizingPatternsCompatible = detectorElement.getPolicies().getPolicy()
+                    .stream()
+                    .noneMatch(detectorPolicy ->
+                        this.namespaceManager.isPatternNamespace(detectorPolicy.getPolicyType().getNamespaceURI())
+                    );
+            } else if (Objects.nonNull(candidate.getPolicies())) {
+                // if the detector has no patterns attached but the candidate has --> not a match
+                // only if there are unresolved patterns
+                characterizingPatternsCompatible = candidate.getPolicies().getPolicy()
+                    .stream()
+                    .noneMatch(candidatePolicy ->
+                        this.namespaceManager.isPatternNamespace(candidatePolicy.getPolicyType().getNamespaceURI())
+                    );
+            }
+        }
+
+        return characterizingPatternsCompatible;
+    }
+
+    private TEntityTemplate[] getTemplates(ToscaEntity left, ToscaEntity right) {
+        TEntityTemplate detectorNodeTemplate, candidate;
+
+        if (this.detectorElements.contains(left.getTemplate())) {
+            detectorNodeTemplate = left.getTemplate();
+            candidate = right.getTemplate();
+        } else {
+            detectorNodeTemplate = right.getTemplate();
+            candidate = left.getTemplate();
+        }
+
+        return new TEntityTemplate[] {detectorNodeTemplate, candidate};
+    }
+}

--- a/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/matching/ToscaTypeMatcher.java
+++ b/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/matching/ToscaTypeMatcher.java
@@ -21,11 +21,11 @@ public class ToscaTypeMatcher implements IToscaMatcher {
 
     @Override
     public boolean isCompatible(ToscaNode left, ToscaNode right) {
-        return left.getNodeTemplate().getType().equals(right.getNodeTemplate().getType());
+        return left.getActualType().equals(right.getActualType());
     }
 
     @Override
     public boolean isCompatible(ToscaEdge left, ToscaEdge right) {
-        return right.getTemplate().getType().equals(left.getTemplate().getType());
+        return right.getActualType().equals(left.getActualType());
     }
 }

--- a/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/model/ToscaEntity.java
+++ b/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/model/ToscaEntity.java
@@ -16,6 +16,7 @@ package org.eclipse.winery.topologygraph.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.winery.model.tosca.TEntityTemplate;
 import org.eclipse.winery.model.tosca.TEntityType;
 
 public abstract class ToscaEntity {
@@ -39,10 +40,13 @@ public abstract class ToscaEntity {
     }
 
     public TEntityType getActualType() {
-        return types.stream().findFirst().orElse(null);
+        // according to the convention that the first element is the actual type:
+        return types.get(0);
     }
 
     public boolean addTEntityType(TEntityType type) {
         return this.types.add(type);
     }
+
+    public abstract TEntityTemplate getTemplate();
 }

--- a/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/model/ToscaNode.java
+++ b/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/model/ToscaNode.java
@@ -27,7 +27,7 @@ public class ToscaNode extends ToscaEntity {
         return getTypes().stream().map(TNodeType.class::cast).collect(Collectors.toList());
     }
 
-    public TNodeTemplate getNodeTemplate() {
+    public TNodeTemplate getTemplate() {
         return nodeTemplate;
     }
 

--- a/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/transformation/ToscaTransformer.java
+++ b/org.eclipse.winery.topologygraph/src/main/java/org/eclipse/winery/topologygraph/transformation/ToscaTransformer.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import javax.xml.namespace.QName;
 
-import org.eclipse.winery.common.ids.definitions.EntityTypeId;
 import org.eclipse.winery.common.ids.definitions.NodeTypeId;
 import org.eclipse.winery.common.ids.definitions.RelationshipTypeId;
 import org.eclipse.winery.model.tosca.TEntityType;
@@ -81,7 +80,6 @@ public class ToscaTransformer {
     }
 
     protected static TEntityType getEntityType(QName qName, Class<? extends TEntityType> tEntityTypeClass) {
-        EntityTypeId ntId = null;
         if (tEntityTypeClass.isAssignableFrom(TNodeType.class)) {
             return RepositoryFactory.getRepository().getElement(new NodeTypeId(qName));
         }

--- a/org.eclipse.winery.topologygraph/src/test/java/org/eclipse/winery/topologygraph/matching/MockNamespaceManager.java
+++ b/org.eclipse.winery.topologygraph/src/test/java/org/eclipse/winery/topologygraph/matching/MockNamespaceManager.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.topologygraph.matching;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.eclipse.winery.repository.backend.NamespaceManager;
+import org.eclipse.winery.repository.backend.filebased.NamespaceProperties;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+public class MockNamespaceManager implements NamespaceManager {
+    @Override
+    public String getPrefix(String namespace) {
+        return "";
+    }
+
+    @Override
+    public boolean hasPermanentProperties(String namespace) {
+        return false;
+    }
+
+    @Override
+    public void removeNamespaceProperties(String namespace) {
+    }
+
+    @Override
+    public void setNamespaceProperties(String namespace, NamespaceProperties properties) {
+    }
+
+    @Override
+    public Map<String, NamespaceProperties> getAllNamespaces() {
+        return null;
+    }
+
+    @Override
+    public @NonNull NamespaceProperties getNamespaceProperties(String namespace) {
+        return null;
+    }
+
+    @Override
+    public void addAllPermanent(Collection<NamespaceProperties> properties) {
+    }
+
+    @Override
+    public void replaceAll(Map<String, NamespaceProperties> map) {
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public boolean isPatternNamespace(String namespace) {
+        return false;
+    }
+}

--- a/org.eclipse.winery.topologygraph/src/test/java/org/eclipse/winery/topologygraph/matching/ToscaPrmPropertyMatcherTest.java
+++ b/org.eclipse.winery.topologygraph/src/test/java/org/eclipse/winery/topologygraph/matching/ToscaPrmPropertyMatcherTest.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+package org.eclipse.winery.topologygraph.matching;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TPolicies;
+import org.eclipse.winery.model.tosca.TPolicy;
+import org.eclipse.winery.repository.backend.NamespaceManager;
+import org.eclipse.winery.topologygraph.model.ToscaNode;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ToscaPrmPropertyMatcherTest {
+
+    private static Stream<Arguments> compatiblePropertiesArguments() {
+        Map<String, String> allInOneLeftProperties = new HashMap<>();
+        allInOneLeftProperties.put("key0", null);
+        allInOneLeftProperties.put("key1", "*");
+        allInOneLeftProperties.put("key2", "");
+        allInOneLeftProperties.put("key3", "special");
+        Map<String, String> allInOneRightProperties = new HashMap<>();
+        allInOneRightProperties.put("key0", "");
+        allInOneRightProperties.put("key1", "I must be set");
+        allInOneRightProperties.put("key2", "I can have anything");
+        allInOneRightProperties.put("key3", "special");
+
+        Map<String, String> mustBeSetLeftProperties = new HashMap<>();
+        mustBeSetLeftProperties.put("key", "*");
+        Map<String, String> mustBeSetRightProperties = new HashMap<>();
+        mustBeSetRightProperties.put("key", "isSet");
+        Map<String, String> mustBeSetButIsNotRightProperties = new HashMap<>();
+        mustBeSetButIsNotRightProperties.put("key", "");
+
+        Map<String, String> mustBeEqualsLeftProperties = new HashMap<>();
+        mustBeEqualsLeftProperties.put("key", "must be equals");
+        Map<String, String> mustBeEqualsRightProperties = new HashMap<>();
+        mustBeEqualsRightProperties.put("key", "must Be equals");
+        Map<String, String> mustBeEqualsButIsNotRightProperties = new HashMap<>();
+        mustBeEqualsButIsNotRightProperties.put("key", "who cares?");
+
+        return Stream.of(
+            Arguments.of(allInOneLeftProperties, allInOneRightProperties, true, "All in one"),
+            Arguments.of(mustBeSetLeftProperties, mustBeSetRightProperties, true, "Must be set"),
+            Arguments.of(mustBeSetLeftProperties, mustBeSetButIsNotRightProperties, false, "Must be set but is not"),
+            Arguments.of(mustBeEqualsLeftProperties, mustBeEqualsRightProperties, true, "Must be equals"),
+            Arguments.of(mustBeEqualsLeftProperties, mustBeEqualsButIsNotRightProperties, false, "Must be equals but is not"),
+            Arguments.of(null, null, true, "If there are no properties, they must still match!")
+        );
+    }
+
+    @ParameterizedTest(name = "{index} => ''{3}''")
+    @MethodSource("compatiblePropertiesArguments")
+    public void compatibleProperties(Map<String, String> leftProperties, Map<String, String> rightProperties, boolean expected, String description) {
+        // region ***** left *****
+        TNodeTemplate left = new TNodeTemplate();
+        if (Objects.nonNull(leftProperties)) {
+            TEntityTemplate.Properties properties = new TNodeTemplate.Properties();
+            properties.setKVProperties(leftProperties);
+            left.setProperties(properties);
+        }
+
+        ToscaNode leftEntity = new ToscaNode();
+        leftEntity.setNodeTemplate(left);
+
+        List<TEntityTemplate> detectorElements = new ArrayList<>();
+        detectorElements.add(left);
+        // endregion
+
+        // region ***** right *****
+        TNodeTemplate right = new TNodeTemplate();
+        if (Objects.nonNull(leftProperties)) {
+            TEntityTemplate.Properties properties2 = new TNodeTemplate.Properties();
+            properties2.setKVProperties(rightProperties);
+            right.setProperties(properties2);
+        }
+
+        ToscaNode rightEntity = new ToscaNode();
+        rightEntity.setNodeTemplate(right);
+        // endregion
+
+        assertEquals(
+            expected,
+            new ToscaPrmPropertyMatcher(detectorElements, new MockNamespaceManager())
+                .propertiesCompatible(leftEntity, rightEntity)
+        );
+    }
+
+    private static Stream<Arguments> characterizingPatternsCompatibleArguments() {
+        NamespaceManager namespaceManager = new MockNamespaceManager();
+        NamespaceManager patternNamespaceManager = new MockNamespaceManager() {
+            @Override
+            public boolean isPatternNamespace(String namespace) {
+                return true;
+            }
+        };
+        
+        TPolicies leftPolicies1 = new TPolicies();
+        TPolicy leftPolicy1 = new TPolicy();
+        leftPolicy1.setPolicyType(QName.valueOf("{ns}policyType1"));
+        leftPolicies1.getPolicy().add(leftPolicy1);
+
+        TPolicies leftPolicies2 = new TPolicies();
+        TPolicy leftPolicy2 = new TPolicy();
+        leftPolicy2.setPolicyType(QName.valueOf("{ns}policyType1123"));
+        leftPolicies2.getPolicy().add(leftPolicy2);
+        
+        TPolicies rightPolicies1 = new TPolicies();
+        TPolicy rightPolicy1 = new TPolicy();
+        rightPolicy1.setPolicyType(QName.valueOf("{ns}policyType1"));
+        rightPolicies1.getPolicy().add(rightPolicy1);
+        
+        TPolicies rightPolicies2 = new TPolicies();
+        TPolicy rightPolicy2 = new TPolicy();
+        rightPolicy2.setPolicyType(QName.valueOf("{ns}policyType1"));
+        rightPolicy2.setPolicyRef(QName.valueOf("{ns2}policyTemplate1"));
+        rightPolicies2.getPolicy().add(rightPolicy2);
+        
+        return Stream.of(
+            Arguments.of(leftPolicies1, rightPolicies1, patternNamespaceManager, true, "Matching policy types without templates"),
+            Arguments.of(leftPolicies1, rightPolicies2, patternNamespaceManager, true, "Matching policy types and more specific policy template in the candidate"),
+            Arguments.of(rightPolicies2, leftPolicies1, patternNamespaceManager, false, "Matching policy types but a specific policy template in the detector"),
+            Arguments.of(leftPolicies2, rightPolicies1, patternNamespaceManager, false, "Different policy types"),
+            Arguments.of(leftPolicies2, null, patternNamespaceManager, false, "Patterns annotated at the detector but not at the candidate"),
+            Arguments.of(null, rightPolicies1, patternNamespaceManager, false, "Patterns annotated at the candidate but not at the detector"),
+            Arguments.of(null, rightPolicies1, namespaceManager, true, "Polices annotated at the candidate but not patterns")
+        );
+    }
+    
+    @ParameterizedTest(name = "{index} => ''{4}''")
+    @MethodSource("characterizingPatternsCompatibleArguments")
+    public void characterizingPatternsCompatibleTest(TPolicies leftPolicies, TPolicies rightPolicies,
+                                                     NamespaceManager namespaceManager, boolean expected, String description) {
+        // region ***** left *****
+        TNodeTemplate left = new TNodeTemplate();
+        if (Objects.nonNull(leftPolicies)) {
+            left.setPolicies(leftPolicies);
+        }
+
+        ToscaNode leftEntity = new ToscaNode();
+        leftEntity.setNodeTemplate(left);
+
+        List<TEntityTemplate> detectorElements = new ArrayList<>();
+        detectorElements.add(left);
+        // endregion
+
+        // region ***** right *****
+        TNodeTemplate right = new TNodeTemplate();
+        if (Objects.nonNull(rightPolicies)) {
+            right.setPolicies(rightPolicies);
+        }
+
+        ToscaNode rightEntity = new ToscaNode();
+        rightEntity.setNodeTemplate(right);
+        // endregion
+
+        assertEquals(
+            expected,
+            new ToscaPrmPropertyMatcher(detectorElements, namespaceManager)
+                .characterizingPatternsCompatible(leftEntity, rightEntity)
+        );
+    }
+}

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/entities-modal/entities-modal.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/entities-modal/entities-modal.component.html
@@ -35,17 +35,11 @@
                 <div class="radio"
                      *ngIf="modalVariantForEditDeleteTasks === '(none)'">
                     <label>
-                        <input type="radio" name="templateCreation"
-                               value="{{modalVariantAndState.modalVariant === 'deployment_artifacts' ? 'createArtifactTemplate' : 'createPolicyTemplate'}}"
-                               checked="checked" id="createArtifactTemplateInput"
+                        <input type="radio" name="templateCreation" value="create" checked="checked"
                                [(ngModel)]="modalSelectedRadioButton"/>
-
-                        <div *ngIf="modalVariantAndState.modalVariant === 'deployment_artifacts'"
-                             style="display: inline-block;">
-                            Create Artifact Template
-                        </div>
-                        <div *ngIf="modalVariantAndState.modalVariant === 'policies'" style="display: inline-block;">
-                            Create Policy Template
+                        <div style="display: inline-block;">
+                            &nbsp;Create {{modalVariantAndState.modalVariant === 'deployment_artifacts' ? 'Artifact' : 'Policy'}}
+                            Template
                         </div>
                     </label>
                     <p *ngIf="modalVariantAndState.modalVariant === 'deployment_artifacts'"
@@ -59,22 +53,18 @@
                 </div>
                 <div class="radio" *ngIf="modalVariantForEditDeleteTasks === '(none)'">
                     <label>
-                        <input type="radio" name="templateCreation" value="link{{modalVariantAndState.modalVariant}}"
-                               id="linkArtifactTemplateOrPolicyTemplateInput"
+                        <input type="radio" name="templateCreation" value="link"
                                [(ngModel)]="modalSelectedRadioButton"/>
-                        <div *ngIf="modalVariantAndState.modalVariant === 'deployment_artifacts'"
-                             style="display: inline-block;">Link Artifact Template
-                        </div>
-                        <div *ngIf="modalVariantAndState.modalVariant === 'policies'" style="display: inline-block;">
-                            Link Policy Template
+                        <div style="display: inline-block;">
+                            &nbsp;Link {{modalVariantAndState.modalVariant === 'deployment_artifacts' ? 'Artifact' : 'Policy'}}
+                            Template
                         </div>
                     </label>
                     <p class="help-block">Check if you want to reuse existing files.</p>
                 </div>
                 <div class="radio" *ngIf="modalVariantForEditDeleteTasks === '(none)'">
                     <label style="margin-bottom: 1em;">
-                        <input type="radio" name="templateCreation" value="skip{{modalVariantAndState.modalVariant}}"
-                               id="skipArtifactTemplateOrPolicyTemplateInput"
+                        <input type="radio" name="templateCreation" value="skip"
                                [(ngModel)]="modalSelectedRadioButton"/>
                         Do not create a template.
                     </label>
@@ -83,7 +73,7 @@
                 </div>
             </fieldset>
             <fieldset>
-                <div class="form-group-grouping">
+                <div class="form-group-grouping" *ngIf="modalSelectedRadioButton === 'create'">
 
                     <!-- createArtifactTemplate class is required for artifactcreationdialog -->
                     <div class="form-group createArtifactTemplate">
@@ -127,9 +117,7 @@
 
                 </div>
                 <!-- link ArtifactTemplate or PolicyTemplate -->
-                <ng-container *ngIf="modalSelectedRadioButton === 'linkdeployment_artifacts' ||
-                                     modalSelectedRadioButton === 'linkpolicies' ||
-                                     modalVariantForEditDeleteTasks !== '(none)'">
+                <ng-container *ngIf="modalSelectedRadioButton === 'link'">
                     <div id="linkArtifactTemplateOrPolicyTemplate" class="form-group">
                         <label *ngIf="modalVariantAndState.modalVariant === 'deployment_artifacts' ||
                                       modalVariantForEditDeleteTasks === 'deployment_artifacts'"
@@ -181,27 +169,20 @@
             </fieldset>
             <fieldset id="artifactTypeFieldset">
                 <div class="form-group" id="artifactTypeOrPolicyTypeDiv">
-                    <label
-                        *ngIf="modalVariantAndState.modalVariant === 'deployment_artifacts' || modalVariantForEditDeleteTasks === 'deployment_artifacts'"
-                        for="artifactTypeOrPolicyTypeField">Artifact Type</label>
-                    <label
-                        *ngIf="modalVariantAndState.modalVariant === 'policies' || modalVariantForEditDeleteTasks === 'policies'"
-                        for="artifactTypeOrPolicyTypeField">Policy Type</label>
+                    <label for="artifactTypeOrPolicyTypeField">
+                        {{modalVariantAndState.modalVariant === 'deployment_artifacts' ? 'Artifact' : 'Policy'}} Type
+                    </label>
 
                     <input type="text"
                            class="form-control"
-                           *ngIf="modalSelectedRadioButton === 'linkpolicies' || modalSelectedRadioButton === 'linkdeployment_artifacts' || modalVariantForEditDeleteTasks != '(none)'"
+                           *ngIf="modalSelectedRadioButton === 'link'"
                            [disabled]="true"
                            [ngModel]="deploymentArtifactOrPolicyModalData.modalType"
                            name="artifactTypeOrPolicyTypeField"
                            placeholder="Select a Template to see its Type."
                            id="artifactTypeOrPolicyTypeField">
                     <select [(ngModel)]="deploymentArtifactOrPolicyModalData.modalType"
-                            *ngIf="modalVariantForEditDeleteTasks === '(none)' &&
-                            (modalSelectedRadioButton === 'skippolicies' ||
-                            modalSelectedRadioButton === 'skipdeployment_artifacts' ||
-                            modalSelectedRadioButton === 'createArtifactTemplate' ||
-                            modalSelectedRadioButton === 'createPolicyTemplate')"
+                            *ngIf="modalSelectedRadioButton === 'skip' || modalSelectedRadioButton === 'create'"
                             name="artifactTypeOrPolicyTypeChooser"
                             class="form-control"
                             id="artifactTypeOrPolicyTypeChooser"

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/entities-modal/entities-modal.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/entities-modal/entities-modal.component.ts
@@ -13,32 +13,24 @@
  *******************************************************************************/
 
 import {
-    AfterViewInit,
-    Component,
-    EventEmitter,
-    Input,
-    OnChanges,
-    OnInit,
-    Output,
-    SimpleChanges,
-    ViewChild
+    AfterViewInit, Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild
 } from '@angular/core';
-import {ModalDirective} from 'ngx-bootstrap';
-import {TPolicy} from '../../models/policiesModalData';
-import {TDeploymentArtifact} from '../../models/artifactsModalData';
-import {QNameWithTypeApiData} from '../../models/generateArtifactApiData';
-import {EntityTypesModel} from '../../models/entityTypesModel';
-import {BackendService} from '../../services/backend.service';
-import {IWineryState} from '../../redux/store/winery.store';
-import {NgRedux} from '@angular-redux/store';
-import {isNullOrUndefined} from 'util';
-import {backendBaseURL, hostURL} from '../../models/configuration';
-import {WineryActions} from '../../redux/actions/winery.actions';
-import {ExistsService} from '../../services/exists.service';
-import {ToastrService} from 'ngx-toastr';
-import {DeploymentArtifactOrPolicyModalData, ModalVariant, ModalVariantAndState} from './modal-model';
-import {EntitiesModalService, OpenModalEvent} from './entities-modal.service';
-import {QName} from '../../models/qname';
+import { ModalDirective } from 'ngx-bootstrap';
+import { TPolicy } from '../../models/policiesModalData';
+import { TDeploymentArtifact } from '../../models/artifactsModalData';
+import { QNameWithTypeApiData } from '../../models/generateArtifactApiData';
+import { EntityTypesModel } from '../../models/entityTypesModel';
+import { BackendService } from '../../services/backend.service';
+import { IWineryState } from '../../redux/store/winery.store';
+import { NgRedux } from '@angular-redux/store';
+import { isNullOrUndefined } from 'util';
+import { backendBaseURL, hostURL } from '../../models/configuration';
+import { WineryActions } from '../../redux/actions/winery.actions';
+import { ExistsService } from '../../services/exists.service';
+import { ToastrService } from 'ngx-toastr';
+import { DeploymentArtifactOrPolicyModalData, ModalVariant, ModalVariantAndState } from './modal-model';
+import { EntitiesModalService, OpenModalEvent } from './entities-modal.service';
+import { QName } from '../../models/qname';
 
 @Component({
     selector: 'winery-entities-modal',
@@ -121,11 +113,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
      */
     updateModal() {
         // Ths if statement sets the initial radio button state
-        if (this.modalVariantAndState.modalVariant.toString() === 'policies') {
-            this.modalSelectedRadioButton = 'createPolicyTemplate';
-        } else {
-            this.modalSelectedRadioButton = 'createArtifactTemplate';
-        }
+        this.modalSelectedRadioButton = 'create';
         if (this.entityTypes !== undefined) {
             try {
                 this.deploymentArtifactOrPolicyModalData.artifactTemplates = this.entityTypes.artifactTemplates;
@@ -155,7 +143,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
         this.artifactOrPolicy.localname = this.deploymentArtifactOrPolicyModalData.modalTemplateName;
         this.artifactOrPolicy.namespace = this.deploymentArtifactOrPolicyModalData.modalTemplateNameSpace;
         this.artifactOrPolicy.type = this.deploymentArtifactOrPolicyModalData.modalType;
-        if (this.modalSelectedRadioButton === 'createArtifactTemplate') {
+        if (this.modalSelectedRadioButton === 'create' && this.modalVariantAndState.modalVariant === ModalVariant.DeploymentArtifacts) {
             const deploymentArtifactToBeSavedToRedux: TDeploymentArtifact = new TDeploymentArtifact(
                 [],
                 [],
@@ -181,7 +169,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
                         this.deploymentArtifactOrPolicyModalData.artifactTemplates = artifactTemplates;
                     });
                 });
-        } else if (this.modalSelectedRadioButton === 'createPolicyTemplate') {
+        } else if (this.modalSelectedRadioButton === 'create' && this.modalVariantAndState.modalVariant === ModalVariant.Policies) {
             const policyToBeSavedToRedux: TPolicy = new TPolicy(
                 this.deploymentArtifactOrPolicyModalData.modalName,
                 this.deploymentArtifactOrPolicyModalData.modalTemplateRef,
@@ -218,7 +206,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
                 this.deploymentArtifactOrPolicyModalData.modalTemplateRef
             );
             this.saveDeploymentArtifactsToModel(deploymentArtifactToBeSavedToRedux);
-        } else if (this.modalSelectedRadioButton === 'skip' + 'deployment_artifacts') {
+        } else if (this.modalSelectedRadioButton === 'skip' && this.modalVariantAndState.modalVariant === ModalVariant.DeploymentArtifacts) {
             // without artifactRef
             const deploymentArtifactToBeSavedToRedux: TDeploymentArtifact = new TDeploymentArtifact(
                 [],
@@ -228,7 +216,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
                 this.deploymentArtifactOrPolicyModalData.modalType
             );
             this.saveDeploymentArtifactsToModel(deploymentArtifactToBeSavedToRedux);
-        } else if (this.modalSelectedRadioButton === 'link' + 'policies') {
+        } else if (this.modalSelectedRadioButton === 'link' && this.modalVariantAndState.modalVariant === ModalVariant.Policies) {
             const policyToBeAddedToRedux: TPolicy = new TPolicy(
                 this.deploymentArtifactOrPolicyModalData.modalName,
                 this.deploymentArtifactOrPolicyModalData.modalTemplateRef,
@@ -237,7 +225,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
                 [],
                 {});
             this.savePoliciesToModel(policyToBeAddedToRedux);
-        } else if (this.modalSelectedRadioButton === 'skip' + 'policies') {
+        } else if (this.modalSelectedRadioButton === 'skip' && this.modalVariantAndState.modalVariant === ModalVariant.Policies) {
             // without policyRef
             const policyToBeAddedToRedux: TPolicy = new TPolicy(
                 this.deploymentArtifactOrPolicyModalData.modalName,
@@ -248,8 +236,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
                 {});
             this.savePoliciesToModel(policyToBeAddedToRedux);
         }
-        /*this.newArtifact.operationName = this.deploymentArtifactSelectedOperation;
-        this.createNewDeploymentArtifact();*/
+
         this.resetModalData();
         this.modal.hide();
     }
@@ -258,9 +245,9 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
      * Auto-completes other relevant values when a deployment-artifactOrPolicy or policy type has been selected in
      * the modal
      */
-    onChangeArtifactTypeOrPolicyTypeInModal(artifactTypeOrPolicyType: any, variant: string): void {
+    onChangeArtifactTypeOrPolicyTypeInModal(artifactTypeOrPolicyType: any, variant: ModalVariant): void {
         let artifactTypesOrPolicyTypes: string;
-        variant === 'deployment_artifacts' ? artifactTypesOrPolicyTypes = 'artifactTypes' : artifactTypesOrPolicyTypes = 'policyTypes';
+        variant === ModalVariant.DeploymentArtifacts ? artifactTypesOrPolicyTypes = 'artifactTypes' : artifactTypesOrPolicyTypes = 'policyTypes';
         // change the ones affected
         this.entityTypes[artifactTypesOrPolicyTypes].some(currentlySelectedOne => {
             if (currentlySelectedOne.name === artifactTypeOrPolicyType) {
@@ -276,7 +263,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
      * This is required to figure out which templateName and Ref have to be pushed to the redux state
      * @param template - either an artifactTemplate or a policyTemplate
      */
-    updatedTemplateToBeLinkedInModal(template, modalVariant: string) {
+    updatedTemplateToBeLinkedInModal(template, modalVariant: ModalVariant) {
         const templateObject: any = JSON.parse(template);
         const qNameWithTypeApiData = new QNameWithTypeApiData;
         qNameWithTypeApiData.localname = new QName(templateObject.qName).localName;
@@ -284,13 +271,13 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
         this.deploymentArtifactOrPolicyModalData.modalTemplateNameSpace = templateObject.namespace;
         this.deploymentArtifactOrPolicyModalData.modalTemplateName = templateObject.name;
         this.deploymentArtifactOrPolicyModalData.modalTemplateRef = templateObject.qName;
-        modalVariant === 'deployment_artifacts' ?
+        modalVariant === ModalVariant.DeploymentArtifacts ?
             this.backendService.requestArtifactTemplate(qNameWithTypeApiData).subscribe(
                 (artifactTemplate) => {
                     this.deploymentArtifactOrPolicyModalData.modalType
                         = artifactTemplate.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].type;
                 }) : console.log('Failed to GET this artifactTemplate from the backend');
-        modalVariant === 'policies' ?
+        modalVariant === ModalVariant.Policies ?
             this.backendService.requestPolicyTemplate(qNameWithTypeApiData).subscribe(
                 (policyTemplate) => {
                     this.deploymentArtifactOrPolicyModalData.modalType
@@ -311,7 +298,7 @@ export class EntitiesModalComponent implements OnInit, AfterViewInit, OnChanges 
             this.deploymentArtifactOrPolicyModalData.modalTemplateRef = '{' +
                 this.deploymentArtifactOrPolicyModalData.modalTemplateNameSpace + '}' + this.deploymentArtifactOrPolicyModalData.modalTemplateName;
 
-            if (this.modalVariantAndState.modalVariant === 'policies') {
+            if (this.modalVariantAndState.modalVariant === ModalVariant.Policies) {
                 url = backendBaseURL + '/policytemplates/'
                     + encodeURIComponent(encodeURIComponent(this.deploymentArtifactOrPolicyModalData.modalTemplateNameSpace)) + '/'
                     + this.deploymentArtifactOrPolicyModalData.modalTemplateName + '/';

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/entityTypesModel.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/entityTypesModel.ts
@@ -12,8 +12,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  ********************************************************************************/
 
-import { Entity, EntityType, TTopologyTemplate, VisualEntityType, Visuals } from './ttopology-template';
+import { Entity, EntityType, TTopologyTemplate, VisualEntityType } from './ttopology-template';
 import { TopologyModelerConfiguration } from './topologyModelerConfiguration';
+import { Visuals } from './visuals';
 
 /**
  * Internal representation of entity Types
@@ -26,7 +27,9 @@ export class EntityTypesModel {
     nodeVisuals: Visuals[];
     relationshipVisuals: Visuals[];
     policyTemplates: Entity[];
+    policyTemplateVisuals: Visuals[];
     policyTypes: EntityType[];
+    policyTypeVisuals: Visuals[];
     relationshipTypes: VisualEntityType[];
     requirementTypes: EntityType[];
     unGroupedNodeTypes: EntityType[];

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/topologyModelerConfiguration.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/topologyModelerConfiguration.ts
@@ -17,6 +17,7 @@ export class TopologyModelerConfiguration {
 
     public readonly webSocketUrl: string;
     public readonly definitionsElement: QName;
+    public readonly idPrefix;
     public readonly relationshipPrefix;
 
     constructor(public readonly id: string,
@@ -31,13 +32,13 @@ export class TopologyModelerConfiguration {
         this.definitionsElement = new QName('{' + ns + '}' + id);
 
         if (this.elementPath === 'detector') {
-            this.relationshipPrefix = 'd_';
+            this.idPrefix = 'd_';
         } else if (this.elementPath === 'refinementstructure') {
-            this.relationshipPrefix = 'rs_';
+            this.idPrefix = 'rs_';
         } else {
-            this.relationshipPrefix = '';
+            this.idPrefix = '';
         }
 
-        this.relationshipPrefix += 'con';
+        this.relationshipPrefix = this.idPrefix + 'con';
     }
 }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/topologyModelerInputDataFormat.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/topologyModelerInputDataFormat.ts
@@ -12,8 +12,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  ********************************************************************************/
 
-import { TTopologyTemplate, Visuals } from './ttopology-template';
+import { TTopologyTemplate } from './ttopology-template';
 import { TopologyModelerConfiguration } from './topologyModelerConfiguration';
+import { Visuals } from './visuals';
 
 export interface TopologyModelerInputDataFormat {
     configuration: TopologyModelerConfiguration;

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/ttopology-template.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/ttopology-template.ts
@@ -12,6 +12,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  ********************************************************************************/
 import { DifferenceStates, VersionUtils } from './ToscaDiff';
+import { Visuals } from './visuals';
 
 export class AbstractTTemplate {
     constructor(public documentation?: any,
@@ -182,17 +183,4 @@ export class TRelationshipTemplate extends AbstractTTemplate {
         return relTemplate;
     }
 
-}
-
-/**
- * This is the datamodel for the style of nodes and relationships
- */
-export class Visuals {
-
-    constructor(public color: string,
-                public typeId: string,
-                public localName?: string,
-                public imageUrl?: string,
-                public pattern?: string) {
-    }
 }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/utils.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/utils.ts
@@ -11,10 +11,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  ********************************************************************************/
-import { TNodeTemplate, TRelationshipTemplate, TTopologyTemplate, Visuals } from './ttopology-template';
+import { TNodeTemplate, TRelationshipTemplate, TTopologyTemplate } from './ttopology-template';
 import { QName } from './qname';
 import { isNullOrUndefined } from 'util';
 import { DifferenceStates, ToscaDiff, VersionUtils } from './ToscaDiff';
+import { Visuals } from './visuals';
 
 export class Utils {
 
@@ -86,20 +87,15 @@ export class Utils {
     }
 
     static getNodeVisualsForNodeTemplate(nodeType: string, nodeVisuals: Visuals[], state?: DifferenceStates): Visuals {
-        let color, imageUrl: string;
         for (const visual of nodeVisuals) {
             const qName = new QName(visual.typeId);
             const localName = qName.localName;
             if (localName === new QName(nodeType).localName) {
-                color = isNullOrUndefined(state) ? visual.color : VersionUtils.getElementColorByDiffState(state);
-                imageUrl = visual.imageUrl;
-                if (imageUrl) {
-                    imageUrl = imageUrl.replace('appearance', 'visualappearance');
-                }
+                const color = !state ? visual.color : VersionUtils.getElementColorByDiffState(state);
                 return <Visuals> {
                     color: color,
                     typeId: nodeType,
-                    imageUrl: imageUrl,
+                    imageUrl: visual.imageUrl,
                     pattern: visual.pattern
                 };
             }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/visuals.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/visuals.ts
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+/**
+ * This is the datamodel for the style of nodes and relationships
+ */
+export class Visuals {
+
+    constructor(public color: string,
+                public typeId: string,
+                public localName?: string,
+                public imageUrl?: string,
+                public pattern?: string) {
+    }
+}

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.css
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.css
@@ -176,3 +176,7 @@ button.btn.btn-sm.btn-outline-secondary:hover, button.btn.btn-sm.btn-outline-sec
     border-radius: 2px;
     color: #000;
 }
+
+.policyAnnotation {
+    margin: 3px;
+}

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
@@ -30,6 +30,10 @@
         {{ nodeTemplate.state }}
     </div>
 
+    <div *ngIf="policyIcons">
+        <img *ngFor="let policyIcon of policyIcons" [src]="policyIcon" class="policyAnnotation">
+    </div>
+
     <div *ngIf="nodeClass !== 'pattern'; else showPattern"
          class="row rounded col-sm-12 node-template-header"
          (click)="openSidebar($event); closeConnectorEndpoints($event)">

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
@@ -13,8 +13,8 @@
  ********************************************************************************/
 
 import {
-    AfterViewInit, Component, ComponentRef, DoCheck, ElementRef, EventEmitter, Input, KeyValueDiffers, NgZone, OnDestroy, OnInit, Output,
-    Renderer2
+    AfterViewInit, Component, ComponentRef, DoCheck, ElementRef, EventEmitter, Input, KeyValueDiffers, NgZone,
+    OnDestroy, OnInit, Output, Renderer2
 } from '@angular/core';
 import { animate, keyframes, state, style, transition, trigger } from '@angular/animations';
 import { NgRedux } from '@angular-redux/store';
@@ -29,6 +29,8 @@ import { isNullOrUndefined } from 'util';
 import { GroupedNodeTypeModel } from '../models/groupedNodeTypeModel';
 import { EntityTypesModel } from '../models/entityTypesModel';
 import { TopologyRendererState } from '../redux/reducers/topologyRenderer.reducer';
+import { TPolicy } from '../models/policiesModalData';
+import { Visuals } from '../models/visuals';
 
 /**
  * Every node has its own component and gets created dynamically.
@@ -66,6 +68,7 @@ export class NodeComponent implements OnInit, AfterViewInit, OnDestroy, DoCheck 
     artifactTypes: any;
     removeZIndex: any;
     propertyDefinitionType: string;
+    policyIcons: string[];
 
     @Input() readonly: boolean;
     @Input() entityTypes: EntityTypesModel;
@@ -171,6 +174,36 @@ export class NodeComponent implements OnInit, AfterViewInit, OnDestroy, DoCheck 
         this.differ = this.differs.find([]).create();
         if (!isNullOrUndefined(this.nodeTemplate.visuals)) {
             this.nodeClass = this.nodeTemplate.visuals.pattern ? 'pattern' : 'nodeTemplate';
+        }
+
+        this.nodeClass = this.nodeTemplate.visuals.pattern ? 'pattern' : 'nodeTemplate';
+
+        // todo: refactor to be updated upon addition of a policy
+        if (this.nodeTemplate.policies && this.nodeTemplate.policies.policy) {
+            this.policyIcons = [];
+            const list: TPolicy[] = this.nodeTemplate.policies.policy;
+
+            for (const value of list) {
+                let visual: Visuals;
+                if (value.policyRef) {
+                    visual = this.entityTypes.policyTemplateVisuals
+                        .find(policyVisual => policyVisual.typeId === value.policyRef);
+                }
+
+                if (!visual) {
+                    visual = this.entityTypes.policyTypeVisuals.find(
+                        policyTypeVisual => policyTypeVisual.typeId === value.policyType
+                    );
+                }
+
+                if (visual && visual.imageUrl) {
+                    this.policyIcons.push(this.hostURL + visual.imageUrl);
+                }
+            }
+
+            if (this.policyIcons.length === 0) {
+                this.policyIcons = null;
+            }
         }
     }
 

--- a/org.eclipse.winery.topologymodeler.ui/src/app/palette/palette.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/palette/palette.component.ts
@@ -17,7 +17,7 @@ import { animate, keyframes, state, style, transition, trigger } from '@angular/
 import { WineryActions } from '../redux/actions/winery.actions';
 import { NgRedux } from '@angular-redux/store';
 import { IWineryState } from '../redux/store/winery.store';
-import { TNodeTemplate, Visuals } from '../models/ttopology-template';
+import { TNodeTemplate } from '../models/ttopology-template';
 import { NewNodeIdTypeColorPropertiesModel } from '../models/newNodeIdTypeColorModel';
 import { isNullOrUndefined } from 'util';
 import { Subscription } from 'rxjs';
@@ -25,6 +25,8 @@ import { Utils } from '../models/utils';
 import { EntityTypesModel } from '../models/entityTypesModel';
 import { GroupedNodeTypeModel } from '../models/groupedNodeTypeModel';
 import { hostURL } from '../models/configuration';
+import { Visuals } from '../models/visuals';
+import { BackendService } from '../services/backend.service';
 
 /**
  * This is the left sidebar, where nodes can be created from.
@@ -85,6 +87,7 @@ export class PaletteComponent implements OnDestroy {
     readonly newNodePositionOffsetY = 30;
 
     constructor(private ngRedux: NgRedux<IWineryState>,
+                private backendService: BackendService,
                 private actions: WineryActions) {
         this.subscriptions.push(ngRedux.select(wineryState => wineryState.wineryState.currentJsonTopology.nodeTemplates)
             .subscribe(currentNodes => this.updateNodes(currentNodes)));
@@ -186,7 +189,7 @@ export class PaletteComponent implements OnDestroy {
                         newId = name.concat('_', '2');
                     }
                     return {
-                        id: newId,
+                        id: this.backendService.configuration.idPrefix + newId,
                         type: type,
                         properties: this.getDefaultPropertiesFromNodeTypes(name)
                     };
@@ -210,7 +213,7 @@ export class PaletteComponent implements OnDestroy {
             for (const node of this.entityTypes.unGroupedNodeTypes) {
                 if (node.id === name) {
                     const result = {
-                        id: node.id,
+                        id: this.backendService.configuration.idPrefix + node.id,
                         type: node.qName,
                         properties: this.getDefaultPropertiesFromNodeTypes(name)
                     };

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/actions/winery.actions.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/actions/winery.actions.ts
@@ -14,9 +14,10 @@
 
 import { Action, ActionCreator } from 'redux';
 import { Injectable } from '@angular/core';
-import { TNodeTemplate, TRelationshipTemplate, Visuals } from '../../models/ttopology-template';
+import { TNodeTemplate, TRelationshipTemplate } from '../../models/ttopology-template';
 import { TDeploymentArtifact } from '../../models/artifactsModalData';
 import { TPolicy } from '../../models/policiesModalData';
+import { Visuals } from '../../models/visuals';
 
 export interface SendPaletteOpenedAction extends Action {
     paletteOpened: boolean;

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
@@ -20,8 +20,9 @@ import {
     SetTargetLocation, SidebarMaxInstanceChanges, SidebarMinInstanceChanges, SidebarNodeNamechange, SidebarStateAction, UpdateNodeCoordinatesAction,
     UpdateRelationshipNameAction, WineryActions
 } from '../actions/winery.actions';
-import { TNodeTemplate, TRelationshipTemplate, TTopologyTemplate, Visuals } from '../../models/ttopology-template';
+import { TNodeTemplate, TRelationshipTemplate, TTopologyTemplate } from '../../models/ttopology-template';
 import { TDeploymentArtifact } from '../../models/artifactsModalData';
+import { Visuals } from '../../models/visuals';
 
 export interface WineryState {
     currentPaletteOpenedState: boolean;

--- a/org.eclipse.winery.topologymodeler.ui/src/app/services/backend.service.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/services/backend.service.ts
@@ -16,7 +16,7 @@ import { Injectable } from '@angular/core';
 import { backendBaseURL, hostURL } from '../models/configuration';
 import { Subject } from 'rxjs/Subject';
 import { isNullOrUndefined } from 'util';
-import { EntityType, TTopologyTemplate, Visuals } from '../models/ttopology-template';
+import { EntityType, TTopologyTemplate } from '../models/ttopology-template';
 import { QNameWithTypeApiData } from '../models/generateArtifactApiData';
 import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { urlElement } from '../models/enums';
@@ -27,6 +27,7 @@ import { Observable } from 'rxjs/Observable';
 import { forkJoin } from 'rxjs';
 import { TopologyModelerConfiguration } from '../models/topologyModelerConfiguration';
 import { ErrorHandlerService } from './error-handler.service';
+import { Visuals } from '../models/visuals';
 
 /**
  * Responsible for interchanging data between the app and the server.
@@ -114,6 +115,8 @@ export class BackendService {
             const currentUrl = url + this.configuration.id + '/' + this.configuration.elementPath;
             const nodeVisualsUrl = backendBaseURL + '/nodetypes/allvisualappearancedata';
             const relationshipVisualsUrl = backendBaseURL + '/relationshiptypes/allvisualappearancedata';
+            const policyVisualsUrl = backendBaseURL + '/policytemplates/allvisualappearancedata';
+            const policyTypesVisualsUrl = backendBaseURL + '/policytypes/allvisualappearancedata';
             // This is required because the information has to be returned together
 
             if (isNullOrUndefined(this.configuration.compareTo)) {
@@ -121,6 +124,8 @@ export class BackendService {
                     this.http.get<TTopologyTemplate>(currentUrl),
                     this.http.get<Visuals>(nodeVisualsUrl),
                     this.http.get<Visuals>(relationshipVisualsUrl),
+                    this.http.get<Visuals>(policyVisualsUrl),
+                    this.http.get<Visuals>(policyTypesVisualsUrl)
                 );
             } else {
                 const compareUrl = url
@@ -133,6 +138,8 @@ export class BackendService {
                     this.http.get<TTopologyTemplate>(currentUrl),
                     this.http.get<Visuals>(nodeVisualsUrl),
                     this.http.get<Visuals>(relationshipVisualsUrl),
+                    this.http.get<Visuals>(policyVisualsUrl),
+                    this.http.get<Visuals>(policyTypesVisualsUrl),
                     this.http.get<ToscaDiff>(compareUrl),
                     this.http.get<TTopologyTemplate>(templateUrl)
                 );

--- a/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
@@ -265,8 +265,10 @@ export class WineryComponent implements OnInit, AfterViewInit {
             const topologyTemplate = topologyData[0];
             this.entityTypes.nodeVisuals = topologyData[1];
             this.entityTypes.relationshipVisuals = topologyData[2];
-            if (topologyData.length === 5 && !isNullOrUndefined(topologyData[3]) && !isNullOrUndefined(topologyData[4])) {
-                this.topologyDifferences = [topologyData[3], topologyData[4]];
+            this.entityTypes.policyTemplateVisuals = topologyData[3];
+            this.entityTypes.policyTypeVisuals = topologyData[4];
+            if (topologyData.length === 7 && !isNullOrUndefined(topologyData[5]) && !isNullOrUndefined(topologyData[6])) {
+                this.topologyDifferences = [topologyData[5], topologyData[6]];
             }
             // init the NodeTemplates and RelationshipTemplates to start their rendering
             this.initTopologyTemplate(topologyTemplate.nodeTemplates, topologyTemplate.relationshipTemplates);


### PR DESCRIPTION
Features

- Add Images to Policy Types and Templates
- Show policies as icons at Node Templates
- Add new matcher for subgraphmappings 
- Add Property Mappings for PRMs
<!-- describe the changes you have made here: what, why, ... -->
![image](https://user-images.githubusercontent.com/23058331/50156831-0f05c400-02d0-11e9-8aff-bf37d1a35787.png)


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [ ] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
