### PR TITLE
Bump up web3j dependency version

### DIFF
--- a/org.eclipse.winery.accountability/pom.xml
+++ b/org.eclipse.winery.accountability/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.web3j</groupId>
             <artifactId>core</artifactId>
-            <version>${org.web3j}</version>
+            <version>${org.web3j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.rutledgepaulv</groupId>
@@ -139,7 +139,7 @@
             <plugin>
                 <groupId>org.web3j</groupId>
                 <artifactId>web3j-maven-plugin</artifactId>
-                <version>${org.web3j}</version>
+                <version>${org.web3j.web3j-maven-plugin.version}</version>
                 <configuration>
                     <nativeJavaType>true</nativeJavaType>
                     <soliditySourceFiles>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,8 @@
         <org.eclipse.jgit.version>5.7.0.202003110725-r</org.eclipse.jgit.version>
         <org.mockito.moickito-core.version>2.19.0</org.mockito.moickito-core.version>
         <org.jgrapht.jgrapht-core.version>1.3.1</org.jgrapht.jgrapht-core.version>
-        <org.web3j>4.2.0</org.web3j>
+        <org.web3j.version>4.6.4</org.web3j.version>
+        <org.web3j.web3j-maven-plugin.version>4.6.5</org.web3j.web3j-maven-plugin.version>
         <org.apache.commons-lang3.version>3.7</org.apache.commons-lang3.version>
         <org.apache.commons.compress.version>1.19</org.apache.commons.compress.version>
         <commons-codec>1.11</commons-codec>


### PR DESCRIPTION
- bump up web3j.core to 4.6.4
- bump up web3j-maven-plugin to 4.6.5

Signed-off-by: Ghareeb Falazi <ghareeb.falazi@hotmail.com>

The previous version of `web3j-maven-plugin` depended on `solcJ`, which was hosted on the `Bintray` repository. `Bintray` was shutdown as of May 2021. However, newer versions of `web3j-maven-plugin` don't need this dependency anympre.

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/master/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
