### PR TITLE
Add default value when reading autocommit configuration

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -21,7 +21,7 @@ The project maintains the following source code repository:
 
 == Copyright Holders
 
-Copyright (c) 2012-2019 University of Stuttgart
+Copyright (c) 2012-2020 University of Stuttgart
 Copyright (c) 2012-2018 C. Timurhan Sungur
 Copyright (c) 2012-2018 Oliver Kopp
 Copyright (c) 2012-2017 Uwe Breitenbücher
@@ -45,7 +45,7 @@ Copyright (c) 2016-2017 Philipp Meyer
 Copyright (c) 2016-2018 Tino Stadelmaier
 Copyright (c) 2017 Ana Cristina Franco da Silva
 Copyright (c) 2017 Christoph Kleine
-Copyright (c) 2017 Clemens Lieb
+Copyright (c) 2017-2020 Clemens Lieb
 Copyright (c) 2017 Heiko Nickerl
 Copyright (c) 2017 Huabing Zhao
 Copyright (c) 2017 Huixin Liu

--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/configuration/GitConfigurationObject.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/configuration/GitConfigurationObject.java
@@ -30,7 +30,7 @@ public class GitConfigurationObject extends AbstractConfigurationObject {
         this.setPassword(configuration.getString(key + "password"));
         this.setClientID(configuration.getString(key + "clientID"));
         this.setUsername(configuration.getString(key + "username"));
-        this.setAutocommit(configuration.getBoolean(key + "autocommit"));
+        this.setAutocommit(configuration.getBoolean(key + "autocommit", false));
         this.configuration = configuration;
     }
 


### PR DESCRIPTION
This avoids throwing a NoSuchElementException when reading the underlying
configuration fails, because the methods returning primitives cannot fall
back to null if the key is missing.

Signed-off-by: Clemens Lieb <vogel612@gmx.de>

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders