### PR TITLE
Remove 16x16 icon

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.html
@@ -36,15 +36,6 @@
         </div>
     </div>
     <div class="uploadImgArea">
-        <b>Icon (16x16) used in palette</b><br>
-        <div class="typeIcon"><img src="{{img16Path}}" height="16" width="16"></div>
-        <winery-uploader #uploader16 id="uploader16"
-                         [uploadUrl]="img16Path"
-                         [uploadMethod]="'PUT'"
-                         [isEditable]="sharedData?.currentVersion?.editable"
-                         (onSuccess)="onUploadSuccess()">
-        </winery-uploader>
-        <br/>
         <div>
             <b>Icon (50x50) used in the node template shapes</b><br/>
             <div class="typeIcon"><img src="{{img50Path}}" height="50" width="50"></div>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/visualAppearance/visualAppearance.component.ts
@@ -33,7 +33,6 @@ export class VisualAppearanceComponent implements OnInit {
     relationshipData: RelationshipTypesVisualsApiData;
     nodeTypeData: NodeTypesVisualsApiData;
     loading = true;
-    img16Path: string;
     img50Path: string;
     isRelationshipType = false;
     isNodeType = false;
@@ -45,7 +44,6 @@ export class VisualAppearanceComponent implements OnInit {
 
     ngOnInit() {
         this.loading = true;
-        this.img16Path = this.service.getImg16x16Path();
         this.img50Path = this.service.getImg50x50Path();
 
         this.isRelationshipType = this.sharedData.toscaComponent.toscaType === ToscaTypes.RelationshipType;

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/visualAppearance/visualAppearance.service.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/visualAppearance/visualAppearance.service.ts
@@ -24,10 +24,6 @@ export class VisualAppearanceService {
                 private route: Router) {
     }
 
-    getImg16x16Path(): string {
-        return backendBaseURL + this.route.url + '/16x16';
-    }
-
     getImg50x50Path(): string {
         return backendBaseURL + this.route.url + '/50x50';
     }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/GenericVisualAppearanceResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/_support/GenericVisualAppearanceResource.java
@@ -112,21 +112,6 @@ public abstract class GenericVisualAppearanceResource {
     public abstract VisualsApiData getJsonData(@Context UriInfo uriInfo);
 
     @GET
-    @Path("16x16")
-    public Response get16x16Image(@HeaderParam("If-Modified-Since") String modified) {
-        // Even if the extension is "png", it might contain a jpg, too
-        // We keep the file extension as the windows explorer can display previews even if the content is not a png
-        return this.getImage(Filename.FILENAME_SMALL_ICON, modified);
-    }
-
-    @PUT
-    @Path("16x16")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response post16x16Image(@FormDataParam("file") InputStream uploadedInputStream, @FormDataParam("file") FormDataBodyPart body) {
-        return this.putImage(Filename.FILENAME_SMALL_ICON, uploadedInputStream, body.getMediaType());
-    }
-
-    @GET
     @Path("50x50")
     public Response get50x50Image(@HeaderParam("If-Modified-Since") String modified) {
         return this.getImage(Filename.FILENAME_BIG_ICON, modified);

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/VisualsApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/VisualsApiData.java
@@ -26,7 +26,6 @@ import org.eclipse.winery.repository.rest.resources._support.GenericVisualAppear
 
 public class VisualsApiData {
 
-    public String iconUrl;
     public String imageUrl;
     public String color;
     public boolean pattern;
@@ -39,15 +38,6 @@ public class VisualsApiData {
         this.color = visuals.getColor();
         this.typeId = parent.getQName();
         this.pattern = repository.getNamespaceManager().isPatternNamespace(parent.getNamespace().getDecoded());
-
-        RepositoryFileReference iconRef = new RepositoryFileReference(visuals.getId(), Filename.FILENAME_SMALL_ICON);
-        if (repository.exists(iconRef)) {
-            if (uriInfo != null) {
-                iconUrl = visuals.getAbsoluteURL(uriInfo) + "16x16";
-            } else {
-                iconUrl = visuals.getAbsoluteURL() + "16x16";
-            }
-        }
 
         RepositoryFileReference imageRef = new RepositoryFileReference(visuals.getId(), Filename.FILENAME_BIG_ICON);
         if (repository.exists(imageRef)) {

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/entitytypes/nodetypes/NodeTypeResourceTest.java
@@ -58,13 +58,6 @@ public class NodeTypeResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    public void baobabAdd16x16Image() throws Exception {
-        this.setRevisionTo("9c486269f6280e0eb14730d01554e7e4553a3d60");
-        this.assertUploadBinary("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/appearance/16x16",
-            "entitytypes/nodetypes/bigIcon.png");
-    }
-
-    @Test
     public void baobabCapabilitiesJSON() throws Exception {
         this.setRevisionTo("8b125a426721f8a0eb17340dc08e9b571b0cd7f7");
         this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/baobab/", "entitytypes/nodetypes/baobab_capabilites.json");


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

The proposed changes remove the 16x16 icon from the UI and the corresponding backend endpoints.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
