### PR TITLE
Fix to use correct backend URL

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.html
@@ -109,7 +109,7 @@
 <hr>
 <h4>General Repository Commands</h4>
 <div>
-    <a [attr.href]=" path + '/?dump'" class="btn btn-primary">Dump Repository</a>
+    <a [attr.href]="path + '?dump'" class="btn btn-primary">Dump Repository</a>
     <button class="btn btn-danger" (click)="clearRepository();" id="btnclearrepository" data-loading-text="Deleting...">
         Clear Repository
     </button>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/artifactTypes/supportedFileTypes/supportedFileTypes.service.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/artifactTypes/supportedFileTypes/supportedFileTypes.service.ts
@@ -16,7 +16,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { InstanceService } from '../../instance.service';
 import { concat, Observable } from 'rxjs';
-import { backendBaseURL } from '../../../configuration';
 import { last } from 'rxjs/operators';
 
 @Injectable()
@@ -29,19 +28,19 @@ export class SupportedFileTypesService {
     }
 
     public getMimeType(): Observable<string> {
-        return this.http.get(backendBaseURL + this.path + '/mimetype', { responseType: 'text' });
+        return this.http.get(this.path + '/mimetype', { responseType: 'text' });
     }
 
     public setMimeType(mimeType: string): Observable<any> {
-        return this.http.put<any>(backendBaseURL + this.path + '/mimetype', mimeType);
+        return this.http.put<any>(this.path + '/mimetype', mimeType);
     }
 
     public getFileExtensions(): Observable<string[]> {
-        return this.http.get<string[]>(backendBaseURL + this.path + '/fileextensions');
+        return this.http.get<string[]>(this.path + '/fileextensions');
     }
 
     public setFileExtensions(fileExtensions: string[]): Observable<any> {
-        return this.http.put<any>(backendBaseURL + this.path + '/fileextensions', fileExtensions);
+        return this.http.put<any>(this.path + '/fileextensions', fileExtensions);
     }
 
     public set(mimeType: string, fileExtensions: string[]): Observable<any> {


### PR DESCRIPTION
Adapt admin components to use correct backend URL.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders