### PR TITLE
bumps version of guava to 30.1.1-jre

### DIFF
--- a/org.eclipse.winery.repository/pom.xml
+++ b/org.eclipse.winery.repository/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.4-jre</version>
+            <version>30.1.1-jre</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
bumps the version of guava higher because of compatibility and security issues
