### PR TITLE
fix/File already exists at save

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/AbstractComponentsWithoutTypeReferenceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/AbstractComponentsWithoutTypeReferenceResource.java
@@ -18,6 +18,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.rest.resources.apiData.QNameApiData;
 
 /**
@@ -33,6 +35,8 @@ public abstract class AbstractComponentsWithoutTypeReferenceResource<T extends A
     @Consumes(MediaType.APPLICATION_JSON)
     public Response onJsonPost(QNameApiData jsonData) {
         ResourceResult creationResult = super.onPost(jsonData.namespace, jsonData.localname);
+        DefinitionsChildId definitionsChildId = this.getDefinitionsChildId(jsonData.namespace, jsonData.localname, false);
+        creationResult.setMessage(RepositoryFactory.getRepository().getElement(definitionsChildId));
         return creationResult.getResponse();
     }
 }


### PR DESCRIPTION
Signed-off-by: Björn Müller <bjoern.mueller@kanu-baerchen.de>

Fix error when creating new nodetype that the file already exists.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
