### PR TITLE
Adds touch all definitions button to admin ui

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.html
@@ -108,12 +108,18 @@
 </div>
 <hr>
 <h4>General Repository Commands</h4>
+<div *ngIf="loading">
+    <div class="smallLoader"></div>
+</div>
 <div>
     <a [attr.href]="path + '?dump'" class="btn btn-primary">Dump Repository</a>
     <button class="btn btn-danger" (click)="clearRepository();" id="btnclearrepository" data-loading-text="Deleting...">
         Clear Repository
     </button>
     <button class="btn btn-default" (click)="uploaderModal.show()">Import Zip Repository</button>
+    <button *ngIf="this.configurationService.isYaml()" class="btn btn-default" (click)="touchAllDefinitions()">Touch
+        Types
+    </button>
 </div>
 
 <winery-modal bsModal #uploaderModal="bs-modal" [modalRef]="uploaderModal">

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.component.ts
@@ -20,6 +20,7 @@ import { ModalDirective } from 'ngx-bootstrap';
 import { HttpErrorResponse } from '@angular/common/http';
 import { WineryValidatorObject } from '../../../wineryValidators/wineryDuplicateValidator.directive';
 import { isNullOrUndefined } from 'util';
+import { WineryRepositoryConfigurationService } from '../../../wineryFeatureToggleModule/WineryRepositoryConfiguration.service';
 
 @Component({
     selector: 'winery-instance-repository',
@@ -28,7 +29,7 @@ import { isNullOrUndefined } from 'util';
 })
 export class RepositoryComponent implements OnInit {
 
-    loading = true;
+    loading = false;
     repositories: Array<Repository> = [];
     newRepository: Repository = new Repository();
     validatorObjectName: WineryValidatorObject;
@@ -48,7 +49,8 @@ export class RepositoryComponent implements OnInit {
     path: string;
 
     constructor(private service: RepositoryService,
-                private notify: WineryNotificationService) {
+                private notify: WineryNotificationService,
+                public configurationService: WineryRepositoryConfigurationService) {
     }
 
     getRepositories() {
@@ -124,6 +126,7 @@ export class RepositoryComponent implements OnInit {
     }
 
     clearRepository() {
+        this.loading = true;
         this.service.clearRepository().subscribe(
             () => this.handleSuccess('Repository cleared'),
             error => this.handleError(error)
@@ -137,5 +140,13 @@ export class RepositoryComponent implements OnInit {
 
     handleError(error: HttpErrorResponse) {
         this.notify.error(error.message, 'Error');
+    }
+
+    touchAllDefinitions() {
+        this.loading = true;
+        this.service.touchAllDefinitions().subscribe((response) => {
+            this.loading = false;
+            this.notify.success('Touch all definitions completed');
+        });
     }
 }

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.service.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/admin/repository/repository.service.ts
@@ -49,4 +49,10 @@ export class RepositoryService {
                 { headers: headers, observe: 'response', responseType: 'text' }
             );
     }
+
+    touchAllDefinitions(): Observable<HttpResponse<string>> {
+        const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+        return this.http.post(backendBaseURL + this.path + '/touch', null,
+            { headers: headers, observe: 'response', responseType: 'text' });
+    }
 }


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

The proposed changes add a button to the administration UI which allows users to touch all definitions. 

![screen](https://user-images.githubusercontent.com/7521847/92388226-3b521b80-f117-11ea-8600-731d65111c31.png)


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
