### PR TITLE
Stop removing artifact-local references during import

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
@@ -838,9 +838,6 @@ public class CsarImporter {
                 continue;
             }
 
-            // we remove the current element as it will be handled during the export
-            iterator.remove();
-
             Path path = rootPath.resolve(reference);
             if (!Files.exists(path)) {
                 errors.add(String.format("Reference %1$s not found", reference));


### PR DESCRIPTION
The import process used to remove artifact references to local files stored inside the artifact.
This implies that during runtime the artifact references attached to a TArtifactTemplate obtained
from an IRepository are not necessarily the references that would be stored in the exported version.

That behaviour would require adjustments for the deployment process of a CSAR that duplicate the
code used during export and for unit testing within the winery (cf. BackendUtils#synchronizeReferences).
It's cleaner to allow the ArtifactReference information to be generally applicable instead of
working around the current behaviour.
