### PR TITLE
Add relationships based on Reqs/Caps

### DIFF
--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/canvas.component.ts
@@ -53,6 +53,7 @@ import { TopologyRendererState } from '../redux/reducers/topologyRenderer.reduce
 import { ThreatModelingModalData } from '../models/threatModelingModalData';
 import { ThreatCreation } from '../models/threatCreation';
 import { TopologyTemplateUtil } from '../models/topologyTemplateUtil';
+import { ReqCapRelationshipService } from '../services/req-cap-relationship.service';
 import { TPolicy } from '../models/policiesModalData';
 
 @Component({
@@ -160,7 +161,9 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
                 private splitMatchService: SplitMatchTopologyService,
                 private placementService: PlaceComponentsService,
                 private reqCapService: ReqCapService,
-                private errorHandler: ErrorHandlerService) {
+                private errorHandler: ErrorHandlerService,
+                private reqCapRelationshipService: ReqCapRelationshipService,
+                private notify: ToastrService) {
         this.newJsPlumbInstance = this.jsPlumbService.getJsPlumbInstance();
         this.newJsPlumbInstance.setContainer('container');
 
@@ -1089,10 +1092,12 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
      * Revalidates the offsets and other data of the container in the DOM.
      */
     public revalidateContainer(): void {
-        setTimeout(() => {
-            this.newJsPlumbInstance.revalidate('container');
-            this.newJsPlumbInstance.repaintEverything();
-        }, 1);
+        if (this.newJsPlumbInstance) {
+            setTimeout(() => {
+                this.newJsPlumbInstance.revalidate('container');
+                this.newJsPlumbInstance.repaintEverything();
+            }, 1);
+        }
     }
 
     /**
@@ -1261,6 +1266,9 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
                 if (this.dragSourceInfos.dragSource) {
                     if (this.newJsPlumbInstance.isSource(this.dragSourceInfos.dragSource)) {
                         this.newJsPlumbInstance.unmakeSource(this.dragSourceInfos.dragSource);
+                    }
+                    if (this.newJsPlumbInstance.isSource(this.dragSourceInfos.nodeId)) {
+                        this.newJsPlumbInstance.unmakeSource(this.dragSourceInfos.nodeId);
                     }
                 }
                 const indexOfNode = this.nodeChildrenIdArray.indexOf(this.dragSourceInfos.nodeId);
@@ -1478,7 +1486,9 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
                 id: '',
                 nameTextFieldValue: '',
                 type: '',
-                properties: ''
+                properties: '',
+                source: '',
+                target: ''
             }
         }));
     }
@@ -1584,6 +1594,47 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
             }
         });
         this.entityTypes.relationshipTypes.forEach(value => this.assignRelTypes(value));
+        this.reqCapRelationshipService.sourceSelectedEvent.subscribe(source => this.setSource(source));
+        this.reqCapRelationshipService.sendSelectedRelationshipTypeEvent.subscribe(relationship => this.setSelectedRelationshipType(relationship));
+    }
+
+    /**
+     * set source for Relationship between Requirement and a Capability
+     * @param dragSourceInfo
+     */
+    setSource(dragSourceInfo: DragSource) {
+        if (dragSourceInfo) {
+            const nodeArrayLength = this.allNodeTemplates.length;
+            const currentNodeIsSource = this.newJsPlumbInstance.isSource(dragSourceInfo.dragSource);
+            if (!this.dragSourceActive && !currentNodeIsSource && nodeArrayLength > 1) {
+                this.newJsPlumbInstance.makeSource(dragSourceInfo.nodeId, {
+                    connectorOverlays: [
+                        ['Arrow', { location: 1 }],
+                    ],
+                });
+                this.dragSourceInfos = dragSourceInfo;
+                this.targetNodes = this.getAllCapabilities();
+                if (this.targetNodes.length > 0) {
+                    this.newJsPlumbInstance.makeTarget(this.targetNodes);
+                    this.dragSourceActive = true;
+                    this.bindReqCapConnection();
+                }
+            }
+        }
+    }
+
+    getAllCapabilities() {
+        const capIds: string[] = [];
+        this.allNodeTemplates.forEach(node => {
+            if (node.capabilities) {
+                if (node.capabilities.capability) {
+                    node.capabilities.capability.forEach(cap => {
+                        capIds.push(node.id + '.' + cap.id);
+                    });
+                }
+            }
+        });
+        return capIds;
     }
 
     /**
@@ -1639,12 +1690,14 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
      * @param $event  The HTML event.
      */
     trackTimeOfMouseDown(): void {
-        this.newJsPlumbInstance.select().removeType('marked');
-        this.revalidateContainer();
-        this.removeDragSource();
-        this.clearSelectedNodes();
-        this.unbindConnection();
-        this.startTime = new Date().getTime();
+        if (this.newJsPlumbInstance) {
+            this.newJsPlumbInstance.select().removeType('marked');
+            this.revalidateContainer();
+            this.removeDragSource();
+            this.clearSelectedNodes();
+            this.unbindConnection();
+            this.startTime = new Date().getTime();
+        }
     }
 
     /**
@@ -1851,7 +1904,9 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
                     id: currentRel.id,
                     nameTextFieldValue: currentRel.name,
                     type: currentRel.type,
-                    properties: currentRel.properties
+                    properties: currentRel.properties,
+                    source: currentRel.sourceElement.ref,
+                    target: currentRel.targetElement.ref
                 }
             }));
             conn.addType('marked');
@@ -2028,6 +2083,111 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
                 this.unbindConnection();
                 this.revalidateContainer();
             });
+        }
+    }
+
+    bindReqCapConnection() {
+        if (this.jsPlumbBindConnection === false && this.selectedRelationshipType) {
+            this.newJsPlumbInstance.bind('connection', info => {
+                this.jsPlumbBindConnection = true;
+                if (this.dragSourceInfos) {
+                    const sourceNode = info.sourceId;
+                    const sourceElement = this.dragSourceInfos.dragSource.id;
+                    const targetElement = info.targetId.substring(info.targetId.indexOf('.') + 1);
+                    const currentTypeValid = this.entityTypes.relationshipTypes.some(relType => relType.qName === this.selectedRelationshipType.qName);
+                    const currentSourceIdValid = this.allNodeTemplates.some(node => node.id === sourceNode);
+                    if (sourceNode && currentTypeValid && currentSourceIdValid) {
+                        const prefix = this.backendService.configuration.relationshipPrefix;
+                        const relName = this.selectedRelationshipType.name;
+                        let relNumber = 0;
+                        let relationshipId: string;
+
+                        do {
+                            relationshipId = prefix + '_' + relName + '_' + relNumber++;
+                        } while (this.allRelationshipTemplates.find(value => value.id === relationshipId));
+                        if (this.searchTypeAndCheckForCompatibility(this.getCapability(targetElement))) {
+                            const newRelationship = new TRelationshipTemplate(
+                                { ref: sourceElement },
+                                { ref: targetElement },
+                                this.selectedRelationshipType.name,
+                                relationshipId,
+                                this.selectedRelationshipType.qName,
+                                TopologyTemplateUtil.getDefaultPropertiesFromEntityTypes(this.selectedRelationshipType.name,
+                                    this.entityTypes.relationshipTypes),
+                                [],
+                                [],
+                                {}
+                            );
+                            this.ngRedux.dispatch(this.actions.saveRelationship(newRelationship));
+                        }
+                        for (const rel of this.newJsPlumbInstance.getConnections()) {
+                            if (rel.targetId === info.targetId) {
+                                this.newJsPlumbInstance.deleteConnection(rel);
+                            }
+                        }
+                        this.dragSourceActive = false;
+                        this.resetDragSource(sourceElement);
+                    }
+                    this.unbindConnection();
+                    this.revalidateContainer();
+                }
+            });
+        }
+    }
+
+    getCapability(targetElement: string) {
+        let capability: any = null;
+        this.allNodeTemplates.forEach(node => {
+            if (node.capabilities) {
+                if (node.capabilities.capability) {
+                    node.capabilities.capability.forEach(cap => {
+                        if (cap.name === targetElement) {
+                            capability = cap;
+                        }
+                    });
+                }
+            }
+        });
+        return capability;
+    }
+
+    /**
+     * check for compatibility of Requirement and Capability
+     * @param dragTargetInfo
+     */
+    searchTypeAndCheckForCompatibility(capability: any) {
+        let requiredTargetType = '';
+
+        this.entityTypes.requirementTypes.some(req => {
+            if (req.qName === this.dragSourceInfos.dragSource.type) {
+                requiredTargetType = req.properties.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].requiredCapabilityType;
+                return true;
+            }
+        });
+        return this.checkForCompatibility(requiredTargetType, capability);
+    }
+
+    /**
+     * check recursive if the target or a parent of its Capability matches
+     * @param requiredTargetType
+     * @param targetOrParent
+     */
+    checkForCompatibility(requiredTargetType: any, targetOrParent: any) {
+        let parentCapType: any;
+        if (requiredTargetType === targetOrParent.type) {
+            return true;
+        } else {
+            this.entityTypes.capabilityTypes.some(cap => {
+                if (cap.qName === targetOrParent.type) {
+                    parentCapType = cap.properties.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].derivedFrom;
+                    return true;
+                }
+            });
+            if (parentCapType) {
+                return this.checkForCompatibility(requiredTargetType, parentCapType);
+            }
+            this.notify.warning('The selected Requirement and Capability are not Compatible');
+            return false;
         }
     }
 

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/canvas.component.ts
@@ -1616,6 +1616,7 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
                 this.targetNodes = this.getAllCapabilities();
                 if (this.targetNodes.length > 0) {
                     this.newJsPlumbInstance.makeTarget(this.targetNodes);
+                    this.newJsPlumbInstance.targetEndpointDefinitions = {};
                     this.dragSourceActive = true;
                     this.bindReqCapConnection();
                 }
