### PR TITLE
Fix/Add Artifacts with addComponent

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/wineryArtifacts/artifact.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/wineryArtifacts/artifact.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -68,18 +68,27 @@
 
             <div *ngIf="isImplementationArtifact">
                 <label class="control-label" for="interfaces">Interface Name</label>
-                <select [(ngModel)]="selectedInterface" id="interfaces" name="interfaces" class="form-control">
+                <select [(ngModel)]="selectedInterface" id="interfaces" name="interfaces" class="form-control"
+                        (change)="interfaceAndOperation()">
                     <option *ngFor="let interfaceItem of interfacesList" [ngValue]="interfaceItem">
                         {{interfaceItem.text}}
                     </option>
                 </select>
 
-                <label class="control-label" for="operations">Operations</label>
-                <select [(ngModel)]="selectedOperation" id="operations" name="operations" class="form-control">
+                <label class="control-label" for="operations">Operation Name</label>
+                <i class="fa fa-question-circle" tooltip="click me" (click)="showHelp()"></i>
+                <select [(ngModel)]="selectedOperation" id="operations" name="operations" class="form-control"
+                        (change)="interfaceAndOperation()">
                     <option *ngFor="let operation of selectedInterface?.operations" [ngValue]="operation">
                         {{operation}}
                     </option>
                 </select>
+                <p *ngIf="!hideHelp" class="help-block">
+                    If no operation is selected, the IA must implement all operations of the selected interface.
+                </p>
+                <button *ngIf="selectedOperation" [textContent]="'clear Operation Name'" type="button"
+                        class="btn btn-default btn-xs" (click)="clearOperation()">
+                </button>
             </div>
             <fieldset>
                 <h4>Artifact Template Creation</h4>
@@ -112,7 +121,7 @@
                 </div>
             </fieldset>
             <winery-qname-selector
-                *ngIf="selectedRadioButton === 'createArtifactTemplate' || selectedRadioButton === 'skipArtifactTemplate' "
+                *ngIf="selectedRadioButton === 'skipArtifactTemplate' "
                 [title]="'Artifact Type'"
                 [displayList]="artifactTypesList"
                 [width]="'none'"
@@ -123,19 +132,29 @@
                 *ngIf="selectedRadioButton === 'linkArtifactTemplate'"
                 [title]="'Artifact Template'"
                 [displayList]="artifactTemplatesList"
+                [width]="'none'"
                 (selectedValueChanged)="onSelectedArtifactTemplateChanged($event.value)">
             </winery-qname-selector>
-            <winery-component-exists
-                *ngIf="selectedRadioButton === 'createArtifactTemplate'"
-                [generateData]=artifact
-                [modalRef]="addArtifactModal">
-            </winery-component-exists>
+            <div class="form-group-grouping typeimplementation">
+                <winery-add-component-data-component *ngIf="selectedRadioButton === 'createArtifactTemplate'"
+                                                     #addComponentData
+                                                     [toscaType]="toscaType"
+                                                     [types]="types"
+                                                     [typeRequired]="typeRequired"
+                                                     [newComponentName]="artifact.name"
+                                                     [validation]="validation"
+                                                     (typeChanged)="onSelectedArtifactTypeChanged($event)"
+                                                     (newComponentNameEvent)="setNewArtifactName($event)"
+                                                     (newComponentNamespaceEvent)="setNewArtifactNamespace($event)"
+                                                     (validFormEvent)="setValid($event)">
+                </winery-add-component-data-component>
+            </div>
         </form>
     </winery-modal-body>
     <winery-modal-footer [showDefaultButtons]="false">
         <button type="button" class="btn btn-default" data-dismiss="modal" (click)="addArtifactModal.hide()">Cancel
         </button>
-        <button type="button" [disabled]="!addArtifactForm?.form.valid || noneSelected"
+        <button type="button" [disabled]="!addArtifactForm?.form.valid || noneSelected || valid"
                 class="btn btn-primary"
                 (click)="addConfirmed()">Add
         </button>
@@ -164,7 +183,8 @@
                                                  title="{{file.name}}"><img src="{{file.thumbnailUrl}}"></a></span>
                     </td>
                     <td>
-                        <p class="name"><a href="{{baseUrl + file.url}}" download="{{file.name}}" title="{{file.name}}">{{file.name}}</a>
+                        <p class="name"><a href="{{baseUrl + file.url}}" download="{{file.name}}"
+                                           title="{{file.name}}">{{file.name}}</a>
                         </p>
                     </td>
                     <td>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/wineryArtifacts/artifact.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/wineryArtifacts/artifact.component.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,7 +20,7 @@ import { NameAndQNameApiData, NameAndQNameApiDataList } from '../../../wineryQNa
 import { InstanceService } from '../../instance.service';
 import { GenerateArtifactApiData } from '../interfaces/generateArtifactApiData';
 import { ModalDirective } from 'ngx-bootstrap';
-import { ArtifactApiData } from '../../../model/wineryComponent';
+import { ArtifactApiData, WineryInstance } from '../../../model/wineryComponent';
 import { backendBaseURL, hostURL } from '../../../configuration';
 import { WineryArtifactFilesService } from './artifact.files.service.';
 import { Router } from '@angular/router';
