### PR TITLE
Set TOSCA meta file version to 1.1 in YAML mode

### DIFF
--- a/org.eclipse.winery.model.csar.toscametafile/src/main/java/org/eclipse/winery/model/csar/toscametafile/TOSCAMetaFileAttributes.java
+++ b/org.eclipse.winery.model.csar.toscametafile/src/main/java/org/eclipse/winery/model/csar/toscametafile/TOSCAMetaFileAttributes.java
@@ -21,9 +21,11 @@ public class TOSCAMetaFileAttributes {
     // of block 0
     final public static String TOSCA_META_VERSION = "TOSCA-Meta-Version";
     final public static String TOSCA_META_VERSION_VALUE = "1.0";
+    final public static String TOSCA_META_FILE_VERSION = "TOSCA-Meta-File-Version";
+    final public static String TOSCA_META_FILE_VERSION_VALUE = "1.1";
     final public static String CSAR_VERSION = "CSAR-Version";
     final public static String CSAR_VERSION_VALUE = "1.0";
-    final public static String YAML_CSAR_VERSION_VALUE = "1.1";
+    final public static String CSAR_VERSION_VALUE_FOR_YAML = "1.1";
     final public static String CREATED_BY = "Created-By";
     final public static String ENTRY_DEFINITIONS = "Entry-Definitions";
     final public static String TOPOLOGY = "Topology";

--- a/org.eclipse.winery.model.csar.toscametafile/src/main/java/org/eclipse/winery/model/csar/toscametafile/YamlTOSCAMetaFileParser.java
+++ b/org.eclipse.winery.model.csar.toscametafile/src/main/java/org/eclipse/winery/model/csar/toscametafile/YamlTOSCAMetaFileParser.java
@@ -14,9 +14,42 @@
 
 package org.eclipse.winery.model.csar.toscametafile;
 
-import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.YAML_CSAR_VERSION_VALUE;
+import java.util.Map;
+
+import org.eclipse.virgo.util.parser.manifest.ManifestContents;
+
+import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.CSAR_VERSION_VALUE_FOR_YAML;
 
 public class YamlTOSCAMetaFileParser extends TOSCAMetaFileParser {
+
+    @Override
+    protected int validateBlock0(ManifestContents mf) {
+        int numErrors = 0;
+        Map<String, String> mainAttr = mf.getMainAttributes();
+
+        numErrors += validateMetaVersion(mainAttr.get(TOSCAMetaFileAttributes.TOSCA_META_FILE_VERSION));
+        numErrors += validateCsarVersion(mainAttr.get(TOSCAMetaFileAttributes.CSAR_VERSION));
+        numErrors += validateCreatedBy(mainAttr.get(TOSCAMetaFileAttributes.CREATED_BY));
+        numErrors += validateEntryDefinitions(mainAttr.get(TOSCAMetaFileAttributes.ENTRY_DEFINITIONS));
+        numErrors += validateDescription(mainAttr.get(TOSCAMetaFileAttributes.DESCRIPTION));
+        numErrors += validateTopology(mainAttr.get(TOSCAMetaFileAttributes.TOPOLOGY));
+
+        return numErrors;
+    }
+
+    @Override
+    protected int validateMetaVersion(String metaFileVersion) {
+        int errors = 0;
+
+        if (metaFileVersion == null) {
+            this.logAttrMissing(TOSCAMetaFileAttributes.TOSCA_META_FILE_VERSION, 0);
+            errors++;
+        } else if (!metaFileVersion.trim().equals(TOSCAMetaFileAttributes.TOSCA_META_FILE_VERSION_VALUE)) {
+            this.logAttrWrongVal(TOSCAMetaFileAttributes.TOSCA_META_FILE_VERSION, 0, TOSCAMetaFileAttributes.TOSCA_META_FILE_VERSION_VALUE);
+            errors++;
+        }
+        return errors;
+    }
 
     @Override
     protected int validateCsarVersion(String csarVersion) {
@@ -25,8 +58,8 @@ public class YamlTOSCAMetaFileParser extends TOSCAMetaFileParser {
         if (csarVersion == null) {
             this.logAttrMissing(TOSCAMetaFileAttributes.CSAR_VERSION, 0);
             errors++;
-        } else if (!(csarVersion.trim()).equals(YAML_CSAR_VERSION_VALUE)) {
-            this.logAttrWrongVal(TOSCAMetaFileAttributes.CSAR_VERSION, 0, TOSCAMetaFileAttributes.YAML_CSAR_VERSION_VALUE);
+        } else if (!csarVersion.trim().equals(CSAR_VERSION_VALUE_FOR_YAML)) {
+            this.logAttrWrongVal(TOSCAMetaFileAttributes.CSAR_VERSION, 0, TOSCAMetaFileAttributes.CSAR_VERSION_VALUE_FOR_YAML);
             errors++;
         }
         return errors;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/export/YamlExporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/export/YamlExporter.java
@@ -27,20 +27,20 @@ import org.eclipse.winery.accountability.exceptions.AccountabilityException;
 import org.eclipse.winery.common.Constants;
 import org.eclipse.winery.common.configuration.Environments;
 import org.eclipse.winery.common.constants.MimeTypes;
-import org.eclipse.winery.repository.backend.IRepository;
 import org.eclipse.winery.model.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.repository.backend.IRepository;
+import org.eclipse.winery.repository.datatypes.ids.elements.DirectoryId;
+import org.eclipse.winery.repository.exceptions.RepositoryCorruptException;
 import org.eclipse.winery.repository.export.CsarContentProperties;
 import org.eclipse.winery.repository.export.CsarExporter;
 import org.eclipse.winery.repository.export.ExportedState;
-import org.eclipse.winery.repository.export.entries.DefinitionsBasedCsarEntry;
-import org.eclipse.winery.repository.yaml.YamlRepository;
-import org.eclipse.winery.repository.datatypes.ids.elements.DirectoryId;
-import org.eclipse.winery.repository.exceptions.RepositoryCorruptException;
 import org.eclipse.winery.repository.export.entries.CsarEntry;
+import org.eclipse.winery.repository.export.entries.DefinitionsBasedCsarEntry;
 import org.eclipse.winery.repository.export.entries.DocumentBasedCsarEntry;
 import org.eclipse.winery.repository.export.entries.RemoteRefBasedCsarEntry;
 import org.eclipse.winery.repository.export.entries.RepositoryRefBasedCsarEntry;
 import org.eclipse.winery.repository.export.entries.XMLDefinitionsBasedCsarEntry;
+import org.eclipse.winery.repository.yaml.YamlRepository;
 import org.eclipse.winery.repository.yaml.export.entries.YAMLDefinitionsBasedCsarEntry;
 
 import org.apache.commons.io.IOUtils;
@@ -50,9 +50,11 @@ import org.slf4j.LoggerFactory;
 import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.CONTENT_TYPE;
 import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.CREATED_BY;
 import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.CSAR_VERSION;
+import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.CSAR_VERSION_VALUE_FOR_YAML;
 import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.ENTRY_DEFINITIONS;
 import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.NAME;
-import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.TOSCA_META_VERSION;
+import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.TOSCA_META_FILE_VERSION;
+import static org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileAttributes.TOSCA_META_FILE_VERSION_VALUE;
 
 public class YamlExporter extends CsarExporter {
 
@@ -161,8 +163,8 @@ public class YamlExporter extends CsarExporter {
         StringBuilder stringBuilder = new StringBuilder();
 
         // Setting Versions
-        stringBuilder.append(TOSCA_META_VERSION).append(": 1.0").append("\n");
-        stringBuilder.append(CSAR_VERSION).append(": 1.1").append("\n");
+        stringBuilder.append(TOSCA_META_FILE_VERSION).append(": ").append(TOSCA_META_FILE_VERSION_VALUE).append("\n");
+        stringBuilder.append(CSAR_VERSION).append(": ").append(CSAR_VERSION_VALUE_FOR_YAML).append("\n");
         stringBuilder.append(CREATED_BY).append(": Winery ").append(Environments.getInstance().getVersion()).append("\n");
 
         // Winery currently is unaware of tDefinitions, therefore, we use the


### PR DESCRIPTION
For compatibility reasons with TOSCA YAML orchestrators, such as xOpera, we have to set the value of `TOSCA-Meta-File-Version` in the meta file to `1.1`.