@@ -2141,7 +2142,7 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
             if (node.capabilities) {
                 if (node.capabilities.capability) {
                     node.capabilities.capability.forEach(cap => {
-                        if (cap.name === targetElement) {
+                        if (cap.id === targetElement) {
                             capability = cap;
                         }
                     });
@@ -2160,7 +2161,7 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
 
         this.entityTypes.requirementTypes.some(req => {
             if (req.qName === this.dragSourceInfos.dragSource.type) {
-                requiredTargetType = req.properties.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].requiredCapabilityType;
+                requiredTargetType = req.full.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].requiredCapabilityType;
                 return true;
             }
         });
@@ -2179,7 +2180,7 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
         } else {
             this.entityTypes.capabilityTypes.some(cap => {
                 if (cap.qName === targetOrParent.type) {
-                    parentCapType = cap.properties.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].derivedFrom;
+                    parentCapType = cap.full.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].derivedFrom;
                     return true;
                 }
             });

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/models/DragSource.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/models/DragSource.ts
@@ -16,6 +16,6 @@
  * Internal representation of drag source infos
  */
 export interface DragSource {
-    dragSource: string;
+    dragSource: any;
     nodeId: string;
 }

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/models/enums.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/models/enums.ts
@@ -34,9 +34,11 @@ export enum urlElement {
     TopologyTemplate = '/topologytemplate/'
 }
 