@@ -29,12 +29,18 @@ import { GenerateData } from '../../../wineryComponentExists/wineryComponentExis
 import { ToscaTypes } from '../../../model/enums';
 import { WineryVersion } from '../../../model/wineryVersion';
 import { HttpErrorResponse } from '@angular/common/http';
+import { SelectData } from '../../../model/selectData';
+import { Utils } from '../../../wineryUtils/utils';
+import { SectionService } from '../../../section/section.service';
+import { AddComponentValidation } from '../../../wineryAddComponentModule/addComponentValidation';
+import { ExistService } from '../../../wineryUtils/existService';
+import { WineryAddComponentDataComponent } from '../../../wineryAddComponentDataModule/addComponentData.component';
 
 @Component({
     selector: 'winery-artifact',
     templateUrl: 'artifact.component.html',
     styleUrls: ['artifact.component.css'],
-    providers: [WineryArtifactService, WineryArtifactFilesService]
+    providers: [WineryArtifactService, WineryArtifactFilesService, SectionService]
 })
 export class WineryArtifactComponent implements OnInit {
 
@@ -43,7 +49,7 @@ export class WineryArtifactComponent implements OnInit {
     name: string;
     loading = true;
     elementToRemove: ArtifactApiData;
-    artifactsData: ArtifactApiData[];
+    artifactsData: ArtifactApiData[] = [];
     interfacesList: SelectableInterface[];
     newArtifact: GenerateArtifactApiData = new GenerateArtifactApiData();
     artifact: GenerateData = new GenerateData();
@@ -72,16 +78,28 @@ export class WineryArtifactComponent implements OnInit {
     @ViewChild('addArtifactModal') addArtifactModal: ModalDirective;
     @ViewChild('uploadFileModal') uploadFileModal: ModalDirective;
     @ViewChild('removeElementModal') removeElementModal: ModalDirective;
+    @ViewChild('addComponentData') addComponentData: WineryAddComponentDataComponent;
 
     private implementationArtifactColumns = [
         { title: 'Interface Name', name: 'interfaceName' },
         { title: 'Operation Name', name: 'operationName' }
     ];
+    toscaType = ToscaTypes.ArtifactTemplate;
+    valid: boolean;
+    validation: any;
+    hideHelp = true;
+    private typeRequired = false;
+    private types: SelectData[];
+    private createComponent: boolean;
+    private nodetype: string;
 
     constructor(private service: WineryArtifactService,
                 public sharedData: InstanceService,
                 private notify: WineryNotificationService,
                 private fileService: WineryArtifactFilesService,
+                private sectionService: SectionService,
+                private existService: ExistService,
+                private nodeTypeService: InstanceService,
                 private router: Router) {
     }
 
@@ -101,6 +119,11 @@ export class WineryArtifactComponent implements OnInit {
         }
 
         this.name = this.isImplementationArtifact ? 'Implementation' : 'Deployment';
+        this.nodeTypeService.getComponentData()
+            .subscribe(
+                compData => this.handleComponentData(compData)
+            );
+        this.getTypes();
     }
 
     onAddClick() {
@@ -111,9 +134,12 @@ export class WineryArtifactComponent implements OnInit {
         } else {
             this.artifact.namespace = this.sharedData.toscaComponent.namespace;
         }
-        const implementation = this.isImplementationArtifact ? 'Implementation' : 'Deployment';
-        this.artifact.name = this.sharedData.toscaComponent.localName.replace('_', '-') + '-' + implementation + 'Artifact';
+        this.artifact.namespace = this.artifact.namespace.slice(0, this.sharedData.toscaComponent.namespace.lastIndexOf('/') + 1) + ToscaTypes.ArtifactTemplate;
+        this.artifact.name = this.nodetype;
         this.artifact.toscaType = ToscaTypes.ArtifactTemplate;
+        this.existCheck();
+        this.addComponentData.createArtifactName(this.sharedData.toscaComponent, this.sharedData.currentVersion,
+            this.selectedOperation, this.isImplementationArtifact, this.nodetype);
         this.addArtifactModal.show();
     }
 
@@ -137,8 +163,8 @@ export class WineryArtifactComponent implements OnInit {
             this.noneSelected = true;
         } else {
             this.noneSelected = false;
-            this.selectedArtifactType = value;
-            this.newArtifact.artifactType = value;
+            this.selectedArtifactType = value.id;
+            this.newArtifact.artifactType = value.id;
         }
     }
 
@@ -170,7 +196,6 @@ export class WineryArtifactComponent implements OnInit {
         if (this.selectedRadioButton === 'createArtifactTemplate') {
             const version = new WineryVersion('', 1, 1);
             this.newArtifact.autoCreateArtifactTemplate = 'true';
-            this.newArtifact.artifactTemplateName = this.artifact.name + WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR + version.toString();
             this.newArtifact.artifactTemplateNamespace = this.artifact.namespace;
             this.makeArtifactUrl();
         } else if (this.selectedRadioButton === 'linkArtifactTemplate') {
@@ -345,7 +370,7 @@ export class WineryArtifactComponent implements OnInit {
     private makeArtifactUrl() {
         this.artifactUrl = backendBaseURL + '/artifacttemplates/' + encodeURIComponent(encodeURIComponent(
             this.newArtifact.artifactTemplateNamespace)) + '/' + this.newArtifact.artifactTemplateName + '/';
-        this.uploadUrl = this.artifactUrl + 'files/';
+        this.uploadUrl = this.artifactUrl + 'files';
     }
 
     private getNamespaceAndLocalNameFromQName(qname: string): { namespace: string; localname: string; } {
@@ -371,4 +396,77 @@ export class WineryArtifactComponent implements OnInit {
 
     }
 
+    private getTypes(componentType?: SelectData) {
+        const typesUrl = Utils.getTypeOfTemplateOrImplementation(this.toscaType);
+        if (!isNullOrUndefined(typesUrl) && !componentType) {
+            this.loading = true;
+            this.typeRequired = true;
+            this.sectionService.getSectionData('/' + typesUrl + '?grouped=angularSelect')
+                .subscribe(
+                    data => this.handleTypes(data),
+                    error => this.showError(error)
+                );
+        } else {
+            this.typeRequired = false;
+        }
+    }
+
+    private handleTypes(types: SelectData[]): void {
+        this.types = types.length > 0 ? types : null;
+        this.loading = false;
+    }
+
+    setNewArtifactName(name: string) {
+        this.newArtifact.artifactTemplateName = name;
+    }
+
+    setNewArtifactNamespace(namespace: string) {
+        this.artifact.namespace = namespace;
+    }
+
+    setValid(valid: boolean) {
+        this.valid = !valid;
+    }
+
+    private existCheck() {
+        const newComponentVersion: WineryVersion = new WineryVersion('', 1, 1);
+        const newComponentFinalName = this.artifact.name + WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR + newComponentVersion.toString();
+        this.artifactUrl = backendBaseURL + '/artifacttemplates/' + encodeURIComponent(encodeURIComponent(
+            this.artifact.namespace)) + '/' + newComponentFinalName + '/';
+
+        this.existService.check(this.artifactUrl)
+            .subscribe(
+                () => this.validate(false),
+                () => this.validate(true)
+            );
+    }
+
+    private validate(create: boolean) {
+        this.validation = new AddComponentValidation();
+        this.createComponent = create;
+        if (!this.createComponent) {
+            this.validation.noDuplicatesAllowed = true;
+        } else {
+            this.validation.noDuplicatesAllowed = false;
+        }
+    }
+
+    interfaceAndOperation() {
+        this.addComponentData.createArtifactName(this.sharedData.toscaComponent, this.sharedData.currentVersion,
+            this.selectedOperation, this.isImplementationArtifact, this.nodetype);
+    }
+
+    private handleComponentData(compData: WineryInstance) {
+        const node = compData.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].nodeType;
+        this.nodetype = node.substring(node.indexOf('}') + 1, node.indexOf('_'));
+    }
+
+    showHelp() {
+        this.hideHelp = !this.hideHelp;
+    }
+
+    clearOperation() {
+        this.selectedOperation = '';
+        this.interfaceAndOperation();
+    }
 }

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/wineryArtifacts/artifact.module.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/wineryArtifacts/artifact.module.ts
@@ -22,6 +22,7 @@ import {FormsModule} from '@angular/forms';
 import {WineryQNameSelectorModule} from '../../../wineryQNameSelector/wineryQNameSelector.module';
 import {WineryComponentExistsModule} from '../../../wineryComponentExists/wineryComponentExists.module';
 import {WineryUploaderModule} from '../../../wineryUploader/wineryUploader.module';
+import { WineryAddDataModule } from '../../../wineryAddComponentDataModule/addComponentData.module';
 
 @NgModule({
     imports: [
@@ -34,6 +35,7 @@ import {WineryUploaderModule} from '../../../wineryUploader/wineryUploader.modul
         WineryQNameSelectorModule,
         WineryUploaderModule,
         FormsModule,
+        WineryAddDataModule,
     ],
     exports: [WineryArtifactComponent],
     declarations: [

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.html
@@ -1,0 +1,139 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ This program and the accompanying materials are made available under the
+  ~ terms of the Eclipse Public License 2.0 which is available at
+  ~ http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+  ~ which is available at https://www.apache.org/licenses/LICENSE-2.0.
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<form #addComponentForm="ngForm">
+    <div *ngIf="!loading; else showLoader">
+        <div *ngIf="!validation?.noTypeAvailable; else showNoTypeAvailable">
+            <div class="form-group">
+                <label for="componentName" class="control-label">Name</label>
+                <input type="text"
+                       class="form-control"
+                       id="componentName"
+                       name="componentName"
+                       #newName="ngModel"
+                       [(ngModel)]="newComponentName"
+                       (input)="onInputChange()"
+                       required>
+                <div *ngIf="(newName.errors || validation?.noDuplicatesAllowed)"
+                     class="alert alert-danger">
+                    <div [hidden]="!validation?.noDuplicatesAllowed">
+                        No duplicates allowed!
+                    </div>
+                    <div [hidden]="!newName?.errors?.required">
+                        Name is required!
+                    </div>
+                </div>
+                <div *ngIf="validation?.differentNamespaceDuplicateWarning
+                                    || validation?.differentCaseDuplicateWarning"
+                     class="alert alert-warning">
+                    <div [hidden]="!validation.differentCaseDuplicateWarning">
+                        There is a duplicate with a different case!
+                    </div>
+                    <div [hidden]="!validation.differentNamespaceDuplicateWarning">
+                        There is a duplicate in another namespace!
+                    </div>
+                </div>
+                <br>
+                <div>
+                    <div>
+                        <label for="newComponentVersion" class="control-label">Versioning:</label>
+                        <button type="button" class="btn btn-default btn-xs collapsebtn"
+                                (click)="versioning()" style="float: right;">
+                            <span class="collapsespan" aria-hidden="true" [class.collapsed]="collapseVersioning"></span>
+                        </button>
+                    </div>
+                    <div [collapse]="collapseVersioning">
+                        <label for="newComponentVersion">
+                            Component version
+                        </label>
+                        <i class="fa fa-question-circle" tooltip="click me" (click)="showHelp()"></i>
+                        <input type="text"
+                               id="newComponentVersion"
+                               name="newComponentVersion"
+                               class="form-control"
+                               #newVersion="ngModel"
+                               (input)="onInputChange()"
+                               [(ngModel)]="newComponentVersion.componentVersion">
+                        <div *ngIf="(newName.dirty || newName.touched) && validation?.noVersionProvidedWarning"
+                             class="alert alert-warning">
+                            <div>
+                                You haven't provided a version!
+                            </div>
+                        </div>
+                        <p *ngIf="!hideHelp" class="help-block">
+                            The <b>component version</b> specifies the components' external version defined by the
+                            creator of the
+                            software (e.g., Apache Tomcat 8.5.1 has a component version <code>8.5.1</code>). Winery adds
+                            management
+                            to the software which is versioned independently of the softwares' version. The version
+                            inside Winery is
+                            called <b>management version</b> and is mandatory. It consists of a <b>winery version</b>
+                            and a <b>work
+                            in progress (wip)</b> version. Upon the creation of a new component, both management
+                            versions are set
+                            automatically with their initial values of 1. The generated name is displayed in the 'Final
+                            name' field
+                            (e.g., the final id for Apache Tomcat 8.5.1 is <code>Tomcat_8.5.1-w1-wip1</code>).
+                            <br><br>
+                            When developing a TOSCA definition, a the wip version is appended until the TOSCA definition
+                            is stable.
+                            To test a TOSCA definition, the wip version can be committed. After a version was committed,
+                            a new
+                            version must be added to apply further changes. Thus, a new wip version must be added (e.g.,
+                            <code>Tomcat_8.5.1-w1-wip1</code> followed by <code>Tomcat_8.5.1-w1-wip2</code> released as
+                            <code>Tomcat_8.5.1-w1</code> must be followed by <code>Tomcat_8.5.1-w2-wip1</code> to enable
+                            changes).
+                            Thereby, different component versions do not affect each other (e.g., <code>Tomcat_8.5.1-w2-wip1</code>
+                            can be created while <code>Tomcat_9.0.1-w3</code> exists).
+                        </p>
+                        <div *ngIf="(validation?.noUnderscoresAllowed)
+                                    && (newVersion.dirty || newVersion.touched)"
+                             class="alert alert-danger">
+                            <div [hidden]="!validation?.noUnderscoresAllowed">
+                                Underscores are not allowed in the version!<br>Please replace them with dashes.
+                            </div>
+                        </div>
+                        <br>
+                        <label for="finalName">Final name</label>
+                        <code class="form-control" id="finalName">{{ newComponentFinalName }}</code>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group" *ngIf="types">
+                <label for="typeSelect" class="control-label">Type</label>
+                <ng-select id="typeSelect" [items]="types" (selected)="typeSelected($event)"
+                           [active]="[newComponentSelectedType]"></ng-select>
+            </div>
+            <br>
+            <!-- pattern parameter is required to enable form validation -->
+            <winery-namespace-selector #namespaceInput
+                                       name="namespace"
+                                       required
+                                       pattern="^\S*$"
+                                       [(ngModel)]="newComponentNamespace"
+                                       [isRequired]="true"
+                                       [useStartNamespace]="useStartNamespace"
+                                       [toscaType]="toscaType">
+            </winery-namespace-selector>
+        </div>
+        <ng-template #showNoTypeAvailable>
+            <alert [type]="'danger'">
+                There are no types available. Please add a type first!
+            </alert>
+        </ng-template>
+    </div>
+    <ng-template #showLoader>
+        <winery-loader></winery-loader>
+    </ng-template>
+</form>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.ts
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { SectionService } from '../section/section.service';
+import { InheritanceService } from '../instance/sharedComponents/inheritance/inheritance.service';
+import { TooltipConfig } from 'ngx-bootstrap';
+import { AddComponentValidation } from '../wineryAddComponentModule/addComponentValidation';
+import { isNullOrUndefined } from 'util';
+import { WineryVersion } from '../model/wineryVersion';
+import { SelectData } from '../model/selectData';
+import { ToscaTypes } from '../model/enums';
+import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
+import { ExistService } from '../wineryUtils/existService';
+import { backendBaseURL } from '../configuration';
+import { ToscaComponent } from '../model/toscaComponent';
+
+export function getToolTip(): TooltipConfig {
+    return Object.assign(new TooltipConfig(), { placement: 'right' });
+}
+
+@Component({
+    selector: 'winery-add-component-data-component',
+    templateUrl: 'addComponentData.component.html',
+    providers: [
+        SectionService,
+        InheritanceService,
+        WineryNotificationService,
+        {
+            provide: TooltipConfig,
+            useFactory: getToolTip
+        }
+    ]
+})
+
+export class WineryAddComponentDataComponent {
+    @Input() toscaType: ToscaTypes;
+    @Input() types: SelectData[];
+    @Input() typeRequired: boolean;
+    @Input() newComponentName: string;
+    @Input() newComponentSelectedType: SelectData = new SelectData();
+    @Input() validation: AddComponentValidation;
+    @Output() typeChanged: EventEmitter<SelectData> = new EventEmitter();
+    @Output() newComponentNameEvent: EventEmitter<string> = new EventEmitter();
+    @Output() newComponentNamespaceEvent: EventEmitter<string> = new EventEmitter();
+    @Output() validFormEvent: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+    loading: boolean;
+    newComponentFinalName: string;
+    newComponentVersion: WineryVersion = new WineryVersion('', 1, 1);
+    newComponentNamespace: string;
+    collapseVersioning = true;
+    hideHelp = true;
+    storage: Storage = localStorage;
+    useStartNamespace = true;
+
+    private readonly storageKey = 'hideVersionHelp';
+    private artifactUrl: string;
+
+    constructor(private sectionService: SectionService, private notify: WineryNotificationService,
+                private existService: ExistService) {
+    }
+
+    onInputChange() {
+        this.validation = new AddComponentValidation();
+        this.newComponentFinalName = this.newComponentName;
+
+        if (this.typeRequired && isNullOrUndefined(this.newComponentSelectedType)) {
+            this.validation.noTypeAvailable = true;
+            return { noTypeAvailable: true };
+        }
+        this.determineFinalName();
+        if (this.newComponentVersion.componentVersion) {
+            this.validation.noUnderscoresAllowed = this.newComponentVersion.componentVersion.includes('_');
+            if (this.validation.noUnderscoresAllowed) {
+                return { noUnderscoresAllowed: true };
+            }
+        }
+
+        this.validation.noVersionProvidedWarning = isNullOrUndefined(this.newComponentVersion.componentVersion)
+            || this.newComponentVersion.componentVersion.length === 0;
+        this.newComponentNameEvent.emit(this.newComponentFinalName);
+        this.newComponentNamespaceEvent.emit(this.newComponentNamespace);
+    }
+
+    showHelp() {
+        if (this.hideHelp) {
+            this.storage.removeItem(this.storageKey);
+        } else {
+            this.storage.setItem(this.storageKey, 'true');
+        }
+        this.hideHelp = !this.hideHelp;
+    }
+
+    typeSelected(type: SelectData) {
+        this.newComponentSelectedType = type;
+        this.typeChanged.emit(this.newComponentSelectedType);
+    }
+
+    private versioning() {
+        this.collapseVersioning = !this.collapseVersioning;
+    }
+
+    private determineFinalName() {
+        if (!isNullOrUndefined(this.newComponentFinalName) && this.newComponentFinalName.length > 0) {
+            this.newComponentFinalName += WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR + this.newComponentVersion.toString();
+            this.createUrlAndCheck();
+        }
+    }
+
+    createUrlAndCheck() {
+        this.artifactUrl = backendBaseURL + '/' + this.toscaType + '/' + encodeURIComponent(encodeURIComponent(
+            this.newComponentNamespace)) + '/' + this.newComponentFinalName + '/';
+
+        this.existService.check(this.artifactUrl)
+            .subscribe(
+                () => this.validate(false),
+                () => this.validate(true)
+            );
+        this.newComponentNameEvent.emit(this.newComponentFinalName);
+        this.newComponentNamespaceEvent.emit(this.newComponentNamespace);
+    }
+
+    private validate(create: boolean) {
+        this.validation = new AddComponentValidation();
+        if (!create) {
+            this.validation.noDuplicatesAllowed = true;
+            this.validFormEvent.emit(false);
+            return { noDuplicatesAllowed: true };
+
+        } else {
+            this.validation.noDuplicatesAllowed = false;
+            this.validFormEvent.emit(true);
+            return { noDuplicatesAllowed: false };
+        }
+    }
+
+    createNoteTypeImplementationName(fullName: SelectData) {
+        const name = fullName.text.substring(0, fullName.text.lastIndexOf('_'));
+        const newVersion = fullName.text.slice(fullName.text.indexOf('_'), fullName.text.length);
+        this.newComponentVersion.componentVersion = newVersion.substring(1, newVersion.indexOf('-'));
+        this.newComponentName = name + '-Impl';
+        this.newComponentFinalName = this.newComponentName + newVersion;
+        this.createUrlAndCheck();
+    }
+
+    createArtifactName(toscaComponent: ToscaComponent, wineryVersion: WineryVersion, operation: string,
+                       isImplementationArtifact: boolean, nodeType: string) {
+        const implementation = isImplementationArtifact ? 'IA' : 'DA';
+        const newVersion = wineryVersion.getWineryAndWipVersion();
+        this.newComponentFinalName = nodeType;
+        if (operation) {
+            this.newComponentVersion.componentVersion = operation + '-' + wineryVersion.getComponentVersion()
+                + WineryVersion.WINERY_VERSION_SEPARATOR + implementation;
+            this.newComponentFinalName += WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR
+                + this.newComponentVersion.componentVersion + WineryVersion.WINERY_VERSION_SEPARATOR + newVersion;
+        } else {
+            this.newComponentVersion.componentVersion = wineryVersion.getComponentVersion()
+                + WineryVersion.WINERY_VERSION_SEPARATOR + implementation;
+            this.newComponentFinalName += WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR
+                + this.newComponentVersion.componentVersion + WineryVersion.WINERY_VERSION_SEPARATOR + newVersion;
+        }
+        this.createUrlAndCheck();
+    }
+}

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.module.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,8 +12,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  ********************************************************************************/
 import { NgModule } from '@angular/core';
-
-import { WineryAddComponent } from './addComponent.component';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { WineryModalModule } from '../wineryModalModule/winery.modal.module';
@@ -24,7 +22,7 @@ import { RouterModule } from '@angular/router';
 import { WineryLoaderModule } from '../wineryLoader/wineryLoader.module';
 import { SelectModule } from 'ng2-select';
 import { AlertModule, CollapseModule, TooltipModule } from 'ngx-bootstrap';
-import { WineryAddDataModule } from '../wineryAddComponentDataModule/addComponentData.module';
+import { WineryAddComponentDataComponent } from './addComponentData.component';
 
 @NgModule({
     imports: [
@@ -40,10 +38,9 @@ import { WineryAddDataModule } from '../wineryAddComponentDataModule/addComponen
         WineryNotificationModule,
         WineryNamespaceSelectorModule,
         WineryDuplicateValidatorModule,
-        WineryAddDataModule,
     ],
-    exports: [WineryAddComponent],
-    declarations: [WineryAddComponent],
+    exports: [WineryAddComponentDataComponent],
+    declarations: [WineryAddComponentDataComponent],
 })
-export class WineryAddModule {
+export class WineryAddDataModule {
 }

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -14,129 +14,23 @@
 <winery-modal bsModal #addModal="bs-modal" [modalRef]="addModal">
     <winery-modal-header [title]="'Add a new ' + addModalType"></winery-modal-header>
     <winery-modal-body>
-        <form #addComponentForm="ngForm">
-            <div *ngIf="!loading; else showLoader">
-                <div *ngIf="!validation?.noTypeAvailable; else showNoTypeAvailable">
-                    <div class="form-group">
-                        <label for="componentName" class="control-label">Name</label>
-                        <input type="text"
-                               class="form-control"
-                               id="componentName"
-                               name="componentName"
-                               #newName="ngModel"
-                               [(ngModel)]="newComponentName"
-                               (input)="onInputChange()"
-                               required>
-                        <div *ngIf="(newName.errors || validation?.noDuplicatesAllowed)
-                                && (newName.dirty || newName.touched)"
-                             class="alert alert-danger">
-                            <div [hidden]="!validation?.noDuplicatesAllowed">
-                                No duplicates allowed!
-                            </div>
-                            <div [hidden]="!newName?.errors?.required">
-                                Name is required!
-                            </div>
-                        </div>
-                        <div *ngIf="validation?.differentNamespaceDuplicateWarning
-                                    || validation?.differentCaseDuplicateWarning"
-                             class="alert alert-warning">
-                            <div [hidden]="!validation.differentCaseDuplicateWarning">
-                                There is a duplicate with a different case!
-                            </div>
-                            <div [hidden]="!validation.differentNamespaceDuplicateWarning">
-                                There is a duplicate in another namespace!
-                            </div>
-                        </div>
-                        <br>
-                        <div>
-                            <div>
-                                <label for="newComponentVersion" class="control-label">Versioning:</label>
-                                <button type="button" class="btn btn-default btn-xs collapsebtn"
-                                        (click)="collapseVersioning = !collapseVersioning" style="float: right;">
-                                    <span class="collapsespan" aria-hidden="true" [class.collapsed]="collapseVersioning"></span>
-                                </button>
-                            </div>
-                            <div [collapse]="collapseVersioning">
-                                <label for="newComponentVersion">
-                                    Component version
-                                </label>
-                                <i class="fa fa-question-circle" tooltip="click me" (click)="showHelp()"></i>
-                                <input type="text"
-                                       id="newComponentVersion"
-                                       name="newComponentVersion"
-                                       class="form-control"
-                                       #newVersion="ngModel"
-                                       (input)="onInputChange()"
-                                       [(ngModel)]="newComponentVersion.componentVersion">
-                                <div *ngIf="(newName.dirty || newName.touched) && validation?.noVersionProvidedWarning"
-                                     class="alert alert-warning">
-                                    <div>
-                                        You haven't provided a version!
-                                    </div>
-                                </div>
-                                <p *ngIf="!hideHelp" class="help-block">
-                                    The <b>component version</b> specifies the components' external version defined by the creator of the
-                                    software (e.g., Apache Tomcat 8.5.1 has a component version <code>8.5.1</code>). Winery adds management
-                                    to the software which is versioned independently of the softwares' version. The version inside Winery is
-                                    called <b>management version</b> and is mandatory. It consists of a <b>winery version</b> and a <b>work
-                                    in progress (wip)</b> version. Upon the creation of a new component, both management versions are set
-                                    automatically with their initial values of 1. The generated name is displayed in the 'Final name' field
-                                    (e.g., the final id for Apache Tomcat 8.5.1 is <code>Tomcat_8.5.1-w1-wip1</code>).
-                                    <br><br>
-                                    When developing a TOSCA definition, a the wip version is appended until the TOSCA definition is stable.
-                                    To test a TOSCA definition, the wip version can be committed. After a version was committed, a new
-                                    version must be added to apply further changes. Thus, a new wip version must be added (e.g.,
-                                    <code>Tomcat_8.5.1-w1-wip1</code> followed by <code>Tomcat_8.5.1-w1-wip2</code> released as
-                                    <code>Tomcat_8.5.1-w1</code> must be followed by <code>Tomcat_8.5.1-w2-wip1</code> to enable changes).
-                                    Thereby, different component versions do not affect each other (e.g., <code>Tomcat_8.5.1-w2-wip1</code>
-                                    can be created while <code>Tomcat_9.0.1-w3</code> exists).
-                                </p>
-                                <div *ngIf="(validation?.noUnderscoresAllowed)
-                                    && (newVersion.dirty || newVersion.touched)"
-                                     class="alert alert-danger">
-                                    <div [hidden]="!validation?.noUnderscoresAllowed">
-                                        Underscores are not allowed in the version!<br>Please replace them with dashes.
-                                    </div>
-                                </div>
-                                <br>
-                                <label for="finalName">Final name</label>
-                                <code class="form-control" id="finalName">{{ newComponentFinalName }}</code>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="form-group" *ngIf="types">
-                        <label for="typeSelect" class="control-label">Type</label>
-                        <ng-select id="typeSelect" [items]="types" (selected)="typeSelected($event)"
-                                   [active]="[newComponentSelectedType]"></ng-select>
-                    </div>
-                    <br>
-                    <!-- pattern parameter is required to enable form validation -->
-                    <winery-namespace-selector #namespaceInput
-                                               name="namespace"
-                                               required
-                                               pattern="^\S*$"
-                                               [(ngModel)]="newComponentNamespace"
-                                               [isRequired]="true"
-                                               [useStartNamespace]="useStartNamespace"
-                                               [toscaType]="toscaType">
-                    </winery-namespace-selector>
-                </div>
-                <ng-template #showNoTypeAvailable>
-                    <alert [type]="'danger'">
-                        There are no types available. Please add a type first!
-                    </alert>
-                </ng-template>
-            </div>
-            <ng-template #showLoader>
-                <winery-loader></winery-loader>
-            </ng-template>
-        </form>
+        <winery-add-component-data-component #addComponentData
+                                             [toscaType]="toscaType"
+                                             [types]="types"
+                                             [typeRequired]="typeRequired"
+                                             [newComponentName]="newComponentName"
+                                             [newComponentSelectedType]="newComponentSelectedType"
+                                             (typeChanged)="typeSelected($event)"
+                                             (newComponentNameEvent)="setNewComponentName($event)"
+                                             (newComponentNamespaceEvent)="setNewComponentNamespace($event)"
+                                             (validFormEvent)="setValid($event)">
+        </winery-add-component-data-component>
     </winery-modal-body>
     <winery-modal-footer
         (onOk)="addComponent()"
         [closeButtonLabel]="'Cancel'"
         [okButtonLabel]="'Add'"
         [hideOnOk]="false"
-        [disableOkButton]="!addComponentForm?.valid || validation?.noTypeAvailable">
+        [disableOkButton]="valid || validation?.noTypeAvailable">
     </winery-modal-footer>
 </winery-modal>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,21 +17,16 @@ import { SelectData } from '../model/selectData';
 import { WineryNotificationService } from '../wineryNotificationModule/wineryNotification.service';
 import { ToscaTypes } from '../model/enums';
 import { Router } from '@angular/router';
-import { NgForm } from '@angular/forms';
 import { Utils } from '../wineryUtils/utils';
 import { SectionData } from '../section/sectionData';
 import { ModalDirective, TooltipConfig } from 'ngx-bootstrap';
-import { WineryNamespaceSelectorComponent } from '../wineryNamespaceSelector/wineryNamespaceSelector.component';
 import { InheritanceService } from '../instance/sharedComponents/inheritance/inheritance.service';
 import { WineryVersion } from '../model/wineryVersion';
 import { AddComponentValidation } from './addComponentValidation';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { ExistService } from '../wineryUtils/existService';
 import { backendBaseURL } from '../configuration';
-
-export function getToolTip(): TooltipConfig {
-    return Object.assign(new TooltipConfig(), { placement: 'right' });
-}
+import { WineryAddComponentDataComponent } from '../wineryAddComponentDataModule/addComponentData.component';
 
 @Component({
     selector: 'winery-add-component',
@@ -39,10 +34,6 @@ export function getToolTip(): TooltipConfig {
     providers: [
         SectionService,
         InheritanceService,
-        {
-            provide: TooltipConfig,
-            useFactory: getToolTip
-        }
     ]
 })
 
@@ -70,13 +61,13 @@ export class WineryAddComponent {
 
     types: SelectData[];
 
-    @ViewChild('addComponentForm') addComponentForm: NgForm;
     @ViewChild('addModal') addModal: ModalDirective;
-    @ViewChild('namespaceInput') namespaceInput: WineryNamespaceSelectorComponent;
+    @ViewChild('addComponentData') addComponentData: WineryAddComponentDataComponent;
     useStartNamespace = true;
 
     private readonly storageKey = 'hideVersionHelp';
     collapseVersioning: boolean;
+    valid: boolean;
 
     constructor(private sectionService: SectionService,
                 private existService: ExistService,
@@ -119,7 +110,6 @@ export class WineryAddComponent {
                     error => this.handleError(error)
                 );
         }
-
         if (!this.loading) {
             this.showModal();
         }
@@ -173,18 +163,15 @@ export class WineryAddComponent {
             this.newComponentNamespace = this.namespace;
         } else {
             this.newComponentNamespace = '';
-
-            if (this.addComponentForm) {
-                this.addComponentForm.reset();
-            }
         }
         this.change.detectChanges();
 
         this.newComponentSelectedType = this.types ?
             this.types[0].children ? this.types[0].children[0] : this.types[0]
             : null;
-        this.namespaceInput.writeValue(this.newComponentNamespace);
-
+        if (this.newComponentSelectedType) {
+            this.addComponentData.createNoteTypeImplementationName(this.newComponentSelectedType);
+        }
         this.addModal.show();
     }
 
@@ -214,51 +201,23 @@ export class WineryAddComponent {
         this.notify.error(error.message, error.statusText);
     }
 
-    onInputChange() {
-        this.validation = new AddComponentValidation();
-        this.newComponentFinalName = this.newComponentName;
-
-        if (this.typeRequired && !this.newComponentSelectedType) {
-            this.validation.noTypeAvailable = true;
-            return { noTypeAvailable: true };
-        }
-
-        if (this.newComponentFinalName && this.newComponentFinalName.length > 0) {
-            this.newComponentFinalName += WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR + this.newComponentVersion.toString();
-            const duplicate = this.componentData.find((component) => component.name.toLowerCase() === this.newComponentFinalName.toLowerCase());
-
-            if (duplicate) {
-                const namespace = this.newComponentNamespace.endsWith('/') ? this.newComponentNamespace.slice(0, -1) : this.newComponentNamespace;
-
-                if (duplicate.namespace === namespace) {
-                    if (duplicate.name === this.newComponentFinalName) {
-                        this.validation.noDuplicatesAllowed = true;
-                        return { noDuplicatesAllowed: true };
-                    } else {
-                        this.validation.differentCaseDuplicateWarning = true;
-                    }
-                } else {
-                    this.validation.differentNamespaceDuplicateWarning = true;
-                }
-            }
-        }
-
-        if (this.newComponentVersion.componentVersion) {
-            this.validation.noUnderscoresAllowed = this.newComponentVersion.componentVersion.includes('_');
-            if (this.validation.noUnderscoresAllowed) {
-                return { noUnderscoresAllowed: true };
-            }
-        }
-
-        this.validation.noVersionProvidedWarning = !this.newComponentVersion.componentVersion
-            || this.newComponentVersion.componentVersion.length === 0;
-    }
-
     private handleComponentData(data: SectionData[]) {
         this.componentData = data;
 
         if (!this.typeRequired || this.types) {
             this.showModal();
         }
+    }
+
+    setNewComponentName(name: string) {
+        this.newComponentFinalName = name;
+    }
+
+    setNewComponentNamespace(namespace: string) {
+        this.newComponentNamespace = namespace;
+    }
+
+    setValid(valid: boolean) {
+        this.valid = !valid;
     }
 }


### PR DESCRIPTION
Signed-off-by: Björn Müller <bjoern.mueller@kanu-baerchen.de>

-Fix wrong namespace when adding an artifact template to a nodetype implementation
-addComponent component for adding an artifact template

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
