### PR TITLE
Fix/remove empty validSourceTypes List from XML

### DIFF
--- a/org.eclipse.winery.common/src/main/resources/TOSCA-v1.0.xsd
+++ b/org.eclipse.winery.common/src/main/resources/TOSCA-v1.0.xsd
@@ -532,6 +532,7 @@
       </xs:union>
      </xs:simpleType>
     </xs:attribute>
+    <xs:attribute name="validSourceTypes" use="optional"/>
    </xs:extension>
   </xs:complexContent>
  </xs:complexType>

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/reqandcapdefs/RequirementOrCapabilityDefinitionsResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/reqandcapdefs/RequirementOrCapabilityDefinitionsResource.java
@@ -125,7 +125,11 @@ public abstract class RequirementOrCapabilityDefinitionsResource<ReqDefOrCapDefR
 
             if (def instanceof TCapabilityDefinition) {
                 ((TCapabilityDefinition) def).setCapabilityType(typeQName);
-                ((TCapabilityDefinition) def).setValidSourceTypes(postData.validSourceTypes);
+                if (postData.validSourceTypes != null) {
+                    if (!postData.validSourceTypes.isEmpty()) {
+                        ((TCapabilityDefinition) def).setValidSourceTypes(postData.validSourceTypes);
+                    }
+                }
             } else {
                 ((TRequirementDefinition) def).setRequirementType(typeQName);
             }

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.winery.repository.rest.resources.entitytypes.nodetypes;
 import org.eclipse.winery.repository.backend.BackendUtils;
 import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
 import org.eclipse.winery.repository.rest.resources.TestIds;
+
 import org.junit.jupiter.api.Test;
 import org.xmlunit.matchers.CompareMatcher;
 
@@ -79,6 +80,13 @@ public class NodeTypeResourceTest extends AbstractResourceTest {
     public void baobabAddCapabilityDefinition() throws Exception {
         this.setRevisionTo("8b125a426721f8a0eb17340dc08e9b571b0cd7f7");
         this.assertNoContentPost("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/capabilitydefinitions/", "entitytypes/nodetypes/baobab_capability_definitions_add_capabilitydefinition.json");
+        this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/capabilitydefinitions/", "entitytypes/nodetypes/baobab_capability_definitions_add_capabilitydefinition_contents.json");
+    }
+
+    @Test
+    public void addCapabilityDefinitionWithNoValidSourceTypes() throws Exception {
+        this.setRevisionTo("8b125a426721f8a0eb17340dc08e9b571b0cd7f7");
+        this.assertNoContentPost("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/capabilitydefinitions/", "entitytypes/nodetypes/baobab_capability_definitions_add_capabilitydefinition_without_validSourceTypes.json");
         this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/capabilitydefinitions/", "entitytypes/nodetypes/baobab_capability_definitions_add_capabilitydefinition_contents.json");
     }
 

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/baobab_capability_definitions_add_capabilitydefinition_without_validSourceTypes.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/baobab_capability_definitions_add_capabilitydefinition_without_validSourceTypes.json
@@ -1,0 +1,7 @@
+{
+    "name": "ImportConstraintsSaturating",
+    "type": "{http://winery.opentosca.org/test/capabilitytypes/fruits}Saturating",
+    "lowerBound": 1,
+    "upperBound": "1",
+    "validSourceTypes":[]
+}


### PR DESCRIPTION
Signed-off-by: Björn Müller <bjoern.mueller@kanu-baerchen.de>

removed empty validSourceTypesList from XML and added validSourceTypes to xsd

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