-export enum toscaEntity {
+export enum TableType {
     Requirements = 'Requirements',
     Capabilities = 'Capabilities',
+    Policies = 'policies',
+    deploymentArtifacts = 'deploymentArtifacts'
 }
 
 export enum toggleModalType {

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/capabilities/capabilities.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/capabilities/capabilities.component.html
@@ -14,7 +14,7 @@
 
 <div *ngIf="capabilitiesExist">
     <winery-toscatype-table
-        [toscaType]="'Capabilities'"
+        [toscaType]="toscaTypes.CapabilityType"
         [currentNodeData]="currentNodeData"
         [toscaTypeData]="capabilities"
         (showClickedReqOrCapModal)="toggleModal($event)">

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/capabilities/capabilities.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/capabilities/capabilities.component.ts
@@ -19,6 +19,7 @@ import { NgRedux } from '@angular-redux/store';
 import { IWineryState } from '../../redux/store/winery.store';
 import { Subscription } from 'rxjs';
 import { CapabilityModel } from '../../models/capabilityModel';
+import { ToscaTypes } from '../../../../../tosca-management/src/app/model/enums';
 
 @Component({
     selector: 'winery-capabilities',
@@ -29,6 +30,8 @@ import { CapabilityModel } from '../../models/capabilityModel';
  * This Handles Information about the node capabilities
  */
 export class CapabilitiesComponent implements OnInit, OnChanges, OnDestroy {
+
+    readonly toscaTypes = ToscaTypes;
 
     @Output() toggleModalHandler: EventEmitter<any>;
     @Input() readonly: boolean;

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/deployment-artifacts/deployment-artifacts.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/deployment-artifacts/deployment-artifacts.component.html
@@ -13,7 +13,7 @@
 -->
 
 <winery-toscatype-table
-    [toscaType]="'deploymentArtifacts'"
+    [toscaType]="tableType.deploymentArtifacts"
     [currentNodeData]="currentNodeData"
     [toscaTypeData]="deploymentArtifacts">
 </winery-toscatype-table>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/deployment-artifacts/deployment-artifacts.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/deployment-artifacts/deployment-artifacts.component.ts
@@ -15,6 +15,8 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { IWineryState } from '../../redux/store/winery.store';
 import { NgRedux } from '@angular-redux/store';
+import { ToscaTypes } from '../../../../../tosca-management/src/app/model/enums';
+import { TableType } from '../../models/enums';
 
 @Component({
     selector: 'winery-deployment-artifacts',
@@ -25,6 +27,9 @@ import { NgRedux } from '@angular-redux/store';
  * This Handles Information about the deployment artifacts
  */
 export class DeploymentArtifactsComponent implements OnInit {
+
+    readonly tableType = TableType;
+
     @Output() toggleModalHandler: EventEmitter<any>;
     @Input() readonly: boolean;
     @Input() currentNodeData: any;

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/policies/policies.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/policies/policies.component.html
@@ -13,7 +13,7 @@
 -->
 
 <winery-toscatype-table
-    [toscaType]="'policies'"
+    [toscaType]="tableType.Policies"
     [currentNodeData]="currentNodeData"
     [toscaTypeData]="policies">
 </winery-toscatype-table>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/policies/policies.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/policies/policies.component.ts
@@ -13,6 +13,7 @@
  ********************************************************************************/
 
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { TableType } from '../../models/enums';
 
 @Component({
     selector: 'winery-policies',
@@ -23,6 +24,9 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
  * This Handles Information about the nodes policies
  */
 export class PoliciesComponent implements OnInit {
+
+    readonly tableType = TableType;
+
     @Output() toggleModalHandler: EventEmitter<any>;
     @Input() readonly: boolean;
     @Input() currentNodeData: any;

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/requirements/requirements.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/requirements/requirements.component.html
@@ -1,5 +1,5 @@
 <!--
- * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,9 +14,10 @@
 
 <div id="requirementDiv" *ngIf="requirementsExist">
     <winery-toscatype-table
-        [toscaType]="'Requirements'"
+        [toscaType]="toscaTypes.RequirementType"
         [currentNodeData]="currentNodeData"
         [toscaTypeData]="requirements"
+        [entityTypes]="entityTypes"
         (showClickedReqOrCapModal)="toggleModal($event)">
     </winery-toscatype-table>
 </div>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/requirements/requirements.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/requirements/requirements.component.ts
@@ -19,6 +19,7 @@ import { NgRedux } from '@angular-redux/store';
 import { IWineryState } from '../../redux/store/winery.store';
 import { Subscription } from 'rxjs';
 import { RequirementModel } from '../../models/requirementModel';
+import { ToscaTypes } from '../../../../../tosca-management/src/app/model/enums';
 
 @Component({
     selector: 'winery-requirements',
@@ -29,6 +30,9 @@ import { RequirementModel } from '../../models/requirementModel';
  * This Handles Information about the nodes requirements
  */
 export class RequirementsComponent implements OnInit, OnChanges, OnDestroy {
+
+    readonly toscaTypes = ToscaTypes;
+
     @Output() toggleModalHandler: EventEmitter<any>;
     @Input() readonly: boolean;
     @Input() currentNodeData: any;

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.css
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -98,4 +98,9 @@ tr:nth-child(even) {
     -moz-user-select: all; /* Firefox all */
     -ms-user-select: all; /* IE 10+ */
     user-select: all;
+}
+
+.relation-button {
+    padding: .05rem .1rem;
+    border-radius: .2rem;
 }

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.css
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.css
@@ -104,3 +104,11 @@ tr:nth-child(even) {
     padding: .05rem .1rem;
     border-radius: .2rem;
 }
+
+.reqCap-button {
+    padding: .05rem .1rem;
+    border-radius: .2rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.html
@@ -84,7 +84,7 @@
     <tbody>
     <tr *ngFor="let reqOrCap of currentToscaTypeData">
         <td *ngIf="toscaType === toscaTypes.CapabilityType" class="toscatype-table-td">
-            <button type="button" class="relation-button btn btn-sm btn-outline-secondary btn-block"
+            <button type="button" class="reqCap-button btn btn-sm btn-outline-secondary btn-block"
                     style="font-size: x-small;" id="{{currentNodeData.nodeTemplate.id +'.'+ reqOrCap.id}}">
                 <i class="fa fa-dot-circle-o" aria-hidden="true"></i> {{""}}
             </button>
@@ -108,9 +108,9 @@
             <div
                 (mousedown)="passCurrentType($event); reqCapRelationshipService.createSourceInfo(this.currentNodeData, reqOrCap);">
                 <div class="btn-group-vertical center-block" role="group" id={{dragSource}}>
-                    <button *ngFor="let rel of ['ConnectsTo','HostedOn']"
-                            type="button" class="relation-button btn btn-sm btn-outline-secondary btn-block"
-                            style="font-size: xx-small;">{{rel}}
+                    <button *ngFor="let rel of entityTypes.relationshipTypes"
+                            type="button" class="reqCap-button btn btn-sm btn-outline-secondary btn-block"
+                            style="font-size: xx-small;">{{rel.id}}
                     </button>
                 </div>
             </div>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.html
@@ -105,8 +105,8 @@
             <span class="cell-comment">{{ reqOrCap.name }}</span>
         </td>
         <td *ngIf="toscaType === toscaTypes.RequirementType" class="toscatype-table-td">
-            <div
-                (mousedown)="passCurrentType($event); reqCapRelationshipService.createSourceInfo(this.currentNodeData, reqOrCap);">
+            <div (mousedown)="passCurrentType($event);
+            reqCapRelationshipService.createSourceInfo(this.currentNodeData, reqOrCap);">
                 <div class="btn-group-vertical center-block" role="group" id={{dragSource}}>
                     <button *ngFor="let rel of entityTypes.relationshipTypes"
                             type="button" class="reqCap-button btn btn-sm btn-outline-secondary btn-block"

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -11,8 +11,7 @@
   ~
   ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-
-<table *ngIf="toscaType==='deploymentArtifacts'" class="toscatype-table" border="1" style="">
+<table *ngIf="toscaType=== tableType.deploymentArtifacts" class="toscatype-table" border="1" style="">
     <thead>
     <tr>
         <th>Name</th>
@@ -41,7 +40,7 @@
     </tbody>
 </table>
 
-<table *ngIf="toscaType==='policies'" class="toscatype-table" border="1">
+<table *ngIf="toscaType===toscaTypes.PolicyType" class="toscatype-table" border="1">
     <thead>
     <tr>
         <th>Name</th>
@@ -71,16 +70,30 @@
     </tbody>
 </table>
 
-<table *ngIf="toscaType==='Capabilities' || toscaType==='Requirements'" class="toscatype-table">
+<table *ngIf="toscaType === toscaTypes.CapabilityType || toscaType === toscaTypes.RequirementType"
+       class="toscatype-table">
     <thead>
     <tr>
+        <th *ngIf="toscaType === toscaTypes.CapabilityType" width="25px"></th>
+        <th>Endpoint</th>
         <th>Id</th>
         <th>Name</th>
-        <th>Type</th>
+        <th *ngIf="toscaType === toscaTypes.RequirementType"></th>
     </tr>
     </thead>
     <tbody>
     <tr *ngFor="let reqOrCap of currentToscaTypeData">
+        <td *ngIf="toscaType === toscaTypes.CapabilityType" class="toscatype-table-td">
+            <button type="button" class="relation-button btn btn-sm btn-outline-secondary btn-block"
+                    style="font-size: x-small;" id="{{currentNodeData.nodeTemplate.id +'.'+ reqOrCap.id}}">
+                <i class="fa fa-dot-circle-o" aria-hidden="true"></i> {{""}}
+            </button>
+        </td>
+        <td class="toscatype-table-td"
+            [class.cell-with-comment]="isEllipsisActive(reqOrCapType)">
+            <div #reqOrCapType (click)="clickReqOrCapType(reqOrCap.type)">{{ reqOrCap.type | localname }}</div>
+            <span class="cell-comment">{{ reqOrCap.type | localname }}</span>
+        </td>
         <td class="toscatype-table-td"
             [class.cell-with-comment]="isEllipsisActive(reqOrCapName)">
             <div #reqOrCapName (click)="showExistingReqOrCapModal($event)">{{ reqOrCap.id }}</div>
@@ -91,10 +104,16 @@
             <div #reqOrCapRef (click)="clickReqOrCapRef(reqOrCap.name)">{{ reqOrCap.name }}</div>
             <span class="cell-comment">{{ reqOrCap.name }}</span>
         </td>
-        <td class="toscatype-table-td"
-            [class.cell-with-comment]="isEllipsisActive(reqOrCapType)">
-            <div #reqOrCapType (click)="clickReqOrCapType(reqOrCap.type)">{{ reqOrCap.type | localname }}</div>
-            <span class="cell-comment">{{ reqOrCap.type | localname }}</span>
+        <td *ngIf="toscaType === toscaTypes.RequirementType" class="toscatype-table-td">
+            <div
+                (mousedown)="passCurrentType($event); reqCapRelationshipService.createSourceInfo(this.currentNodeData, reqOrCap);">
+                <div class="btn-group-vertical center-block" role="group" id={{dragSource}}>
+                    <button *ngFor="let rel of ['ConnectsTo','HostedOn']"
+                            type="button" class="relation-button btn btn-sm btn-outline-secondary btn-block"
+                            style="font-size: xx-small;">{{rel}}
+                    </button>
+                </div>
+            </div>
         </td>
     </tr>
     </tbody>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,8 +16,11 @@ import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChange
 import { QName } from '../../models/qname';
 import { EntitiesModalService, OpenModalEvent } from '../../canvas/entities-modal/entities-modal.service';
 import { ModalVariant } from '../../canvas/entities-modal/modal-model';
-import { definitionType, toscaEntity, urlElement } from '../../models/enums';
+import { definitionType, TableType, urlElement } from '../../models/enums';
 import { BackendService } from '../../services/backend.service';
+import { EntityTypesModel } from '../../models/entityTypesModel';
+import { ReqCapRelationshipService } from '../../services/req-cap-relationship.service';
+import { ToscaTypes } from '../../../../../tosca-management/src/app/model/enums';
 
 @Component({
     selector: 'winery-toscatype-table',
@@ -26,9 +29,13 @@ import { BackendService } from '../../services/backend.service';
 })
 export class ToscatypeTableComponent implements OnInit, OnChanges {
 
+    readonly toscaTypes = ToscaTypes;
+    readonly tableType = TableType;
+
     @Input() toscaType: string;
     @Input() currentNodeData: any;
     @Input() toscaTypeData: any;
+    @Input() entityTypes: EntityTypesModel;
 
     // Event emitter for showing the modal of a clicked capability or requirement id
     @Output() showClickedReqOrCapModal: EventEmitter<any>;
@@ -38,7 +45,8 @@ export class ToscatypeTableComponent implements OnInit, OnChanges {
     latestNodeTemplate?: any = {};
 
     constructor(private entitiesModalService: EntitiesModalService,
-                private backendService: BackendService) {
+                private backendService: BackendService,
+                private reqCapRelationshipService: ReqCapRelationshipService) {
         this.showClickedReqOrCapModal = new EventEmitter();
     }
 
@@ -156,7 +164,7 @@ export class ToscatypeTableComponent implements OnInit, OnChanges {
      */
     clickReqOrCapRef(reqOrCapRef: string) {
         let clickedDefinition;
-        if (this.toscaType === toscaEntity.Requirements) {
+        if (this.toscaType === this.toscaTypes.RequirementType) {
             clickedDefinition = definitionType.RequirementDefinitions;
         } else {
             clickedDefinition = definitionType.CapabilityDefinitions;
@@ -175,7 +183,7 @@ export class ToscatypeTableComponent implements OnInit, OnChanges {
      */
     clickReqOrCapType(reqOrCapType: string) {
         let clickedType;
-        if (this.toscaType === toscaEntity.Requirements) {
+        if (this.toscaType === this.toscaTypes.RequirementType) {
             clickedType = urlElement.RequirementTypeURL;
         } else {
             clickedType = urlElement.CapabilityTypeURL;
@@ -187,4 +195,19 @@ export class ToscatypeTableComponent implements OnInit, OnChanges {
         window.open(url, '_blank');
     }
 
+    passCurrentType($event): void {
+        let currentType: string;
+
+        try {
+            currentType = $event.srcElement.innerText.replace(/\n/g, '').replace(/\s+/g, '');
+        } catch (e) {
+            currentType = $event.target.innerText.replace(/\n/g, '').replace(/\s+/g, '');
+        }
+        this.entityTypes.relationshipTypes.some(relType => {
+            if (relType.qName.includes(currentType)) {
+                this.reqCapRelationshipService.passCurrentType(relType);
+                return true;
+            }
+        });
+    }
 }

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/actions/winery.actions.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/actions/winery.actions.ts
@@ -36,7 +36,9 @@ export interface SidebarStateAction extends Action {
         type: string,
         minInstances: string,
         maxInstances: string,
-        properties: string
+        properties: string,
+        source: string,
+        target: string
     };
 }
 

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/reducers/winery.reducer.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/reducers/winery.reducer.ts
@@ -45,7 +45,9 @@ export const INITIAL_WINERY_STATE: WineryState = {
         type: '',
         minInstances: 1,
         maxInstances: 1,
-        properties: ''
+        properties: '',
+        source: '',
+        target: ''
     },
     currentJsonTopology: new TTopologyTemplate,
     currentNodeData: {

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/services/req-cap-relationship.service.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/services/req-cap-relationship.service.ts
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+import { BehaviorSubject } from 'rxjs';
+import { EntityType } from '../models/ttopology-template';
+import { EventEmitter, Output } from '@angular/core';
+
+export class ReqCapRelationshipService {
+    @Output() sourceSelectedEvent: EventEmitter<any>;
+    @Output() sendSelectedRelationshipTypeEvent: EventEmitter<any>;
+    private closedEndpointEvent = new BehaviorSubject<any>('');
+    private askForRepaintEvent = new BehaviorSubject<any>('');
+
+    constructor() {
+        this.sourceSelectedEvent = new EventEmitter();
+        this.sendSelectedRelationshipTypeEvent = new EventEmitter();
+    }
+
+    createSourceInfo(currentNodeData: any, reqOrCap: any) {
+        const dragSourceInfo = {
+            dragSource: reqOrCap,
+            nodeId: currentNodeData.nodeTemplate.id
+        };
+        this.sourceSelectedEvent.emit(dragSourceInfo);
+    }
+
+    passCurrentType(currentType: EntityType): void {
+        this.sendSelectedRelationshipTypeEvent.emit(currentType);
+    }
+
+    closeConnectorEndpoints(currentNodeData: any, reqOrCap: any): void {
+        const dragTargetInfo = {
+            dragSource: reqOrCap,
+            nodeId: currentNodeData.nodeTemplate.id
+        };
+        this.closedEndpointEvent.next(dragTargetInfo);
+        this.repaint(new Event('repaint'));
+    }
+
+    closeConnectionEventListener() {
+        return this.closedEndpointEvent.asObservable();
+    }
+
+    repaint($event) {
+        setTimeout(() => this.askForRepaintEvent.next('Repaint'), 1);
+    }
+
+    repaintEventListener() {
+        return this.askForRepaintEvent.asObservable();
+    }
+
+}

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebar/sidebar.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebar/sidebar.component.html
@@ -44,6 +44,18 @@
                 </a>
             </div>
             <div *ngIf="sidebarState.nodeClicked == false">
+                <label for="connectionSource"> Source </label>
+                <a id="connectionSource"
+                   target="_blank"
+                   class="form-control">
+                    {{sidebarState.source}}
+                </a>
+                <label for="connectionTarget"> Target </label>
+                <a id="connectionTarget"
+                   target="_blank"
+                   class="form-control">
+                    {{sidebarState.target}}
+                </a>
                 <div class="form-group">
                     <label>Properties</label>
                     <winery-properties

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebar/sidebar.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebar/sidebar.component.ts
@@ -148,7 +148,9 @@ export class SidebarComponent implements OnInit, OnDestroy {
                         relData: {
                             newRelName: data,
                             id: this.sidebarState.id,
-                            properties: this.sidebarState.properties
+                            properties: this.sidebarState.properties,
+                            source: this.sidebarState.source,
+                            target: this.sidebarState.target
                         }
                     }));
                 }
@@ -162,7 +164,9 @@ export class SidebarComponent implements OnInit, OnDestroy {
                         type: this.sidebarState.type,
                         minInstances: Number(this.sidebarState.minInstances),
                         maxInstances: Number(this.sidebarState.maxInstances),
-                        properties: this.sidebarState.properties
+                        properties: this.sidebarState.properties,
+                        source: this.sidebarState.source,
+                        target: this.sidebarState.target
                     }
                 }));
             });
@@ -190,7 +194,9 @@ export class SidebarComponent implements OnInit, OnDestroy {
                         type: this.sidebarState.type,
                         minInstances: Number(data),
                         maxInstances: this.sidebarState.maxInstances,
-                        properties: this.sidebarState.properties
+                        properties: this.sidebarState.properties,
+                        source: this.sidebarState.source,
+                        target: this.sidebarState.target
                     }
                 }));
             });
@@ -217,7 +223,9 @@ export class SidebarComponent implements OnInit, OnDestroy {
                         type: this.sidebarState.type,
                         minInstances: this.sidebarState.minInstances,
                         maxInstances: Number(data),
-                        properties: this.sidebarState.properties
+                        properties: this.sidebarState.properties,
+                        source: this.sidebarState.source,
+                        target: this.sidebarState.target
                     }
                 }));
             });
@@ -259,7 +267,9 @@ export class SidebarComponent implements OnInit, OnDestroy {
                 type: this.sidebarState.type,
                 minInstances: this.sidebarState.minInstances,
                 maxInstances: this.sidebarState.maxInstances,
-                properties: this.sidebarState.properties
+                properties: this.sidebarState.properties,
+                source: this.sidebarState.source,
+                target: this.sidebarState.target
             }
         }));
     }
@@ -319,7 +329,9 @@ export class SidebarComponent implements OnInit, OnDestroy {
                 type: this.sidebarState.type,
                 minInstances: this.sidebarState.minInstances,
                 maxInstances: this.sidebarState.maxInstances,
-                properties: this.sidebarState.properties
+                properties: this.sidebarState.properties,
+                source: this.sidebarState.source,
+                target: this.sidebarState.target
             }
         }));
     }

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.component.ts
@@ -13,9 +13,7 @@
  ********************************************************************************/
 
 import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
