### PR TITLE
Fixes setting the namespace via a new namespace template

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.html
@@ -129,7 +129,7 @@
                                            [isRequired]="true"
                                            [useStartNamespace]="useStartNamespace"
                                            [toscaType]="toscaType"
-                                           (input)="createUrlAndCheck()">
+                                           (onChange)="createUrlAndCheck()">
                 </winery-namespace-selector>
             </div>
         </div>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
@@ -119,6 +119,7 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
     set namespaceValue(value: string) {
         this.innerNamespaceValue = value;
         this.propagateChange(this.innerNamespaceValue);
+        this.onChange.emit(this.innerNamespaceValue);
         if (this.namespaceInput) {
             this.namespaceInput.nativeElement.focus();
         }


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

Workflow to reproduce the addressed issue:

1. Navigate to `/servicetemplates`
2. Press `Add new`
3. Enter a name
4. Apply a new namespace template
5. Press save

The result is a service template which does not use the applied namespace. The proposed changes should fix that.
Furthermore, this should fix the problem described in [radon-gmt issue #32](https://github.com/radon-h2020/radon-gmt/issues/32).

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
