### PR TITLE
fix naming convention of tests

### DIFF
--- a/org.eclipse.winery.yaml.converter/src/test/java/org/eclipse/winery/yaml/converter/xml/ShowcaseTest.java
+++ b/org.eclipse.winery.yaml.converter/src/test/java/org/eclipse/winery/yaml/converter/xml/ShowcaseTest.java
@@ -31,8 +31,8 @@ import org.eclipse.winery.yaml.converter.xml.support.AbstractTestX2Y;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class Showcase extends AbstractTestX2Y {
-    public Showcase() {
+public class ShowcaseTest extends AbstractTestX2Y {
+    public ShowcaseTest() {
         super(Paths.get("src/test/resources/xml/Showcase"));
     }
 

--- a/org.eclipse.winery.yaml.converter/src/test/java/org/eclipse/winery/yaml/converter/yaml/DatatypesTest.java
+++ b/org.eclipse.winery.yaml.converter/src/test/java/org/eclipse/winery/yaml/converter/yaml/DatatypesTest.java
@@ -22,9 +22,9 @@ import org.eclipse.winery.yaml.converter.yaml.support.AbstractTestY2X;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class Datatypes extends AbstractTestY2X {
+public class DatatypesTest extends AbstractTestY2X {
 
-    public Datatypes() {
+    public DatatypesTest() {
         super(Paths.get("src/test/resources/yaml/Datatypes"));
     }
 

--- a/org.eclipse.winery.yaml.converter/src/test/java/org/eclipse/winery/yaml/converter/yaml/ShowcasesTest.java
+++ b/org.eclipse.winery.yaml.converter/src/test/java/org/eclipse/winery/yaml/converter/yaml/ShowcasesTest.java
@@ -35,9 +35,9 @@ import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-public class Showcases extends AbstractTestY2X {
+public class ShowcasesTest extends AbstractTestY2X {
 
-    public Showcases() {
+    public ShowcasesTest() {
         super(Paths.get("src/test/resources/yaml/Showcase"));
     }
 


### PR DESCRIPTION
This commit enforces the default naming convention to enable maven to actually find and run tests without configuring maven surefire plugin.
Without this naming scheme no tests are executed during the build.
This is an attempt to fix the failing builds in the jenkins.

Signed-off-by: Julian Sudendorf <julian.sudendorf@gmail.com>

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
