### PR TITLE
Feature/frontent integration of multiple repositories

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2017 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -11,13 +11,109 @@
   ~
   ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<h4>Manage Git Repositories</h4>
+<div>
+    <winery-table [columns]="columns"
+                  [data]="repositories"
+                  (addBtnClicked)="onAddClick()"
+                  (removeBtnClicked)="onRemoveClick($event)">
+    </winery-table>
+    <div *ngIf="cloning">
+        <div class="smallLoader"></div>
+    </div>
+
+    <winery-modal bsModal #confirmDeleteModal="bs-modal" [modalRef]="confirmDeleteModal">
+        <winery-modal-header [title]="'Remove Git Repository'"></winery-modal-header>
+        <winery-modal-body>
+            <!--
+                The following lines are used to Delete a Repository, but because of untreated dependencies in Topologies it's not ready to use
+            -->
+            <!--<p *ngIf="elementToRemove != null" id="diagyesnomsg">
+                Do you want to delete this Repository: <span
+                style="font-weight:bold;">{{ elementToRemove.name }}</span>?
+            </p>-->
+            Not working yet!
+        </winery-modal-body>
+        <!--<winery-modal-footer (onOk)="deleteRepository();"
+                             [closeButtonLabel]="'OK'"
+                             [okButtonLabel]="'Yes'">
+        </winery-modal-footer>-->
+    </winery-modal>
+
+    <winery-modal bsModal #addModal="bs-modal" [modalRef]="addModal">
+        <winery-modal-header [title]="'Add Git Repository'"></winery-modal-header>
+        <winery-modal-body>
+            <form #addTypeForm="ngForm" id="addRepositoryForm">
+                <div *ngIf="newRepository">
+                    <div class="form-group">
+                        <label class="control-label" for="name">Name</label>
+                        <input #name="ngModel"
+                               id="name"
+                               class="form-control"
+                               type="text"
+                               name="name"
+                               autocomplete=off
+                               required
+                               [(ngModel)]="newRepository.name"/>
+                        <div *ngIf="name.errors && (name.dirty || name.touched)" class="alert alert-danger">
+                            <div [hidden]="!name.errors.wineryDuplicateValidator">
+                                No duplicates allowed!
+                            </div>
+                            <div [hidden]="!name.errors.required">
+                                Name is required
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="control-label" for="url">URL</label>
+                        <input #url="ngModel"
+                               id="url"
+                               class="form-control"
+                               type="text"
+                               name="url"
+                               autocomplete=off
+                               required
+                               [(ngModel)]="newRepository.url"/>
+                        <div *ngIf="url.errors && (url.dirty || url.touched)" class="alert alert-danger">
+                            <div [hidden]="!url.errors.required">
+                                URL is required
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="control-label" for="branch">Branch</label>
+                        <input #branch="ngModel"
+                               id="branch"
+                               class="form-control"
+                               type="text"
+                               name="branch"
+                               autocomplete=off
+                               required
+                               [(ngModel)]="newRepository.branch"/>
+                        <div *ngIf="url.errors && (branch.dirty || url.touched)" class="alert alert-danger">
+                            <div [hidden]="!branch.errors.required">
+                                Branch is required
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </winery-modal-body>
+        <winery-modal-footer (onOk)="addRepository(); addTypeForm.reset();"
+                             [closeButtonLabel]="'Cancel'"
+                             [okButtonLabel]="'Add'"
+                             [disableOkButton]="!addTypeForm?.form.valid">
+        </winery-modal-footer>
+    </winery-modal>
+</div>
+<hr>
 <h4>General Repository Commands</h4>
 <div>
     <a [attr.href]=" path + '/?dump'" class="btn btn-primary">Dump Repository</a>
     <button class="btn btn-danger" (click)="clearRepository();" id="btnclearrepository" data-loading-text="Deleting...">
         Clear Repository
     </button>
-    <button class="btn btn-default" (click)="uploaderModal.show()">Import Repository</button>
+    <button class="btn btn-default" (click)="uploaderModal.show()">Import Zip Repository</button>
 </div>
 
 <winery-modal bsModal #uploaderModal="bs-modal" [modalRef]="uploaderModal">

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,26 +13,114 @@
  *******************************************************************************/
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { RepositoryService } from './repository.service';
+import { Repository } from './repository';
 import { WineryNotificationService } from '../../../wineryNotificationModule/wineryNotification.service';
 import { backendBaseURL } from '../../../configuration';
 import { ModalDirective } from 'ngx-bootstrap';
 import { HttpErrorResponse } from '@angular/common/http';
