### PR TITLE
Rename capability type constraints tab to valid source types

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validSourceTypes/validSourceTypes.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validSourceTypes/validSourceTypes.component.html
@@ -16,14 +16,13 @@
 </div>
 <div *ngIf="!loading">
     <div class="right">
-        <button class="btn btn-primary" name="save" (click)="saveToServer()"
+        <button class="btn btn-primary" name="save" style="margin-bottom: 10px;" (click)="saveToServer()"
                 [disabled]="!sharedData?.currentVersion?.editable">
             Save
         </button>
     </div>
 
-    <winery-table [title]="title"
-                  [columns]="columns"
+    <winery-table [columns]="columns"
                   [data]="validSourceTypes?.nodes"
                   (addBtnClicked)="onAddClick()"
                   (removeBtnClicked)="onRemoveClicked($event)">

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/model/subMenuItem.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/model/subMenuItem.ts
@@ -79,7 +79,7 @@ export class SubMenuItems {
     static readonly threatModeling: SubMenuItem = { displayName: 'Threat Modeling', urlFragment: 'threatmodeling' };
     static readonly topologyTemplate: SubMenuItem = { displayName: 'Topology Template', urlFragment: 'topologytemplate' };
     static readonly validSourcesAndTargets: SubMenuItem = { displayName: 'Valid Sources and Targets', urlFragment: 'validsourcesandtargets' };
-    static readonly capabilityTypeConstraints: SubMenuItem = { displayName: 'Constraints', urlFragment: 'constraints' };
+    static readonly capabilityTypeConstraints: SubMenuItem = { displayName: 'Valid Source Types', urlFragment: 'constraints' };
     static readonly supportedFiles: SubMenuItem = { displayName: 'Supported File Types', urlFragment: 'supportedfiles' };
     static readonly xml: SubMenuItem = { displayName: 'XML', urlFragment: 'xml' };
     static readonly attributes: SubMenuItem = { displayName: 'Attribute Definitions', urlFragment: 'attributes' };


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

The proposed changes rename the "Constraints" tab of Capability Types to "Valid Source Types"

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