-import {
-    Entity, EntityType, TNodeTemplate, TRelationshipTemplate, TTopologyTemplate, VisualEntityType
-} from './models/ttopology-template';
+import { Entity, EntityType, TNodeTemplate, TRelationshipTemplate, TTopologyTemplate, VisualEntityType } from './models/ttopology-template';
 import { ILoaded, LoadedService } from './services/loaded.service';
 import { AppReadyEventService } from './services/app-ready-event.service';
 import { BackendService } from './services/backend.service';
@@ -171,6 +169,7 @@ export class WineryComponent implements OnInit, AfterViewInit {
                             capabilityType.qName,
                             capabilityType.name,
                             capabilityType.namespace,
+                            capabilityType.properties,
                             capabilityType.full
                         ));
                 });
@@ -185,6 +184,7 @@ export class WineryComponent implements OnInit, AfterViewInit {
                             requirementType.qName,
                             requirementType.name,
                             requirementType.namespace,
+                            requirementType.properties,
                             requirementType.full
                         ));
                 });

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.module.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.module.ts
@@ -51,6 +51,7 @@ import { WineryModalModule } from '../../../tosca-management/src/app/wineryModal
 import { EnricherComponent } from './enricher/enricher.component';
 import { WineryFeatureToggleModule } from '../../../tosca-management/src/app/wineryFeatureToggleModule/winery-feature-toggle.module';
 import { PlaceComponentsService } from './services/placement.service';
+import { ReqCapRelationshipService } from './services/req-cap-relationship.service';
 
 @NgModule({
     declarations: [
@@ -105,6 +106,7 @@ import { PlaceComponentsService } from './services/placement.service';
         ErrorHandlerService,
         StatefulAnnotationsService,
         PlaceComponentsService,
+        ReqCapRelationshipService
     ],
     bootstrap: [WineryComponent]
 })


### PR DESCRIPTION
Added Relationships between Requirements and Capabilities in Topologymodeler.
Automatically checks if Requirement and Capability are compatible.
Checks for capabilities inherited from a parent to see if they are compatible and then creates the connection.

![image](https://user-images.githubusercontent.com/40024030/65690160-c1906180-e06e-11e9-9ea3-c3ec76eaa2c4.png)

Signed-off-by: Björn Müller <bjoern.mueller@kanu-baerchen.de>

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