+import { WineryValidatorObject } from '../../../wineryValidators/wineryDuplicateValidator.directive';
+import { isNullOrUndefined } from 'util';
 
 @Component({
     selector: 'winery-instance-repository',
-    templateUrl: 'repository.component.html'
+    templateUrl: 'repository.component.html',
+    providers: [RepositoryService],
 })
 export class RepositoryComponent implements OnInit {
 
+    loading = true;
+    repositories: Array<Repository> = [];
+    newRepository: Repository = new Repository();
+    validatorObjectName: WineryValidatorObject;
+    validatorObjectUrl: WineryValidatorObject;
+    validatorObjectBranch: WineryValidatorObject;
+    columns = [
+        { title: 'Name', name: 'name' },
+        { title: 'Git Repository', name: 'url' },
+        { title: 'Branch', name: 'branch' }
+    ];
+    elementToRemove: any;
+    cloning = false;
+
     @ViewChild('uploaderModal') uploaderModal: ModalDirective;
+    @ViewChild('addModal') addModal: ModalDirective;
+    @ViewChild('confirmDeleteModal') confirmDeleteModal: ModalDirective;
     path: string;
 
     constructor(private service: RepositoryService,
                 private notify: WineryNotificationService) {
     }
 
+    getRepositories() {
+        this.service.getAllRepositories().subscribe(
+            data => {
+                this.repositories = data;
+                this.validatorObjectName = new WineryValidatorObject(this.repositories, 'name');
+                this.validatorObjectUrl = new WineryValidatorObject(this.repositories, 'url');
+                this.validatorObjectBranch = new WineryValidatorObject(this.repositories, 'branch');
+            },
+            error => this.notify.error(error.toString())
+        );
+    }
+
     ngOnInit() {
         this.path = backendBaseURL + this.service.path + '/';
+        this.getRepositories();
+    }
+
+    addRepository() {
+        this.repositories.push(this.newRepository);
+        this.save();
+    }
+
+    onAddClick() {
+        this.newRepository = new Repository(null, null, null);
+        this.validatorObjectName.isActive = true;
+        this.addModal.show();
+    }
+
+    onRemoveClick(data: any) {
+        if (isNullOrUndefined(data)) {
+            return;
+        } else {
+            this.elementToRemove = data;
+            this.confirmDeleteModal.show();
+        }
+    }
+
+    save() {
+        this.cloning = true;
+        this.service.postRepositories(this.repositories).subscribe(
+            data => this.handleSave(),
+            error => this.handleError(error)
+        );
+    }
+
+    deleteRepository() {
+        this.confirmDeleteModal.hide();
+        this.deleteItem(this.elementToRemove);
+        this.elementToRemove = null;
+        this.save();
+    }
+
+    private deleteItem(itemToDelete: Repository): void {
+        const list = this.repositories;
+        for (let i = 0; i < list.length; i++) {
+            if (list[i].name === itemToDelete.name) {
+                list.splice(i, 1);
+            }
+        }
+    }
+
+    private handleSave() {
+        this.cloning = false;
+        this.handleSuccess('Saved changes on server');
+        this.getRepositories();
+    }
+
+    private handleRemove() {
+        this.handleSuccess('Removed repository from server');
+        this.getRepositories();
     }
 
     clearRepository() {
@@ -43,11 +131,11 @@ export class RepositoryComponent implements OnInit {
     }
 
     handleSuccess(message: string) {
+        this.loading = false;
         this.notify.success(message);
     }
 
     handleError(error: HttpErrorResponse) {
-        this.notify.error(error.message);
+        this.notify.error(error.message, 'Error');
     }
-
 }

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.module.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.module.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,16 +11,22 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-import {NgModule} from '@angular/core';
-import {RepositoryComponent} from './repository.component';
-import {WineryUploaderModule} from '../../../wineryUploader/wineryUploader.module';
-import {RepositoryService} from './repository.service';
-import {WineryModalModule} from '../../../wineryModalModule/winery.modal.module';
+import { NgModule } from '@angular/core';
+import { RepositoryComponent } from './repository.component';
+import { WineryUploaderModule } from '../../../wineryUploader/wineryUploader.module';
+import { RepositoryService } from './repository.service';
+import { WineryModalModule } from '../../../wineryModalModule/winery.modal.module';
+import { WineryTableModule } from '../../../wineryTableModule/wineryTable.module';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
 
 @NgModule({
     imports: [
+        WineryTableModule,
         WineryUploaderModule,
-        WineryModalModule
+        WineryModalModule,
+        FormsModule,
+        CommonModule
     ],
     exports: [RepositoryComponent],
     declarations: [RepositoryComponent],

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.service.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.service.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,7 +15,8 @@ import { Injectable } from '@angular/core';
 import { backendBaseURL } from '../../../configuration';
 import { Observable } from 'rxjs';
 import { Router } from '@angular/router';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { Repository } from './repository';
 
 @Injectable()
 export class RepositoryService {
@@ -35,4 +36,17 @@ export class RepositoryService {
             );
     }
 
+    getAllRepositories(): Observable<Repository[]> {
+        return this.http.get<Repository[]>(backendBaseURL + this.path + '/repositories');
+    }
+
+    postRepositories(repository: Repository[]): Observable<HttpResponse<string>> {
+        const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+        return this.http
+            .post(
+                backendBaseURL + this.path + '/repositories',
+                repository,
+                { headers: headers, observe: 'response', responseType: 'text' }
+            );
+    }
 }

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.ts
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+export class Repository {
+    name: string;
+    url: string;
+    branch: string;
+
+    constructor(pName= '', pUrl = '', pBranch = '') {
+        this.name = pName;
+        this.url = pUrl;
+        this.branch = pBranch;
+    }
+}

--- a/org.eclipse.winery.frontends/app/tosca-management/src/css/wineryCommon.css
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/css/wineryCommon.css
@@ -145,6 +145,15 @@ div.orionxmleditordiv {
     animation: spin 1s linear infinite;
 }
 
+.smallLoader {
+    border: 4px solid #f3f3f3; /* Light grey */
+    border-top: 4px solid #3498db; /* Blue */
+    border-radius: 50%;
+    width: 25px;
+    height: 25px;
+    animation: spin 1s linear infinite;
+}
+
 @keyframes spin {
     0% {
         transform: rotate(0deg);

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/RepositoryAdminResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/admin/RepositoryAdminResource.java
@@ -13,18 +13,29 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.admin;
 
-import com.sun.jersey.core.header.FormDataContentDisposition;
-import com.sun.jersey.multipart.FormDataParam;
-import org.eclipse.winery.repository.backend.IRepositoryAdministration;
-import org.eclipse.winery.repository.backend.RepositoryFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+
+import org.eclipse.winery.repository.backend.IRepositoryAdministration;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.backend.filebased.RepositoryConfigurationManager;
+import org.eclipse.winery.repository.backend.filebased.RepositoryProperties;
+
+import com.sun.jersey.core.header.FormDataContentDisposition;
+import com.sun.jersey.multipart.FormDataParam;
 
 public class RepositoryAdminResource {
 
@@ -54,5 +65,31 @@ public class RepositoryAdminResource {
             }
         };
         return Response.ok().header("Content-Disposition", "attachment;filename=\"repository.zip\"").type(org.eclipse.winery.common.constants.MimeTypes.MIMETYPE_ZIP).entity(so).build();
+    }
+
+    /**
+     * returns List of Repositories to frontend
+     *
+     * @return List of Repositories
+     */
+    @GET
+    @Path("repositories")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<RepositoryProperties> getRepositoriesAsJson() {
+        return RepositoryConfigurationManager.getRepositoriesFromFile();
+    }
+
+    /**
+     * get Repositories from frontend
+     */
+    @POST
+    @Path("repositories")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response addRepository(List<RepositoryProperties> repositoriesList) {
+        if (repositoriesList == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("repositories list must be given.").build();
+        }
+        RepositoryConfigurationManager.addRepositoryToFile(repositoriesList);
+        return Response.ok().build();
     }
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Constants.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/Constants.java
@@ -77,7 +77,7 @@ public class Constants {
     public static final String TOSCA_PLANTYPE_BUILD_PLAN = "http://docs.oasis-open.org/tosca/ns/2011/12/PlanTypes/BuildPlan";
     public static final String TOSCA_PLANTYPE_TERMINATION_PLAN = "http://docs.oasis-open.org/tosca/ns/2011/12/PlanTypes/TerminationPlan";
     public static final String TOSCA_PLANTYPE_MANAGEMENT_PLAN = "http://opentosca.org/tosca/plantypes/management";
-    
+
     public static final String DIRNAME_SELF_SERVICE_METADATA = "SELFSERVICE-Metadata";
 
     public static final String LICENSE_FILE_NAME = "LICENSE";

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
@@ -138,6 +138,7 @@ import org.eclipse.winery.repository.GitInfo;
 import org.eclipse.winery.repository.JAXBSupport;
 import org.eclipse.winery.repository.backend.constants.Filename;
 import org.eclipse.winery.repository.backend.constants.MediaTypes;
+import org.eclipse.winery.repository.backend.filebased.FilebasedRepository;
 import org.eclipse.winery.repository.backend.filebased.GitBasedRepository;
 import org.eclipse.winery.repository.backend.xsd.XsdImportManager;
 import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateFilesDirectoryId;
@@ -1647,9 +1648,15 @@ public class BackendUtils {
         versionList.get(0).setReleasable(true);
 
         if (current[0].isVersionedInWinery() && RepositoryFactory.getRepository() instanceof GitBasedRepository) {
-            GitBasedRepository gitRepo = (GitBasedRepository) RepositoryFactory.getRepository();
-            boolean changesInFile = gitRepo.hasChangesInFile(BackendUtils.getRefOfDefinitions(id));
-
+            boolean changesInFile = false;
+            for (FilebasedRepository repo : RepositoryFactory.repositoryList) {
+                if (repo.getClass().equals(GitBasedRepository.class)) {
+                    GitBasedRepository gitRepo = (GitBasedRepository) repo;
+                    if (gitRepo.hasChangesInFile(BackendUtils.getRefOfDefinitions(id))) {
+                        changesInFile = true;
+                    }
+                }
+            }
             if (!current[0].isLatestVersion()) {
                 // The current version may still be releasable, if it's the latest WIP version of a component version.
                 List<WineryVersion> collect = versionList.stream()

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/RepositoryFactory.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/RepositoryFactory.java
@@ -16,6 +16,8 @@ package org.eclipse.winery.repository.backend;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -32,6 +34,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RepositoryFactory {
+
+    public static List<FilebasedRepository> repositoryList = new ArrayList<>();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryFactory.class);
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/FileUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/FileUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2013 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,15 +13,21 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.backend.filebased;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
 
@@ -29,10 +35,9 @@ public class FileUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
 
-
     /**
-     * Deletes given path. If path a file, it is directly deleted. If it is a
-     * directory, the directory is recursively deleted.
+     * Deletes given path. If path a file, it is directly deleted. If it is a directory, the directory is recursively
+     * deleted.
      * <p>
      * Does not try to change read-only files to read-write files
      * <p>
@@ -83,8 +88,7 @@ public class FileUtils {
     }
 
     /**
-     * Creates the given directory including its parent directories, if they do
-     * not exist.
+     * Creates the given directory including its parent directories, if they do not exist.
      */
     public static void createDirectory(Path path) throws IOException {
         Path parent = path.getParent();
@@ -99,10 +103,105 @@ public class FileUtils {
         }
     }
 
+    /**
+     * Copy every file from source to target except those listed in ignoreFiles
+     */
+    public static void copyFiles(Path source, Path target, List<String> ignoreFiles) {
+        if (Files.isDirectory(source) && Files.isDirectory(target)) {
+            try {
+                Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
+
+                    @Override
+                    public synchronized FileVisitResult preVisitDirectory(Path file, BasicFileAttributes attrs) {
+                        Path newDir = target.resolve(source.relativize(file));
+
+                        if (ignoreFiles.contains(file.getFileName().toString())) {
+                            return FileVisitResult.SKIP_SUBTREE;
+                        } else {
+                            try {
+                                Files.copy(file, newDir);
+                            } catch (FileAlreadyExistsException ex) {
+                                return FileVisitResult.CONTINUE;
+                            } catch (IOException ex) {
+                                return FileVisitResult.SKIP_SUBTREE;
+                            }
+                        }
+
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult visitFile(Path dir, BasicFileAttributes attrs) throws IOException {
+                        Path newFile = target.resolve(source.relativize(dir));
+
+                        if (ignoreFiles.contains(dir.getFileName().toString())) {
+                            return FileVisitResult.SKIP_SUBTREE;
+                        } else {
+                            try {
+                                Files.copy(dir, newFile);
+                            } catch (IOException ex) {
+                                ex.printStackTrace();
+                            }
+                        }
+
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                        if (exc == null) {
+                            Path newDir = target.resolve(source.relativize(dir));
+                            try {
+                                FileTime time = Files.getLastModifiedTime(dir);
+                                Files.setLastModifiedTime(newDir, time);
+                            } catch (IOException ex) {
+                                ex.printStackTrace();
+                            }
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            } catch (IOException e) {
+                FileUtils.LOGGER.debug("Could not copy dir", e);
+            }
+        } else {
+            try {
+                Files.delete(source);
+            } catch (IOException e) {
+                FileUtils.LOGGER.debug("Could not copy file", e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Delete every File in the given path except those listed in ignoreFiles
+     */
+    public static void deleteFiles(Path path, List<String> ignoreFiles) {
+        FileVisitor<Path> fv = new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                try {
+
+                    if (!ignoreFiles.contains(file.getFileName().toString())) {
+                        forceDelete(file);
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        };
+
+        try {
+            Files.walkFileTree(path, EnumSet.noneOf(FileVisitOption.class), 1, fv);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
     // public static Response readContentFromFile(RepositoryFileReference ref) {
     // try {
     // RepositoryFactory.getRepository().readContentFromFile(ref);
     // }
     // }
-
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/GitBasedRepository.java
@@ -98,7 +98,15 @@ public class GitBasedRepository extends FilebasedRepository {
             this.git = new Git(gitRepo);
         }
 
-        this.workingRepositoryRoot = generateWorkingRepositoryRoot();
+        if (this.repositoryRoot.resolve(Constants.DEFAULT_LOCAL_REPO_NAME).toFile().exists()) {
+            if (!(this instanceof MultiRepository)) {
+                this.workingRepositoryRoot = this.repositoryRoot.resolve(Constants.DEFAULT_LOCAL_REPO_NAME);
+            } else {
+                this.workingRepositoryRoot = repositoryDep;
+            }
+        } else {
+            this.workingRepositoryRoot = repositoryDep;
+        }
 
         this.eventBus = new EventBus();
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/RepositoryConfigurationManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/RepositoryConfigurationManager.java
@@ -18,20 +18,18 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.file.Files;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.eclipse.winery.repository.Constants;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.backend.constants.Filename;
 import org.eclipse.winery.repository.backend.filebased.management.IRepositoryResolver;
 import org.eclipse.winery.repository.backend.filebased.management.RepositoryResolverFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,88 +38,110 @@ public class RepositoryConfigurationManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryConfigurationManager.class);
 
-    private static File repositoriesConfiguration;
-    private static JsonNode repoNode = JsonNodeFactory.instance.objectNode();
-    private static Map<String, String> repositories = new HashMap<>();
+    private static File repositoryConfiguration;
+    private static List<RepositoryProperties> repositoriesList = new ArrayList<>();
 
-    private final MultiRepository multiRepository;
-
-    public RepositoryConfigurationManager(MultiRepository repository) {
-        this.multiRepository = repository;
-    }
-
-    public void initRepositoryConfigurationManager() throws IOException {
-        repositoriesConfiguration = this.multiRepository.getRepositoryDep().resolve(Filename.FILENAME_JSON_REPOSITORIES).toFile();
+    public static void initRepositoryConfigurationManager(MultiRepository repository) throws IOException {
+        repositoryConfiguration = new File(repository.getRepositoryDep().toString(), Filename.FILENAME_JSON_REPOSITORIES);
         readRepositoriesConfig();
     }
 
-    protected void readRepositoriesConfig() throws IOException {
-        if (repositoriesConfiguration.exists()) {
+    public static void addRepositoryToFile(List<RepositoryProperties> repositories) {
+        repositoriesList = repositories;
+        saveConfiguration();
+        loadRepositoriesByList();
+    }
+
+    public static List<RepositoryProperties> getRepositoriesFromFile() {
+        repositoriesList.clear();
+        if (repoContainsConfigFile()) {
+            try {
+                readRepositoriesConfig();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return repositoriesList;
+    }
+
+    private static void readRepositoriesConfig() throws IOException {
+        if (repoContainsConfigFile()) {
             LOGGER.info("Found Repositories file");
-            loadCfg(repositoriesConfiguration);
-            loadRepositories();
+            loadConfiguration(repositoryConfiguration);
+            loadRepositoriesByList();
         } else {
-            saveConfiguration(repositoriesConfiguration, repoNode);
-        }
-        LOGGER.info("Repositories loaded = " + this.multiRepository.getRepositoriesMap().keySet().size());
-        this.multiRepository.getRepositoriesMap().keySet().forEach(k -> LOGGER.info("Repository {} loaded.", k.getRepositoryRoot()));
-    }
-
-    private void loadRepositories() {
-        Map<String, String> tempRepo = new HashMap<>(repositories);
-        repositoriesByMap(tempRepo);
-        saveConfiguration(repositoriesConfiguration, repoNode);
-    }
-
-    private void saveConfiguration(File repoCfg, JsonNode repoNode) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-            objectMapper.writeValue(repoCfg, repoNode);
-        } catch (IOException e) {
-            LOGGER.error("Error while saving the configuration", e);
-            e.printStackTrace();
+            saveConfiguration();
         }
     }
 
-    private Map<String, String> loadCfg(File cfg) throws IOException {
+    private static void saveConfiguration() {
+        if (!repoContainsConfigFile()) {
+            createRepositoryConfigurationFile();
+            try {
+                RepositoryFactory.reconfigure();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } else {
+            ObjectMapper objectMapper = new ObjectMapper();
+            try {
+                objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+                objectMapper.writeValue(repositoryConfiguration, repositoriesList);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static boolean repoContainsConfigFile() {
+        File repo = new File(FilebasedRepository.getDefaultRepositoryFilePath(), Filename.FILENAME_JSON_REPOSITORIES);
+
+        if (repo.exists()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private static void loadConfiguration(File configuration) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
-
-        byte[] jsonData = Files.readAllBytes(cfg.toPath());
-        JsonNode node = objectMapper.readTree(jsonData);
-
-        Map<String, String> result = new HashMap<>();
-        node.fieldNames().forEachRemaining(name -> {
-            String repoBranch = node.get(name).toString().replace('"', ' ').trim();
-            result.put(name, repoBranch);
-            ((ObjectNode) repoNode).put(name, repoBranch);
+        ObjectReader reader = objectMapper.readerFor(new TypeReference<List<RepositoryProperties>>() {
         });
 
-        repositories.putAll(result);
-        return result;
+        repositoriesList = reader.readValue(configuration);
     }
 
-    private void repositoriesByMap(Map<String, String> map) {
-        map.forEach((url, branch) -> createRepository(url, branch));
+    private static void loadRepositoriesByList() {
+        for (RepositoryProperties repository : repositoriesList
+        ) {
+            createRepository(repository.getUrl(), repository.getBranch());
+        }
     }
 
-    private void createRepository(String url) {
-        createRepository(url, Constants.MASTER_BRANCH);
+    private static void createRepositoryConfigurationFile() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        repositoryConfiguration = new File(FilebasedRepository.getDefaultRepositoryFilePath(), Filename.FILENAME_JSON_REPOSITORIES);
+        try {
+            Files.createFile(repositoryConfiguration.toPath());
+            objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+            objectMapper.writeValue(repositoryConfiguration, repositoriesList);
+        } catch (IOException exception) {
+            exception.printStackTrace();
+        }
     }
 
-    private void createRepository(String url, String branch) {
-        Optional<IRepositoryResolver> optResolver = RepositoryResolverFactory.getResolver(url, branch);
-
-        if (!optResolver.isPresent()) {
-            return;
+    private static void createRepository(String url, String branch) {
+        IRepositoryResolver resolver = null;
+        if (RepositoryResolverFactory.getResolver(url, branch).isPresent()) {
+            resolver = RepositoryResolverFactory.getResolver(url, branch).get();
         }
 
-        IRepositoryResolver resolver = optResolver.get();
-
-        if (!this.multiRepository.getRepositoryUtils().checkRepositoryDuplicate(url)) {
+        if (resolver != null && !RepositoryUtils.checkRepositoryDuplicate(url)) {
+            String ownerDirectory;
+            File ownerRootFile;
             try {
-                String ownerDirectory = URLEncoder.encode(resolver.getRepositoryMaintainerUrl(), "UTF-8");
-                File ownerRootFile = new File(multiRepository.getRepositoryRoot().toFile(), ownerDirectory);
+                ownerDirectory = URLEncoder.encode(resolver.getRepositoryMaintainerUrl(), "UTF-8");
+                ownerRootFile = new File(FilebasedRepository.getDefaultRepositoryFilePath(), ownerDirectory);
 
                 if (!ownerRootFile.exists()) {
                     Files.createDirectories(ownerRootFile.toPath());
@@ -130,11 +150,12 @@ public class RepositoryConfigurationManager {
                 File repositoryLocation = new File(ownerRootFile, resolver.getRepositoryName());
                 FilebasedRepository repository = resolver.createRepository(repositoryLocation);
 
-                this.multiRepository.addRepository(repository);
+                MultiRepository.addRepository(repository);
 
-                File cfgFile = new File(repository.getRepositoryDep().toString(), Filename.FILENAME_JSON_REPOSITORIES);
-                if (cfgFile.exists()) {
-                    repositoriesByMap(loadCfg(cfgFile));
+                File configurationFile = new File(repository.getRepositoryDep().toString(), Filename.FILENAME_JSON_REPOSITORIES);
+                if (configurationFile.exists()) {
+                    loadConfiguration(configurationFile);
+                    loadRepositoriesByList();
                 }
             } catch (IOException | GitAPIException e) {
                 LOGGER.error("Error while creating the repository structure");

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/RepositoryProperties.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/RepositoryProperties.java
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.backend.filebased;
+
+import java.io.Serializable;
+
+public class RepositoryProperties implements Serializable, Comparable<RepositoryProperties> {
+
+    private String name;
+    private String url;
+    private String branch;
+
+    public RepositoryProperties() {
+    }
+
+    public RepositoryProperties(String name, String url) {
+
+        this.name = name;
+        this.url = url;
+        this.branch = "master";
+    }
+
+    public RepositoryProperties(String name, String url, String branch) {
+
+        this.name = name;
+        this.url = url;
+        this.branch = branch;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public void setBranch(String branch) {
+        this.branch = branch;
+    }
+
+    @Override
+    public int compareTo(RepositoryProperties o) {
+        int compareTo = this.name.compareTo(o.name);
+
+        if (compareTo == 0) {
+            return this.url.compareTo(o.url);
+        }
+
+        return compareTo;
+    }
+}

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/RepositoryUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/RepositoryUtils.java
@@ -70,14 +70,15 @@ class RepositoryUtils {
             } catch (UnsupportedOperationException uoe) {
                 LOGGER.warn("Error when setting the attributes of the .gitignore", uoe);
             }
-
         }
     }
 
-    protected boolean checkRepositoryDuplicate(String url) {
-        for (FilebasedRepository frepo : this.multiRepository.getRepositoriesMap().keySet()) {
-            if ((frepo instanceof GitBasedRepository) && ((GitBasedRepository) frepo).getRepositoryUrl().equals(url)) {
-                return true;
+    protected static boolean checkRepositoryDuplicate(String url) {
+        for (FilebasedRepository frepo : MultiRepository.getRepositoriesMap().keySet()) {
+            if ((frepo instanceof GitBasedRepository) && (((GitBasedRepository) frepo).getRepositoryUrl() != null)) {
+                if (((GitBasedRepository) frepo).getRepositoryUrl().equals(url)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/management/AbstractGitResolver.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/management/AbstractGitResolver.java
@@ -29,15 +29,21 @@ public abstract class AbstractGitResolver implements IRepositoryResolver {
     private final String vcsSystem = "git";
     private final String repositoryUrl;
     private final String repositoryBranch;
+    private final String repositoryMaintainer;
+    private final String repositoryName;
 
     public AbstractGitResolver(String url) {
         this.repositoryUrl = url;
         this.repositoryBranch = "master";
+        this.repositoryMaintainer = getRepositoryMaintainer();
+        this.repositoryName = getRepositoryName();
     }
 
     public AbstractGitResolver(String url, String branch) {
         this.repositoryUrl = url;
         this.repositoryBranch = branch;
+        this.repositoryMaintainer = getRepositoryMaintainer();
+        this.repositoryName = getRepositoryName();
     }
 
     @Override


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Added the ability to set up multiple repositories in the OpenTOSCA UI to management/repositories:
![image](https://user-images.githubusercontent.com/40024030/62463341-09d78580-b78a-11e9-851a-cb511c87e7d9.png)
After adding a new repository, the new file structure is automatically created in the winery-repository folder and the repsoitories.json is created.
![image](https://user-images.githubusercontent.com/40024030/62463349-1065fd00-b78a-11e9-87c1-1923ec4a71b6.png)
The old repository is moved to the workspace folder and each new repository gets its own folder named by the url.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
