### PR TITLE
Fix insert UNBOUNDED as number of occurences in node type capabilities

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/nodeTypes/capabilityOrRequirementDefinitions/capOrReqDef.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/nodeTypes/capabilityOrRequirementDefinitions/capOrReqDef.component.ts
@@ -221,7 +221,7 @@ export class CapOrReqDefComponent implements OnInit {
         for (const entry of apidata.capOrRegDefinitionsList) {
             const name = entry.name;
             const lowerBound = entry.lowerBound;
-            const upperBound = entry.upperBound === 'unbounded' ? '∞' : entry.upperBound;
+            const upperBound = entry.upperBound === 'UNBOUNDED' ? '∞' : entry.upperBound;
             const type = this.capOrReqTypeToHref(isNullOrUndefined(entry.capabilityType)
             === false ? entry.capabilityType : entry.requirementType);
             const constraint = '<button class="btn btn-xs" style="pointer-events: none;">Constraint...</button>';
@@ -289,7 +289,7 @@ export class CapOrReqDefComponent implements OnInit {
         this.addModal.hide();
         this.capOrReqDefToBeAdded.lowerBound = this.lowerBoundSpinner.value;
         if (this.upperBoundSpinner.value === '∞') {
-            this.capOrReqDefToBeAdded.upperBound = 'unbounded';
+            this.capOrReqDefToBeAdded.upperBound = 'UNBOUNDED';
         } else {
             this.capOrReqDefToBeAdded.upperBound = this.upperBoundSpinner.value;
         }


### PR DESCRIPTION
Related to [radon-gmt #26](https://github.com/radon-h2020/radon-gmt/issues/26)

When setting the number of occurrences in capabilities of node types to infinity 'unbounded' instead of 'UNBOUNDED' was sent to the backend by the management UI. This has been fixed.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
