### PR TITLE
Stop creating new Repository for reading Definitions

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/AbstractRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/AbstractRepository.java
@@ -114,7 +114,7 @@ public abstract class AbstractRepository implements IRepository {
             return BackendUtils.createWrapperDefinitionsAndInitialEmptyElement(this, id);
         }
         try {
-            InputStream is = RepositoryFactory.getRepository().newInputStream(ref);
+            InputStream is = this.newInputStream(ref);
             Unmarshaller u = JAXBSupport.createUnmarshaller();
             return (Definitions) u.unmarshal(is);
         } catch (Exception e) {


### PR DESCRIPTION
Calling `getDefinitions` on an IRepository instance no longer creates a new repository with the current repository configurations cached in the RepositoryFactory. This behaviour broke handling of multiple repositories accessed from the same JVM as necessary for OpenTOSCA/container#78.

Signed-off-by: Clemens Lieb <vogel612@gmx.de>