### PR TITLE
fixes Nullpointer issue with WineryKVProperties 

### DIFF
--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/servicetemplates/DriverInjection.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/servicetemplates/DriverInjection.json
@@ -139,6 +139,7 @@
             "properties": {
                 "propertyType": "KV",
                 "namespace": "http://winery.opentosca.org/test/ponyuniverse/propertiesdefinition/winery",
+                "elementName" : "Properties",
                 "kvproperties": {
                     "Driver": ""
                 }

--- a/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/ServiceTemplateResource-getInjectionOptions-DriverInjectionTest.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/ServiceTemplateResource-getInjectionOptions-DriverInjectionTest.json
@@ -104,7 +104,8 @@
                 },
                 "properties": {
                     "propertyType": "KV",
-                    "namespace": "http://winery.opentosca.org/test/ponyuniverse/propertiesdefinition/winery",
+                    "namespace" : "http://winery.opentosca.org/test/ponyuniverse/propertiesdefinition/winery",
+                    "elementName" : "Properties",
                     "kvproperties": {
                         "Driver": ""
                     }

--- a/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/apache-spark-on-vsphere-result.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/apache-spark-on-vsphere-result.json
@@ -84,6 +84,8 @@
             },
             "properties": {
                 "propertyType": "KV",
+                "namespace" : "http://www.example.org",
+                "elementName" : "Properties",
                 "kvproperties": {
                     "HypervisorEndpoint": "https://iaasvc.informatik.uni-stuttgart.de/sdk",
                     "HypervisorTenantID": "smartservices",
@@ -108,6 +110,8 @@
             },
             "properties": {
                 "propertyType": "KV",
+                "namespace" : "http://www.example.org",
+                "elementName" : "Properties",
                 "kvproperties": {
                     "VMIP": "",
                     "VMInstanceID": "",

--- a/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/baobab_topologytemplate_v2.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/baobab_topologytemplate_v2.json
@@ -23,6 +23,8 @@
             },
             "properties": {
                 "propertyType": "KV",
+                "namespace" : "http://www.example.org",
+                "elementName" : "Properties",
                 "kvproperties": {
                     "Antioxidants": "",
                     "VitaminC": "",

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/xml/converter/PropertyMappingSupport.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/xml/converter/PropertyMappingSupport.java
@@ -97,8 +97,8 @@ public class PropertyMappingSupport {
         org.eclipse.winery.model.tosca.TEntityTemplate.WineryKVProperties result = new org.eclipse.winery.model.tosca.TEntityTemplate.WineryKVProperties();
         result.setKVProperties(properties);
         // remove defaults required for serialization
-        result.setElementName(elementName.equals("Properties") ? null : elementName);
-        result.setNamespace(namespace == null || namespace.equals(Namespaces.EXAMPLE_NAMESPACE_URI) ? null : namespace);
+        result.setElementName(elementName);
+        result.setNamespace(namespace);
         return result;
     }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/xml/converter/PropertyMappingSupport.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/xml/converter/PropertyMappingSupport.java
@@ -95,7 +95,6 @@ public class PropertyMappingSupport {
         }
         org.eclipse.winery.model.tosca.TEntityTemplate.WineryKVProperties result = new org.eclipse.winery.model.tosca.TEntityTemplate.WineryKVProperties();
         result.setKVProperties(properties);
-        // remove defaults required for serialization
         result.setElementName(elementName);
         result.setNamespace(namespace);
         return result;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/xml/converter/PropertyMappingSupport.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/xml/converter/PropertyMappingSupport.java
@@ -16,7 +16,6 @@ package org.eclipse.winery.repository.xml.converter;
 
 import java.util.LinkedHashMap;
 
-import org.eclipse.winery.model.tosca.constants.Namespaces;
 import org.eclipse.winery.model.tosca.xml.XTEntityTemplate;
 
 import org.slf4j.Logger;


### PR DESCRIPTION
fixes issue with WineryKVProperties having null as elementName and namespace is the case when the elementName is "Properties" and namespace "http://www.example.org"

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [x] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
