### PR TITLE
Add endpoint to retrieve TOSCA Light models

### DIFF
--- a/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/toscalight/ToscaLightChecker.java
+++ b/org.eclipse.winery.common/src/main/java/org/eclipse/winery/common/toscalight/ToscaLightChecker.java
@@ -81,6 +81,7 @@ public class ToscaLightChecker {
         QName serviceTemplateQName = new QName(serviceTemplate.getTargetNamespace(), serviceTemplate.getName());
         this.errorList = new HashMap<>();
         this.errorList.put(serviceTemplateQName, new ArrayList<>());
+        this.foundError = false;
 
         // Tags -> metadata
 

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/model/toscaComponent.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/model/toscaComponent.ts
@@ -43,7 +43,7 @@ export class ToscaComponent {
                 this.xmlCsarPath = this.backendPath + '/?csar';
                 this.provenanceCsarPath = this.xmlCsarPath + '&addToProvenance';
                 this.yamlCsarPath = this.backendPath + '/?yaml&csar';
-                this.edmmExportPath = this.backendPath + '/?edmm';
+                this.edmmExportPath = this.backendPath + '/?edmm&edmmUseAbsolutePaths';
             }
         }
         if (this.localName) {

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/MainResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/MainResource.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -33,11 +34,16 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
+import javax.xml.namespace.QName;
 
+import org.eclipse.winery.common.version.VersionUtils;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.repository.export.EdmmUtils;
 import org.eclipse.winery.repository.importing.CsarImportOptions;
 import org.eclipse.winery.repository.importing.CsarImporter;
 import org.eclipse.winery.repository.importing.ImportMetaInformation;
 import org.eclipse.winery.repository.rest.RestUtils;
+import org.eclipse.winery.repository.rest.datatypes.ComponentId;
 import org.eclipse.winery.repository.rest.resources.API.APIResource;
 import org.eclipse.winery.repository.rest.resources.admin.AdminTopResource;
 import org.eclipse.winery.repository.rest.resources.compliancerules.ComplianceRulesResource;
@@ -270,5 +276,22 @@ public class MainResource {
         } else {
             return Response.status(Status.BAD_REQUEST).entity(errors).build();
         }
+    }
+
+    @GET
+    @Path("toscaLightModels")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<ComponentId> getToscaLightModels() {
+        return EdmmUtils.getAllToscaLightCompliantModels().entrySet()
+            .stream()
+            .sorted()
+            .map(entry -> {
+                QName qName = entry.getKey();
+                TServiceTemplate serviceTemplate = entry.getValue();
+                return new ComponentId(qName.getLocalPart(), serviceTemplate.getName(), qName.getNamespaceURI(),
+                    qName, null, VersionUtils.getVersion(qName.getLocalPart())
+                );
+            })
+            .collect(Collectors.toList());
     }
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/AbstractComponentInstanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/AbstractComponentInstanceResource.java
@@ -303,7 +303,7 @@ public abstract class AbstractComponentInstanceResource implements Comparable<Ab
         // thus, there is the hack with ?csar and ?yaml
         // the hack is implemented at getDefinitionsAsResponse
         if ((csar != null) || (yaml != null) || (xml != null) || (edmm != null)) {
-            return this.getDefinitionsAsResponse(csar, yaml, edmm, addToProvenance, edmmUseAbsolutePaths, uriInfo);
+            return this.getDefinitionsAsResponse(csar, yaml, edmm, edmmUseAbsolutePaths, addToProvenance, uriInfo);
         }
         String repositoryUiUrl = Environments.getInstance().getUiConfig().getEndpoints().get("repositoryUiUrl");
         String uiUrl = uriInfo.getAbsolutePath().toString().replaceAll(Environments.getInstance().getUiConfig().getEndpoints().get("repositoryApiUrl"), repositoryUiUrl);

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/AbstractComponentInstanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/AbstractComponentInstanceResource.java
@@ -258,6 +258,7 @@ public abstract class AbstractComponentInstanceResource implements Comparable<Ab
         @QueryParam(value = "csar") String csar,
         @QueryParam(value = "yaml") String yaml,
         @QueryParam(value = "edmm") String edmm,
