### PR TITLE
Fixes YAML export for multi repositories and the generated file structure

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/FileUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/FileUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -199,6 +199,10 @@ public class FileUtils {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    public static boolean isPresent(Path path) {
+        return Files.exists(path);
     }
 
     // public static Response readContentFromFile(RepositoryFileReference ref) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/MultiRepositoryManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/MultiRepositoryManager.java
@@ -65,6 +65,10 @@ public class MultiRepositoryManager {
         }
     }
 
+    boolean isMultiRepositoryFileStuctureEstablished(Path repoPath) {
+        return FileUtils.isPresent(repoPath.resolve(Constants.DEFAULT_LOCAL_REPO_NAME));
+    }
+
     /**
      * Creates the filestructure for a multirepository and moves the files in localRepository to workspace
      *

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/entries/YAMLDefinitionsBasedCsarEntry.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/entries/YAMLDefinitionsBasedCsarEntry.java
@@ -27,6 +27,7 @@ import org.eclipse.winery.repository.JAXBSupport;
 import org.eclipse.winery.repository.backend.IRepository;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.backend.filebased.GitBasedRepository;
+import org.eclipse.winery.repository.backend.filebased.MultiRepository;
 import org.eclipse.winery.repository.backend.filebased.YamlRepository;
 import org.eclipse.winery.repository.converter.X2YConverter;
 import org.eclipse.winery.repository.converter.support.writer.YamlWriter;
@@ -45,6 +46,10 @@ public class YAMLDefinitionsBasedCsarEntry implements CsarEntry {
                 c = new X2YConverter((YamlRepository) wrapper.getRepository());
             } else if (repo instanceof YamlRepository) {
                 c = new X2YConverter((YamlRepository) repo);
+            } else if (repo instanceof MultiRepository) {
+                MultiRepository wrapper = (MultiRepository) RepositoryFactory.getRepository();
+                GitBasedRepository localRepoWrapper = (GitBasedRepository) wrapper.getLocalRepository();
+                c = new X2YConverter((YamlRepository) localRepoWrapper.getRepository());
             } else {
                 throw new WineryRepositoryException("The chosen repository mode is incompatible with YAML-based export");
             }


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

Previously the YAML export for MultiRepositories was not supported, this is implemented now.
Furthermore, a bug which generated the special file structure for MultiRepositories too often is fixed with the proposed changes.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
