### PR TITLE
Add feature to upload a state for a nodetemplate

### DIFF
--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/version/VersionUtils.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/version/VersionUtils.java
@@ -13,6 +13,7 @@
  ********************************************************************************/
 package org.eclipse.winery.common.version;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,7 +44,8 @@ import io.github.adr.embedded.ADR;
 /**
  * Utility class for working with versions.
  *
- * TODO: DefinitionsChildId specific parts should go into into the DefinitionsChildId to have a true object-oriented thinking
+ * TODO: DefinitionsChildId specific parts should go into into the DefinitionsChildId to have a true object-oriented
+ * thinking
  */
 public class VersionUtils {
 
@@ -195,7 +197,7 @@ public class VersionUtils {
         return ToscaDiff.convertDiffToToscaDiff(diffNode, oldVersion, newVersion);
     }
 
-    public static String getNewId(DefinitionsChildId oldId, String appendixName) {
+    public static String getNewComponentVersionId(DefinitionsChildId oldId, String appendixName) {
         WineryVersion version = VersionUtils.getVersion(oldId);
         String oldVersion = version.toString();
 
@@ -209,5 +211,23 @@ public class VersionUtils {
         version.setWorkInProgressVersion(1);
 
         return VersionUtils.getNameWithoutVersion(oldId) + WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR + version.toString();
+    }
+
+    public static WineryVersion getNewWineryVersion(List<WineryVersion> versions) {
+        WineryVersion[] version = new WineryVersion[1];
+        version[0] = versions.stream().filter(WineryVersion::isCurrentVersion)
+            .findFirst()
+            .orElseThrow(NullPointerException::new);
+
+        if (!version[0].isReleasable()) {
+            versions.forEach(wineryVersion -> {
+                if (Objects.nonNull(version[0].getComponentVersion()) && version[0].getComponentVersion().equals(wineryVersion.getComponentVersion())
+                    && wineryVersion.getWineryVersion() > version[0].getWineryVersion()) {
+                    version[0] = wineryVersion;
+                }
+            });
+        }
+
+        return new WineryVersion(version[0].getComponentVersion(), version[0].getWineryVersion() + 1, 1);
     }
 }

--- a/org.eclipse.winery.common/src/test/java/org/eclipse/winery/common/VersionUtilsTest.java
+++ b/org.eclipse.winery.common/src/test/java/org/eclipse/winery/common/VersionUtilsTest.java
@@ -153,7 +153,7 @@ public class VersionUtilsTest {
         String expectedId = "myId_w1-wip56-" + appendix + "-w1-wip1";
         ServiceTemplateId serviceTemplateId = new ServiceTemplateId("https://ex.org/tosca/sts", id, false);
 
-        assertEquals(expectedId, VersionUtils.getNewId(serviceTemplateId, appendix));
+        assertEquals(expectedId, VersionUtils.getNewComponentVersionId(serviceTemplateId, appendix));
     }
 
     @Test
@@ -163,7 +163,7 @@ public class VersionUtilsTest {
         String expectedId = "myId_component-version-w1-" + appendix + "-w1-wip1";
         ArtifactTypeId serviceTemplateId = new ArtifactTypeId("https://ex.org/tosca/sts", id, false);
 
-        assertEquals(expectedId, VersionUtils.getNewId(serviceTemplateId, appendix));
+        assertEquals(expectedId, VersionUtils.getNewComponentVersionId(serviceTemplateId, appendix));
     }
 
     private DefinitionsChildId getDefinitionChildId(String namespace, String name, String componentVersion, int wineryVersion, int wipVersion) {

--- a/org.eclipse.winery.model.substitution/src/main/java/org/eclipse/winery/model/substitution/AbstractSubstitution.java
+++ b/org.eclipse.winery.model.substitution/src/main/java/org/eclipse/winery/model/substitution/AbstractSubstitution.java
@@ -56,7 +56,7 @@ public class AbstractSubstitution {
         try {
             ServiceTemplateId substitutedServiceTemplateId = new ServiceTemplateId(
                 serviceTemplateId.getNamespace().getDecoded(),
-                VersionUtils.getNewId(serviceTemplateId, versionAppendix),
+                VersionUtils.getNewComponentVersionId(serviceTemplateId, versionAppendix),
                 false
             );
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
@@ -140,7 +140,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPoli
         return deploymentArtifacts;
     }
 
-    public void setDeploymentArtifacts(@Nullable TDeploymentArtifacts value) {
+    public void setDeploymentArtifacts(TDeploymentArtifacts value) {
         this.deploymentArtifacts = value;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/constants/OpenToscaBaseTypes.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/constants/OpenToscaBaseTypes.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.model.tosca.constants;
+
+import javax.xml.namespace.QName;
+
+public class OpenToscaBaseTypes {
+
+    // region ********* base elements *********
+    public static final QName virtualMachineNodeType = QName.valueOf("{http://opentosca.org/baseelements/nodetypes}VM");
+    public static final QName DockerEngineNodeType = QName.valueOf("{http://opentosca.org/baseelements/nodetypes}DockerEngine");
+    // endregion
+
+    // region ********* secure elements *********
+    public static final QName secureProxyContainer = QName.valueOf("{http://opentosca.org/secureelements/nodetypes}SecureProxyContainer");
+    public static final QName secureProxy = QName.valueOf("{http://opentosca.org/secureelements/nodetypes}SecureProxy");
+    // endregion
+
+    public static final QName stateArtifactType = QName.valueOf("{http://opentosca.org/artifacttypes}State");
+}

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/ResourceResult.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/ResourceResult.java
@@ -24,7 +24,7 @@ public class ResourceResult {
     private Status status = null;
     private URI uri = null;
     private GenericId id = null;
-    private String message = null;
+    private Object message = null;
 
     public ResourceResult() {
     }
@@ -67,7 +67,7 @@ public class ResourceResult {
         return this.getStatus() == Status.CREATED || this.getStatus() == Status.OK;
     }
 
-    public void setMessage(String message) {
+    public void setMessage(Object message) {
         this.message = message;
     }
 

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/QNameApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/QNameApiData.java
@@ -14,7 +14,17 @@
 
 package org.eclipse.winery.repository.rest.resources.apiData;
 
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+
 public class QNameApiData {
     public String localname;
     public String namespace;
+
+    public QNameApiData() {
+    }
+
+    public QNameApiData(DefinitionsChildId newId) {
+        this.localname = newId.getXmlId().getDecoded();
+        this.namespace = newId.getNamespace().getDecoded();
+    }
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/artifacts/DeploymentArtifactsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/artifacts/DeploymentArtifactsResource.java
@@ -14,21 +14,24 @@
 
 package org.eclipse.winery.repository.rest.resources.artifacts;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
 import org.eclipse.winery.model.tosca.TDeploymentArtifact;
 import org.eclipse.winery.model.tosca.TDeploymentArtifacts;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.repository.rest.resources._support.INodeTemplateResourceOrNodeTypeImplementationResource;
 
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import org.eclipse.jdt.annotation.NonNull;
 
 public class DeploymentArtifactsResource extends GenericArtifactsResource<DeploymentArtifactResource, TDeploymentArtifact> {
 
     private List<TDeploymentArtifact> deploymentArtifacts;
-
 
     public DeploymentArtifactsResource(TNodeTemplate nodeTemplate, INodeTemplateResourceOrNodeTypeImplementationResource res) {
         this(DeploymentArtifactsResource.getDeploymentArtifacts(nodeTemplate), res);
@@ -42,8 +45,7 @@ public class DeploymentArtifactsResource extends GenericArtifactsResource<Deploy
     /**
      * Determines the list of DAs belonging to the given node template.
      * <p>
-     * If no DAs are existing, an empty list is created in the model for the
-     * node template
+     * If no DAs are existing, an empty list is created in the model for the node template
      */
     private static List<TDeploymentArtifact> getDeploymentArtifacts(TNodeTemplate nodeTemplate) {
         TDeploymentArtifacts deploymentArtifacts = nodeTemplate.getDeploymentArtifacts();
@@ -64,6 +66,11 @@ public class DeploymentArtifactsResource extends GenericArtifactsResource<Deploy
             res.add(r);
         }
         return res;
+    }
+
+    @NonNull
+    public List<TDeploymentArtifact> getDeploymentArtifacts() {
+        return Objects.nonNull(this.deploymentArtifacts) ? this.deploymentArtifacts : new ArrayList<>();
     }
 
     @Override

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/FilesResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytemplates/artifacttemplates/FilesResource.java
@@ -84,10 +84,13 @@ public class FilesResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Response onPost(@FormDataParam("file") InputStream uploadedInputStream, @FormDataParam("file") FormDataContentDisposition fileDetail, @FormDataParam("file") FormDataBodyPart body, @Context UriInfo uriInfo) {
+        return onPost(uploadedInputStream, fileDetail, body, uriInfo, fileDetail.getFileName());
+    }
+
+    public Response onPost(@FormDataParam("file") InputStream uploadedInputStream, @FormDataParam("file") FormDataContentDisposition fileDetail, @FormDataParam("file") FormDataBodyPart body, @Context UriInfo uriInfo, String fileName) {
         // existence check not required as instantiation of the resource ensures that the object only exists if the resource exists
         FilesResource.LOGGER.debug("Beginning with file upload");
 
-        String fileName = fileDetail.getFileName();
         if (StringUtils.isEmpty(fileName)) {
             return Response.status(Status.BAD_REQUEST).build();
         }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/NodeTemplateResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/NodeTemplateResource.java
@@ -13,31 +13,66 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.servicetemplates.topologytemplates;
 
-import io.swagger.annotations.ApiOperation;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.ids.Namespace;
+import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
+import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
+import org.eclipse.winery.common.version.VersionUtils;
+import org.eclipse.winery.common.version.WineryVersion;
+import org.eclipse.winery.model.tosca.TDeploymentArtifact;
+import org.eclipse.winery.model.tosca.TDeploymentArtifacts;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.constants.Namespaces;
+import org.eclipse.winery.model.tosca.constants.OpenToscaBaseTypes;
+import org.eclipse.winery.repository.backend.BackendUtils;
+import org.eclipse.winery.repository.backend.IRepository;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.INodeTemplateResourceOrNodeTypeImplementationResource;
 import org.eclipse.winery.repository.rest.resources._support.IPersistable;
 import org.eclipse.winery.repository.rest.resources._support.collections.IIdDetermination;
+import org.eclipse.winery.repository.rest.resources.apiData.QNameWithTypeApiData;
 import org.eclipse.winery.repository.rest.resources.artifacts.DeploymentArtifactsResource;
 import org.eclipse.winery.repository.rest.resources.entitytemplates.TEntityTemplateResource;
+import org.eclipse.winery.repository.rest.resources.entitytemplates.artifacttemplates.ArtifactTemplateResource;
+import org.eclipse.winery.repository.rest.resources.entitytemplates.artifacttemplates.ArtifactTemplatesResource;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.ServiceTemplateResource;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
-import javax.xml.namespace.QName;
-import java.util.List;
-import java.util.Map;
+import com.sun.jersey.core.header.FormDataContentDisposition;
+import com.sun.jersey.multipart.FormDataBodyPart;
+import com.sun.jersey.multipart.FormDataParam;
+import io.swagger.annotations.ApiOperation;
 
 public class NodeTemplateResource extends TEntityTemplateResource<TNodeTemplate> implements INodeTemplateResourceOrNodeTypeImplementationResource {
 
     private final QName qnameX = new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "x");
     private final QName qnameY = new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "y");
+    private final TNodeTemplate nodeTemplate;
 
     public NodeTemplateResource(IIdDetermination<TNodeTemplate> idDetermination, TNodeTemplate o, int idx, List<TNodeTemplate> list, IPersistable res) {
         super(idDetermination, o, idx, list, res);
+        this.nodeTemplate = o;
     }
 
     @Path("deploymentartifacts/")
@@ -116,6 +151,81 @@ public class NodeTemplateResource extends TEntityTemplateResource<TNodeTemplate>
     public Namespace getNamespace() {
         // TODO Auto-generated method stub
         throw new IllegalStateException("Not yet implemented.");
+    }
+
+    @POST
+    @Path("state")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Response createStateElement(@FormDataParam("file") InputStream uploadedInputStream, @FormDataParam("file")
+        FormDataContentDisposition fileDetail, @FormDataParam("file") FormDataBodyPart body, @Context UriInfo uriInfo) {
+        // ensure that the artifact type exists.
+        IRepository repo = RepositoryFactory.getRepository();
+        repo.getElement(new ArtifactTypeId(OpenToscaBaseTypes.stateArtifactType));
+
+        // create DA
+        Optional<TDeploymentArtifact> stateDeploymentArtifact = this.getDeploymentArtifacts().getDeploymentArtifacts().stream()
+            .filter(artifact -> artifact.getArtifactType().equals(OpenToscaBaseTypes.stateArtifactType))
+            .findFirst();
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmm");
+
+        TDeploymentArtifact deploymentArtifact = new TDeploymentArtifact();
+        deploymentArtifact.setArtifactType(OpenToscaBaseTypes.stateArtifactType);
+        deploymentArtifact.setName("state");
+
+        String componentVersion = dateFormat.format(new Date());
+        ArtifactTemplateId newArtifactTemplateId = new ArtifactTemplateId(
+            "http://opentosca.org/artifacttemplates",
+            this.getServiceTemplateResource().getServiceTemplate().getName() + "-" + this.nodeTemplate.getId() + "-State"
+                + WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR + componentVersion
+                + WineryVersion.WINERY_VERSION_SEPARATOR + WineryVersion.WINERY_VERSION_PREFIX + "1"
+            , false
+        );
+
+        // if there is already a state artifact, update the file
+        if (stateDeploymentArtifact.isPresent()) {
+            deploymentArtifact = stateDeploymentArtifact.get();
+
+            // create new ArtifactTemplate version
+            ArtifactTemplateId oldArtifactTemplateId = new ArtifactTemplateId(deploymentArtifact.getArtifactRef());
+            List<WineryVersion> versions = BackendUtils.getAllVersionsOfOneDefinition(oldArtifactTemplateId);
+            WineryVersion newWineryVersion = VersionUtils.getNewWineryVersion(versions);
+            newWineryVersion.setWorkInProgressVersion(0);
+            newWineryVersion.setComponentVersion(componentVersion);
+
+            newArtifactTemplateId = (ArtifactTemplateId) VersionUtils.getDefinitionInTheGivenVersion(
+                oldArtifactTemplateId,
+                newWineryVersion
+            );
+        } else {
+            new ArtifactTemplatesResource()
+                .onJsonPost(new QNameWithTypeApiData(
+                    newArtifactTemplateId.getQName().getLocalPart(),
+                    newArtifactTemplateId.getQName().getNamespaceURI(),
+                    OpenToscaBaseTypes.stateArtifactType.toString()
+                ));
+
+            TDeploymentArtifacts list = this.nodeTemplate.getDeploymentArtifacts();
+            if (Objects.nonNull(list)) {
+                list = new TDeploymentArtifacts();
+                this.nodeTemplate.setDeploymentArtifacts(list);
+            }
+
+            list.getDeploymentArtifact().add(deploymentArtifact);
+        }
+
+        deploymentArtifact.setArtifactRef(newArtifactTemplateId.getQName());
+
+        Response response = new ArtifactTemplateResource(newArtifactTemplateId)
+            .getFilesResource()
+            .onPost(uploadedInputStream, fileDetail, body, uriInfo, this.nodeTemplate.getId() + ".state");
+
+        if (response.getStatus() != Response.Status.CREATED.getStatusCode()) {
+            return response;
+        }
+
+        return RestUtils.persist(this.res);
     }
 
     /**

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
@@ -269,6 +269,14 @@ public abstract class AbstractResourceTest extends TestWithGitBackedRepository {
             .statusCode(201);
     }
 
+    protected void assertNoContentPost(String restUrl, Path file) {
+        start()
+            .multiPart(file.toFile())
+            .post(callURL(restUrl))
+            .then()
+            .statusCode(204);
+    }
+
     protected void assertDelete(String restURL) {
         try {
             start()
@@ -287,7 +295,16 @@ public abstract class AbstractResourceTest extends TestWithGitBackedRepository {
             .statusCode(204);
     }
 
-    public static String replacePathStringEncoding(String toConvert) {
+    protected static String replacePathStringEncoding(String toConvert) {
         return toConvert.replace("%3A", "%253A").replace("%2F", "%252F");
+    }
+
+    protected void assertPostWithOverwrite(String restUrl, Path file, boolean overwrite) {
+        start()
+            .multiPart(file.toFile())
+            .formParam("overwrite", overwrite)
+            .post(callURL(restUrl))
+            .then()
+            .statusCode(201);
     }
 }

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
@@ -307,4 +307,16 @@ public abstract class AbstractResourceTest extends TestWithGitBackedRepository {
             .then()
             .statusCode(201);
     }
+
+    protected String assertPostWithNoContent(String restUrl) {
+        return start()
+            .accept(ContentType.JSON.toString())
+            .post(callURL(restUrl))
+            .then()
+            .statusCode(201)
+            .extract()
+            .response()
+            .body()
+            .asString();
+    }
 }

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/MainResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/MainResourceTest.java
@@ -21,15 +21,6 @@ import java.nio.file.Path;
 
 public class MainResourceTest extends AbstractResourceTest {
 
-    protected void assertPostWithOverwrite(String restUrl, Path file, boolean overwrite) {
-        start()
-            .multiPart(file.toFile())
-            .formParam("overwrite", overwrite)
-            .post(callURL(restUrl))
-            .then()
-            .statusCode(201);
-    }
-
     @Test
     @Ignore("The NamespaceManager does not reload Namespaces.properties upon each change. Thus, this tests fails under certain conditions -- winery-defs-for_servicetemplates-ImportCsarWithOverwriteTest vs. winery-defs-for_servicetemplates1-ImportCsarWithOverwriteTest")
     public void importCSARTestWithOverwrite() throws Exception {

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/servicetemplates/ServiceTemplateResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/servicetemplates/ServiceTemplateResourceTest.java
@@ -14,10 +14,17 @@
 package org.eclipse.winery.repository.rest.resources.servicetemplates;
 
 import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
+import org.eclipse.winery.common.version.VersionUtils;
+import org.eclipse.winery.common.version.WineryVersion;
 import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
+import org.eclipse.winery.repository.rest.resources.apiData.QNameApiData;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.eclipse.jdt.annotation.Checks.assertNonNull;
+import static org.junit.Assert.assertTrue;
 
 public class ServiceTemplateResourceTest extends AbstractResourceTest {
 
@@ -131,5 +138,18 @@ public class ServiceTemplateResourceTest extends AbstractResourceTest {
     public void getListWithComponentVersionsOnly() throws Exception {
         this.setRevisionTo("20f6d0afd4395ab83f059cb5fabbb08218c9fcbd");
         this.assertGet("servicetemplates?grouped=angularSelect&includeVersions=componentVersionOnly", "servicetemplates/listWithComponentVersionsOnly.json");
+    }
+
+    @Test
+    public void createNewStatefulVersion() throws Exception {
+        this.setRevisionTo("eb37f5cfec50c046985eac308e46482ce8bea8e3");
+        String response = this.assertPostWithNoContent("servicetemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fservicetemplates/ServiceTemplateWithOneNodeTemplate_w1-wip1/createnewstatefulversion");
+
+        QNameApiData newId = new ObjectMapper().readValue(response, QNameApiData.class);
+
+        assertNonNull(newId);
+        WineryVersion version = VersionUtils.getVersion(newId.localname);
+        assertNonNull(version);
+        assertTrue(version.getComponentVersion().startsWith("stateful-w1-wip1-"));
     }
 }

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/NodeTemplateResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/NodeTemplateResourceTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.rest.resources.servicetemplates.topologytemplates;
+
+import java.nio.file.Path;
+
+import org.eclipse.winery.model.tosca.TDeploymentArtifact;
+import org.eclipse.winery.model.tosca.TDeploymentArtifacts;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.constants.OpenToscaBaseTypes;
+import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.junit.Test;
+
+import static org.eclipse.jdt.annotation.Checks.assertNonNull;
+import static org.junit.Assert.assertEquals;
+
+public class NodeTemplateResourceTest extends AbstractResourceTest {
+
+    @Test
+    public void addStateArtifactToNodeTemplate() throws Exception {
+        this.setRevisionTo("origin/plain");
+
+        Path filePath = MavenTestingUtils.getProjectFilePath("src/test/resources/servicetemplates/plan.zip");
+        this.assertNoContentPost("servicetemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fservicetemplates/ServiceTemplateWithOneNodeTemplate_w1-wip1/"
+                + "topologytemplate/nodetemplates/NodeTypeWith5Versions_0_3.4-w3-wip1/state",
+            filePath);
+
+        String s = start()
+            .accept(ContentType.JSON.toString())
+            .get(callURL("servicetemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fservicetemplates/ServiceTemplateWithOneNodeTemplate_w1-wip1/" +
+                "topologytemplate/nodetemplates/NodeTypeWith5Versions_0_3.4-w3-wip1"))
+            .then()
+            .log()
+            .ifValidationFails()
+            .statusCode(200)
+            .extract()
+            .response()
+            .getBody()
+            .asString();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        TNodeTemplate nodeTemplate = objectMapper.readValue(s, TNodeTemplate.class);
+
+        TDeploymentArtifacts deploymentArtifacts = nodeTemplate.getDeploymentArtifacts();
+        assertNonNull(deploymentArtifacts);
+        TDeploymentArtifact deploymentArtifact = deploymentArtifacts.getDeploymentArtifact("state");
+        assertNonNull(deploymentArtifact);
+        assertEquals(OpenToscaBaseTypes.stateArtifactType, deploymentArtifact.getArtifactType());
+    }
+}

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/splitting/Splitting.java
@@ -83,7 +83,7 @@ public class Splitting {
         // create wrapper service template
         ServiceTemplateId splitServiceTemplateId = new ServiceTemplateId(
             id.getNamespace().getDecoded(),
-            VersionUtils.getNewId(id, "split"),
+            VersionUtils.getNewComponentVersionId(id, "split"),
             false);
 
         repository.forceDelete(splitServiceTemplateId);
@@ -102,7 +102,7 @@ public class Splitting {
         // create wrapper service template
         ServiceTemplateId matchedServiceTemplateId = new ServiceTemplateId(
             id.getNamespace().getDecoded(),
-            VersionUtils.getNewId(id, "split-matched"),
+            VersionUtils.getNewComponentVersionId(id, "split-matched"),
             false);
 
         repository.forceDelete(matchedServiceTemplateId);
@@ -180,7 +180,7 @@ public class Splitting {
         // create wrapper service template
         ServiceTemplateId matchedServiceTemplateId = new ServiceTemplateId(
             id.getNamespace().getDecoded(),
-            VersionUtils.getNewId(id, "matched"),
+            VersionUtils.getNewComponentVersionId(id, "matched"),
             false);
 
         RepositoryFactory.getRepository().forceDelete(matchedServiceTemplateId);


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
### Description
This adds the functionality to update the model during runtime with a state snapshot for a particular Node Template.
Therefore it also provides an endpoint to create a new stateful version of the current Service Template.

@nyuuyn:
- The endpoint to upload a state for a Node Template is the following: `/servicetemplates/{ns}/{id}/topologytemplate/nodetemplates/{id}/state`.
- The endpoint to create a new stateful ST version is: `/servicetemplates/{ns}/{id}/createnewstatefulversion`
    - Return type: `{ localname: string, namspace: string }`


### Checks
- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