+        @QueryParam(value = "edmmUseAbsolutePaths") String edmmUseAbsolutePaths,
         @QueryParam(value = "addToProvenance") String addToProvenance,
         @Context UriInfo uriInfo
     ) {
@@ -267,7 +268,7 @@ public abstract class AbstractComponentInstanceResource implements Comparable<Ab
         }
 
         if (edmm != null && this.element instanceof TServiceTemplate) {
-            return RestUtils.getEdmmModel((TServiceTemplate) this.element);
+            return RestUtils.getEdmmModel((TServiceTemplate) this.element, edmmUseAbsolutePaths != null);
         }
 
         // TODO: It should be possible to specify ?yaml&csar to retrieve a CSAR and ?yaml to retrieve the .yaml representation
@@ -295,13 +296,14 @@ public abstract class AbstractComponentInstanceResource implements Comparable<Ab
         @QueryParam(value = "yaml") String yaml,
         @QueryParam(value = "edmm") String edmm,
         @QueryParam(value = "addToProvenance") String addToProvenance,
+        @QueryParam(value = "edmmUseAbsolutePaths") String edmmUseAbsolutePaths,
         @QueryParam(value = "xml") String xml,
         @Context UriInfo uriInfo) {
         // in case there is an URL requested directly via the browser UI, the accept cannot be put at the link.
         // thus, there is the hack with ?csar and ?yaml
         // the hack is implemented at getDefinitionsAsResponse
         if ((csar != null) || (yaml != null) || (xml != null) || (edmm != null)) {
-            return this.getDefinitionsAsResponse(csar, yaml, edmm, addToProvenance, uriInfo);
+            return this.getDefinitionsAsResponse(csar, yaml, edmm, addToProvenance, edmmUseAbsolutePaths, uriInfo);
         }
         String repositoryUiUrl = Environments.getInstance().getUiConfig().getEndpoints().get("repositoryUiUrl");
         String uiUrl = uriInfo.getAbsolutePath().toString().replaceAll(Environments.getInstance().getUiConfig().getEndpoints().get("repositoryApiUrl"), repositoryUiUrl);
@@ -363,14 +365,12 @@ public abstract class AbstractComponentInstanceResource implements Comparable<Ab
         try {
             this.element = this.definitions.getElement();
         } catch (IndexOutOfBoundsException e) {
-            if (this instanceof GenericImportResource) {
-                //noinspection StatementWithEmptyBody
                 // everything allright:
                 // ImportResource is a quick hack using 99% of the functionality offered here
                 // As only 1% has to be "quick hacked", we do that instead of a clean design
                 // Clean design: Introduce a class between this and AbstractComponentInstanceResource, where this class and ImportResource inhertis from
                 // A clean design introducing a super class AbstractDefinitionsBackedResource does not work, as we currently also support PropertiesBackedResources and such a super class would required multi-inheritance
-            } else {
+            if (!(this instanceof GenericImportResource)) {
                 throw new IllegalStateException("Wrong storage format: No ServiceTemplateOrNodeTypeOrNodeTypeImplementation found.");
             }
         }
@@ -521,7 +521,7 @@ public abstract class AbstractComponentInstanceResource implements Comparable<Ab
 
     @Path("tags/")
     public final TagsResource getTags() {
-        TTags tags = null;
+        TTags tags;
         if (this.element instanceof TServiceTemplate) {
             tags = ((TServiceTemplate) this.element).getTags();
             if (tags == null) {

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/export/EdmmUtilsTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/export/EdmmUtilsTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.export;
+
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.repository.TestWithGitBackedRepository;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EdmmUtilsTest extends TestWithGitBackedRepository {
+
+    @Test
+    void getAllToscaLightCompliantServiceTemplates() throws Exception {
+        this.setRevisionTo("origin/plain");
+
+        Map<QName, TServiceTemplate> allToscaLightCompliantModels = EdmmUtils.getAllToscaLightCompliantModels();
+
+        assertEquals(12, allToscaLightCompliantModels.size());
+    }
+}


### PR DESCRIPTION
To support the TOSCA Lightning toolchain, I added an endpoint to get all TOSCA Light models.

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
