### PR TITLE
Set up GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Winery CI
+
+on: [ push, pull_request ]
+
+jobs:
+
+  java8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -Pjava -B package
+
+  java12:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 12
+        uses: actions/setup-java@v1
+        with:
+          java-version: 12
+      - name: Build with Maven
+        run: mvn -Pjava -B package
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 12
+        uses: actions/setup-java@v1
+        with:
+          java-version: 12
+      - name: Build with Maven
+        run: mvn -Pfrontend -B package


### PR DESCRIPTION
This PR enables GitHub Actions to build the Winery frontend and backend in three separate jobs (similar to what we have/had with TravisCI).