### PR TITLE
Add DNT (do not track) header to allowed CORS headers

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/webapp/WEB-INF/web.xml
+++ b/org.eclipse.winery.repository.rest/src/main/webapp/WEB-INF/web.xml
@@ -43,12 +43,12 @@
             <param-value>GET,PUT,POST,DELETE,HEAD,OPTIONS</param-value>
         </init-param>
         <init-param>
-            <param-name>cors.exposed.headers</param-name>
-            <param-value>Location, Access-Control-Allow-Origin</param-value>
+            <param-name>cors.allowed.headers</param-name>
+            <param-value>Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,DNT</param-value>
         </init-param>
         <init-param>
-            <param-name>cors.preflight.maxage</param-name>
-            <param-value>10</param-value>
+            <param-name>cors.exposed.headers</param-name>
+            <param-value>Location,Access-Control-Allow-Origin</param-value>
         </init-param>
     </filter>
 


### PR DESCRIPTION
Added DNT header to allowed CORS headers since it is added by the browser(s) and, therefore, no way to avoid sending it (which is ok, but we have to allow the usage accordingly).