### PR TITLE
Fixes validators in dynamic text component

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/attributes/attributes.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/attributes/attributes.component.ts
@@ -14,13 +14,10 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { AttributesService } from './attributes.service';
 import { InstanceService } from '../../instance.service';
-import { ModalDirective } from 'ngx-bootstrap';
-import { WineryTableColumn } from '../../../wineryTableModule/wineryTable.component';
-import { WineryValidatorObject } from '../../../wineryValidators/wineryDuplicateValidator.directive';
 import { AttributeDefinition } from '../../../model/attribute';
 import { HttpErrorResponse } from '@angular/common/http';
 import { WineryDynamicTableMetadata } from '../../../wineryDynamicTable/wineryDynamicTableMetadata';
-import { DynamicTextComponent, DynamicTextData } from '../../../wineryDynamicTable/formComponents/dynamicText.component';
+import { DynamicTextData } from '../../../wineryDynamicTable/formComponents/dynamicText.component';
 import { Validators } from '@angular/forms';
 import { DynamicDropdownData } from '../../../wineryDynamicTable/formComponents/dynamicDropdown.component';
 

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
@@ -105,7 +105,7 @@ export class PropertiesDefinitionComponent implements OnInit {
                 { label: 'boolean', value: 'boolean' },
                 { label: 'timestamp', value: 'timestamp' }
             ];
-            this.dynamicTableData.push(new DynamicDropdownData<YamlTypes>('type', 'Type', options, 1));
+            this.dynamicTableData.push(new DynamicDropdownData<YamlTypes>('type', 'Type', options, 1, 'string'));
         } else {
             const options = [
                 { label: 'xsd:string', value: 'xsd:string' },
@@ -114,7 +114,7 @@ export class PropertiesDefinitionComponent implements OnInit {
                 { label: 'xsd:anyURI', value: 'xsd:anyURI' },
                 { label: 'xsd:QName', value: 'xsd:QName' }
             ];
-            this.dynamicTableData.push(new DynamicDropdownData<XmlTypes>('type', 'Type', options, 1));
+            this.dynamicTableData.push(new DynamicDropdownData<XmlTypes>('type', 'Type', options, 1, 'xsd:string'));
         }
     }
 

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryDynamicTable/formComponents/dynamicText.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryDynamicTable/formComponents/dynamicText.component.ts
@@ -28,9 +28,13 @@ import { FormGroup, ValidatorFn } from '@angular/forms';
                      class="alert alert-danger">
                     <div [hidden]="!textForm.errors.required">Field is required</div>
                 </div>
-                <div *ngIf="parentFormGroup.errors && (textForm.dirty || textForm.touched)"
+                <div *ngIf="parentFormGroup.errors && (textForm.dirty || textForm.touched)
+                && this.config.key === parentFormGroup.errors.wineryDuplicateValidator.property"
                      class="alert alert-danger">
-                    <div [hidden]="!parentFormGroup.errors.wineryDuplicateValidator">{{parentFormGroup.errors.wineryDuplicateValidator.message}}</div>
+                    <div
+                        [hidden]="!parentFormGroup.errors.wineryDuplicateValidator">
+                        {{parentFormGroup.errors.wineryDuplicateValidator.message}}
+                    </div>
                 </div>
             </div>
         </div>
@@ -59,6 +63,6 @@ export class DynamicTextData extends WineryDynamicTableMetadata<string> {
                 defaultValue?: string,
                 disabled?: boolean,
                 sortTableCol?: boolean) {
-        super(key, label, order, defaultValue, disabled, sortTableCol);
+        super(key, label, order, defaultValue, disabled, sortTableCol, validation);
     }
 }

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryDynamicTable/wineryDynamicTable.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryDynamicTable/wineryDynamicTable.component.ts
@@ -94,7 +94,7 @@ export class WineryDynamicTableComponent implements OnInit, DoCheck {
     humanReadableTableData: any[] = [];
 
     // hashmap for quick access of dynamicMetadata depending on the key
-    dynamicDataMap: Map<string, WineryDynamicTableMetadata>;
+    dynamicDataMap = new Map<string, WineryDynamicTableMetadata>();
 
     modalValidators: ValidatorFn[];
 


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

Validators were not added to the dynamic text component and rendered in the wrong field.
The proposed changes aim to fix this.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
