### PR TITLE
Fix name handling in requirement assignments

### DIFF
--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/models/topologyTemplateUtil.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/models/topologyTemplateUtil.ts
@@ -101,11 +101,17 @@ export class TopologyTemplateUtil {
             }
             reqDefs.forEach(reqDef => {
                 const req = RequirementModel.fromRequirementDefinition(reqDef);
-                if (!node.requirements.requirement.find(r => r.name === req.name)) {
+                if (!node.requirements.requirement.find(r => {
+                    if (req.unbounded) {
+                        return r.name === req.name && r.relationship === req.relationship;
+                    } else {
+                        return r.name === req.name;
+                    }
+                })) {
                     node.requirements.requirement.push(req);
                 }
             });
-            node.requirements.requirement.forEach(req => req.id = this.generateYAMLRequirementID(node, req.name));
+            node.requirements.requirement.forEach(req => req.id = this.generateYAMLRequirementID(node, req));
         }
 
         return new TNodeTemplate(
@@ -182,8 +188,8 @@ export class TopologyTemplateUtil {
         return nodeTemplates;
     }
 
-    static generateYAMLRequirementID(nodeTemplate: TNodeTemplate, requirement: string): string {
-        return `${nodeTemplate.id}_req_${requirement}`;
+    static generateYAMLRequirementID(nodeTemplate: TNodeTemplate, requirement: RequirementModel): string {
+        return `${nodeTemplate.id}_req_${requirement.name}`;
     }
 
     static generateYAMLCapabilityID(nodeTemplate: TNodeTemplate, capability: string): string {

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/toscatype-table/toscatype-table.component.ts
@@ -245,18 +245,12 @@ export class ToscatypeTableComponent implements OnInit, OnChanges {
                 nodeType.full.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].requirementDefinitions &&
                 nodeType.full.serviceTemplateOrNodeTypeOrNodeTypeImplementation[0].requirementDefinitions.requirementDefinition) {
 
-                // if the requirement is unbounded, there might be multiple numbered reqModels with name different from the reqDef
-                let nameToCompare = req.name;
-                if (req.name.lastIndexOf('_') > 0) {
-                    nameToCompare = req.name.substring(0, req.name.lastIndexOf('_'));
-                }
-
                 const requirementDefinition = nodeType
                     .full
                     .serviceTemplateOrNodeTypeOrNodeTypeImplementation[0]
                     .requirementDefinitions
                     .requirementDefinition
-                    .find((reqDef: RequirementDefinitionModel) => reqDef.name === nameToCompare);
+                    .find((reqDef: RequirementDefinitionModel) => reqDef.name === req.name);
                 if (requirementDefinition) {
                     return requirementDefinition;
                 }


### PR DESCRIPTION
Signed-off-by: Vladimir Yussupov <v.yussupov@gmail.com>

This fix changes the way requirements assignments are created for unbounded Requirement Definitions.
Since matching between requirement assignments and requirement definitions happens using the 'name', now the list of requirements in Node Templates can have equal names, e.g., multiple 'invoker' requirement assignments.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
