### PR TITLE
fixes url to planbuilder service of the opentosca runtime

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/PlansResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/PlansResource.java
@@ -186,7 +186,7 @@ public class PlansResource extends EntityWithIdCollectionResource<PlanResource, 
         LOGGER.info("Generating plans for Service Template...");
         // Only if plan builder endpoint is available
         String planBuilderBaseUrl =
-            Environments.getInstance().getUiConfig().getEndpoints().get("container") + "/containerapi/planbuilder";
+            Environments.getInstance().getUiConfig().getEndpoints().get("container") + "/planbuilder";
         if (RestUtils.isResourceAvailable(planBuilderBaseUrl)) {
             // Determine URIs
             String plansURI = uriInfo.getAbsolutePath().resolve("../plans").toString();


### PR DESCRIPTION
fixes the url of planbuilder service of the OpenTOSCA runtime to use the new API, enabling to generate plans within Winery again

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [x] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
