### PR TITLE
fixes nullpointer bug in ModelUtilities

### DIFF
--- a/org.eclipse.winery.model/org.eclipse.winery.model.tosca.canonical/src/main/java/org/eclipse/winery/model/tosca/utils/ModelUtilities.java
+++ b/org.eclipse.winery.model/org.eclipse.winery.model.tosca.canonical/src/main/java/org/eclipse/winery/model/tosca/utils/ModelUtilities.java
@@ -656,8 +656,8 @@ public abstract class ModelUtilities {
         if (relationshipTemplate.getTargetElement().getRef() instanceof TCapability) {
             TCapability capability = (TCapability) relationshipTemplate.getTargetElement().getRef();
             return topologyTemplate.getNodeTemplates().stream()
-                .filter(nt -> nt.getRequirements() != null
-                    && nt.getRequirements().getRequirement().contains(capability))
+                .filter(nt -> nt.getCapabilities() != null
+                    && nt.getCapabilities().getCapability().contains(capability))
                 .findAny().get();
         } else {
             return (TNodeTemplate) relationshipTemplate.getTargetElement().getRef();


### PR DESCRIPTION
A Copy/Paste bug introduced nullpointer exceptions when working with nodeTemplates that had capabilities


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
