### PR TITLE
YAML: Enable Winery to handle empty string values

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2017-2021 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -107,16 +107,16 @@
             <div class="form-group">
                 <label class="control-label" for="name">Name</label>
                 <input #nameInput
-                    #propName="ngModel"
-                    id="name"
-                    class="form-control"
-                    type="text"
-                    [name]="isYaml ? 'name' : 'key'"
-                    autocomplete=off
-                    required
-                    [(ngModel)]="isYaml ? editedProperty.name : editedProperty.key"
-                    [wineryDuplicateValidator]="validatorObject"/>
-
+                       #propName="ngModel"
+                       id="name"
+                       class="form-control"
+                       type="text"
+                       [name]="isYaml ? 'name' : 'key'"
+                       autocomplete=off
+                       required
+                       [disabled]="propertyOperation === 'Edit'"
+                       [(ngModel)]="isYaml ? editedProperty.name : editedProperty.key"
+                       [wineryDuplicateValidator]="validatorObject"/>
                 <div *ngIf="propName.errors && (propName.dirty || propName.touched)"
                      class="alert alert-danger">
                     <div [hidden]="!propName.errors.wineryDuplicateValidator">
@@ -140,7 +140,8 @@
             <div class="form-group" [hidden]="typeSelect.value !== 'map' && typeSelect.value !== 'list'">
                 <label class="control-label" for="entrySchema">Entry Schema</label>
                 <!-- for now we do not support or condone nesting maps or lists -->
-                <select #entrySchemaSelect name="entrySchema" class="form-control" id="entrySchema" [value]="editedProperty.entrySchema.type">
+                <select #entrySchemaSelect name="entrySchema" class="form-control" id="entrySchema"
+                        [value]="editedProperty.entrySchema.type">
                     <option *ngFor="let type of availableTypes" value="{{ type }}">
                         {{ type }}
                     </option>
@@ -149,7 +150,8 @@
             <div class="form-group" [hidden]="typeSelect.value !== 'map'">
                 <label class="control-label" for="keySchema">Key Schema</label>
                 <!-- for now we do not support or condone nesting maps or lists -->
-                <select #keySchemaSelect name="keySchema" class="form-control" id="keySchema" [value]="editedProperty.keySchema.type">
+                <select #keySchemaSelect name="keySchema" class="form-control" id="keySchema"
+                        [value]="editedProperty.keySchema.type">
                     <option *ngFor="let type of availableTypes" value="{{ type }}">
                         {{ type }}
                     </option>
@@ -157,15 +159,18 @@
             </div>
             <div class="form-group">
                 <label class="control-label" for="defaultValue">Default Value</label>
-                <input #defaultValueInput id="defaultValue" class="form-control" type="text" [value]="editedProperty.defaultValue"/>
+                <input #defaultValueInput id="defaultValue" class="form-control" type="text"
+                       [value]="editedProperty.defaultValue"/>
             </div>
             <div class="form-group">
-                <input #requiredCheckbox type="checkbox" id="isRequired" style="margin-right: 7px" [checked]="editedProperty.required"/>
+                <input #requiredCheckbox type="checkbox" id="isRequired" style="margin-right: 7px"
+                       [checked]="editedProperty.required"/>
                 <label class="control-label" for="isRequired">Is required</label>
             </div>
             <div class="form-group">
                 <label class="control-label" for="description">Description</label>
-                <input #descriptionInput id="description" class="form-control" type="text" [value]="editedProperty.description"/>
+                <input #descriptionInput id="description" class="form-control" type="text"
+                       [value]="editedProperty.description"/>
             </div>
             <div class="form-group">
                 <label class="control-label" for="constraints">Constraints</label>
@@ -174,7 +179,8 @@
             <span><b>{{constraintClause.key}}</b>:
                 <span *ngIf="constraintClause.value != null">{{constraintClause.value}}</span>
                 <span *ngIf="constraintClause.list != null">{{constraintClause.list.toString()}}</span>
-                <button class="rightbutton btn btn-danger btn-xs" (click)="removeConstraint(constraintClause)">Delete</button>
+                <button class="rightbutton btn btn-danger btn-xs"
+                        (click)="removeConstraint(constraintClause)">Delete</button>
             </span>
                 </div>
             </div>
@@ -202,7 +208,7 @@
         [closeButtonLabel]="'Cancel'"
         [okButtonLabel]="propertyOperation"
         [modalRef]="editorModalRef"
-        [disableOkButton]="!propName.valid">
+        [disableOkButton]="!propName.valid && !propName.disabled">
     </winery-modal-footer>
 </ng-template>
 

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
@@ -388,13 +388,22 @@ export class PropertiesDefinitionComponent implements OnInit {
         this.editedProperty.required = required;
         this.editedProperty.description = description;
         this.editedProperty.constraints = this.editedConstraints;
-        // no need to update resourceApiData for edit operation because the editedProperty is a reference
         if (this.propertyOperation === 'Add') {
             if (this.isYaml) {
                 this.resourceApiData.propertiesDefinition.properties.push(this.editedProperty);
             } else {
                 this.resourceApiData.winerysPropertiesDefinition.propertyDefinitionKVList.push(this.editedProperty);
             }
+        }
+        if (this.propertyOperation === 'Edit') {
+            let arr: any[];
+            if (this.isYaml) {
+                arr = this.resourceApiData.propertiesDefinition.properties;
+            } else {
+                arr = this.resourceApiData.winerysPropertiesDefinition.propertyDefinitionKVList;
+            }
+            const index = arr.findIndex((el) => el.name === this.editedProperty.name);
+            arr[index] = this.editedProperty;
         }
         this.editorModalRef.hide();
         this.clearEditedProperty();

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/ToCanonical.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/ToCanonical.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020-2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -120,6 +120,7 @@ import org.eclipse.winery.repository.yaml.converter.support.InheritanceUtils;
 import org.eclipse.winery.repository.yaml.converter.support.TypeConverter;
 import org.eclipse.winery.repository.yaml.converter.support.extension.YTImplementationArtifactDefinition;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
@@ -1233,16 +1234,22 @@ public class ToCanonical {
     }
 
     private TEntityType.YamlPropertyDefinition convert(YTPropertyDefinition node, String name) {
-        return new TEntityType.YamlPropertyDefinition.Builder(name)
+        TEntityType.YamlPropertyDefinition.Builder builder = new TEntityType.YamlPropertyDefinition.Builder(name)
             .setType(node.getType())
             .setDescription(node.getDescription())
             .setRequired(node.getRequired())
-            .setDefaultValue(ValueHelper.toString(node.getDefault()))
             .setStatus(TEntityType.YamlPropertyDefinition.Status.getStatus(node.getStatus().toString()))
             .setConstraints(convertList(node.getConstraints(), this::convert))
             .setEntrySchema(convert(node.getEntrySchema()))
-            .setKeySchema(convert(node.getKeySchema()))
-            .build();
+            .setKeySchema(convert(node.getKeySchema()));
+        // special handling to keep empty string values
+        if (node.getType() != null && node.getType().toString().equals("string")
+            && node.getDefault() != null && StringUtils.isEmpty(node.getDefault().toString())) {
+            builder.setDefaultValue("\"\"");
+        } else {
+            builder.setDefaultValue(ValueHelper.toString(node.getDefault()));
+        }
+        return builder.build();
     }
 
     @Nullable


### PR DESCRIPTION
This PR introduces the following changes:
- Adapt ToCanonical converter to keep `""` values
- Fix PropDef edit dialog to save changed values properly

---

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
