### PR TITLE
Add xml response

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/QNameApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/QNameApiData.java
@@ -14,8 +14,11 @@
 
 package org.eclipse.winery.repository.rest.resources.apiData;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
 import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
 
+@XmlRootElement(name = "QName")
 public class QNameApiData {
     public String localname;
     public String namespace;

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/ServiceTemplateResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/ServiceTemplateResource.java
@@ -320,7 +320,7 @@ public class ServiceTemplateResource extends AbstractComponentInstanceResourceCo
 
     @POST()
     @Path("createnewstatefulversion")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces( {MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public Response createNewStatefulVersion() {
         ServiceTemplateId id = (ServiceTemplateId) this.getId();
         WineryVersion version = VersionUtils.getVersion(id);

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
@@ -308,9 +308,9 @@ public abstract class AbstractResourceTest extends TestWithGitBackedRepository {
             .statusCode(201);
     }
 
-    protected String assertPostWithNoContent(String restUrl) {
+    protected String assertPostWithNoContent(String restUrl, ContentType contentType) {
         return start()
-            .accept(ContentType.JSON.toString())
+            .accept(contentType)
             .post(callURL(restUrl))
             .then()
             .statusCode(201)

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/servicetemplates/ServiceTemplateResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/servicetemplates/ServiceTemplateResourceTest.java
@@ -20,6 +20,7 @@ import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
 import org.eclipse.winery.repository.rest.resources.apiData.QNameApiData;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -143,7 +144,7 @@ public class ServiceTemplateResourceTest extends AbstractResourceTest {
     @Test
     public void createNewStatefulVersion() throws Exception {
         this.setRevisionTo("eb37f5cfec50c046985eac308e46482ce8bea8e3");
-        String response = this.assertPostWithNoContent("servicetemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fservicetemplates/ServiceTemplateWithOneNodeTemplate_w1-wip1/createnewstatefulversion");
+        String response = this.assertPostWithNoContent("servicetemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fservicetemplates/ServiceTemplateWithOneNodeTemplate_w1-wip1/createnewstatefulversion", ContentType.JSON);
 
         QNameApiData newId = new ObjectMapper().readValue(response, QNameApiData.class);
 
@@ -151,5 +152,11 @@ public class ServiceTemplateResourceTest extends AbstractResourceTest {
         WineryVersion version = VersionUtils.getVersion(newId.localname);
         assertNonNull(version);
         assertTrue(version.getComponentVersion().startsWith("stateful-w1-wip1-"));
+    }
+
+    @Test
+    public void createNewStatefulVersionAndGetXml() throws Exception {
+        this.setRevisionTo("eb37f5cfec50c046985eac308e46482ce8bea8e3");
+        this.assertPostWithNoContent("servicetemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fservicetemplates/ServiceTemplateWithOneNodeTemplate_w1-wip1/createnewstatefulversion", ContentType.XML);
     }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
To use this feature in the container, we need XML support for the new stateful version feature (see https://github.com/eclipse/winery/pull/393#issuecomment-458231805).
This PR adds XML support. @nyuuyn 


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
