### PR TITLE
Remove winey prefix for generated IDs

### DIFF
--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
@@ -136,7 +136,7 @@ public abstract class AbstractResourceTest extends TestWithGitBackedRepository {
                 .get(callURL(restURL))
                 .then()
                 .log()
-                .all()
+                .ifValidationFails()
                 .statusCode(200)
                 .extract()
                 .response()

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/AbstractResourceTest.java
@@ -136,7 +136,7 @@ public abstract class AbstractResourceTest extends TestWithGitBackedRepository {
                 .get(callURL(restURL))
                 .then()
                 .log()
-                .ifValidationFails()
+                .all()
                 .statusCode(200)
                 .extract()
                 .response()

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/MainResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/MainResourceTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 public class MainResourceTest extends AbstractResourceTest {
 
     @Test
-    @Disabled("The NamespaceManager does not/ reload Namespaces.properties upon each change. Thus, this tests fails under certain conditions -- winery-defs-for_servicetemplates-ImportCsarWithOverwriteTest vs. winery-defs-for_servicetemplates1-ImportCsarWithOverwriteTest")
+    @Disabled("The NamespaceManager does not/ reload Namespaces.properties upon each change. Thus, this tests fails under certain conditions -- servicetemplates-ImportCsarWithOverwriteTest vs. servicetemplates1-ImportCsarWithOverwriteTest")
     public void importCSARTestWithOverwrite() throws Exception {
         setRevisionTo("dc30db8f6086a8bcf6b39881d124f15fb05168f4");
         this.assertGet("servicetemplates/http%253A%252F%252Fplain.winery.opentosca.org%252Fservicetemplates/ImportCsarWithOverwriteTest/", "entitytypes/servicetemplates/importCsarWithOverwriteTest_initial.json");

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/baobab_initial.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/baobab_initial.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_ntyiIfruits-baobab_impl",
+    "id": "ntyiIfruits-baobab_impl",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/initial_artifact_template.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entityimplementations/nodetypeimplementations/initial_artifact_template.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_fruitsats-baobab_bananaInterface_IA",
+    "id": "fruitsats-baobab_bananaInterface_IA",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/MyTinyTest.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/MyTinyTest.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_artifacttemplates-MyTinyTest",
+    "id": "artifacttemplates-MyTinyTest",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/MyTinyTest.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/MyTinyTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Definitions xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" id="winery-defs-for_artifacttemplates-MyTinyTest"
+<Definitions xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" id="artifacttemplates-MyTinyTest"
              targetNamespace="http://opentosca.org/artifacttemplates">
     <Import importType="http://docs.oasis-open.org/tosca/ns/2011/12"
             location="http://localhost:9080/winery/artifacttypes/http%253A%252F%252Fopentosca.org%252Fartifacttypes/MiniArtifactType/?definitions"

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/artifactTemplateContainsUpdatedFileReferenceInJson-withFile.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/artifactTemplateContainsUpdatedFileReferenceInJson-withFile.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_otateIgeneral-artifactTemplateContainsUpdatedFileReferenceInJson",
+    "id": "otateIgeneral-artifactTemplateContainsUpdatedFileReferenceInJson",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/artifactTemplateContainsUpdatedFileReferenceInJson-withoutFile.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytemplates/artifacttemplates/artifactTemplateContainsUpdatedFileReferenceInJson-withoutFile.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_otateIgeneral-artifactTemplateContainsUpdatedFileReferenceInJson",
+    "id": "otateIgeneral-artifactTemplateContainsUpdatedFileReferenceInJson",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/DressageEquipment_Pony.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/DressageEquipment_Pony.xml
@@ -1,6 +1,6 @@
 <tosca:Definitions xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12"
                    xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12"
-                   id="winery-defs-for_ns0-DressageEquipment_Pony"
+                   id="ns0-DressageEquipment_Pony"
                    targetNamespace="http://winery.opentosca.org/test/ponyuniverse">
     <tosca:Import namespace="http://winery.opentosca.org/test/ponyuniverse" location="ns0__PonyEquipment.tosca"
                   importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/artifacttypes/war.xml
@@ -1,4 +1,4 @@
-<Definitions xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" id="winery-defs-for_otatyIgeneral-WAR"
+<Definitions xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" id="otatyIgeneral-WAR"
              targetNamespace="http://opentosca.org/artifacttypes">
     <ArtifactType abstract="no" final="no" name="WAR" targetNamespace="http://opentosca.org/artifacttypes"/>
 </Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/capabilitytypes/instance.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/capabilitytypes/instance.xml
@@ -1,6 +1,6 @@
 <tosca:Definitions
     xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12"
-    id="winery-defs-for_wfc-Healthy"
+    id="wfc-Healthy"
     targetNamespace="http://winery.opentosca.org/test/capabilitytypes/fruits">
     <tosca:CapabilityType name="Healthy" targetNamespace="http://winery.opentosca.org/test/capabilitytypes/fruits"/>
 </tosca:Definitions>

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/addedNodeType.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/addedNodeType.json
@@ -8,7 +8,7 @@
     "otherAttributes": {
 
     },
-    "id": "winery-defs-for_tosca1-myLittleExample_1.0.0-w1-1",
+    "id": "tosca1-myLittleExample_1.0.0-w1-1",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/baobab_with_interfaces.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/baobab_with_interfaces.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12"
                    xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12"
-                   targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits" id="winery-defs-for_wfn-baobab">
+                   targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits" id="wfn-baobab">
     <tosca:NodeType name="baobab" abstract="no" final="no"
                     targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:bordercolor="#89ee01">
         <winery:PropertiesDefinition elementname="BaobabProperties"

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/lemonproperties-at-c25aa724201824fce6eddcc7c35a666c6e015880.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/nodetypes/lemonproperties-at-c25aa724201824fce6eddcc7c35a666c6e015880.xml
@@ -1,5 +1,5 @@
 <Definitions xmlns="http://docs.oasis-open.org/tosca/ns/2011/12"
-             xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" id="winery-defs-for_wfn-lemon"
+             xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" id="wfn-lemon"
              targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits">
     <Import importType="http://www.w3.org/2001/XMLSchema"
             location="http://localhost:9080/winery/nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/lemon/propertiesdefinition/xsd"

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/relationshiptypes/kiwi_initial.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/relationshiptypes/kiwi_initial.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_ntyIfruits-kiwi",
+    "id": "ntyIfruits-kiwi",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/servicetemplates/importCsarWithOverwriteTest_afterOverwrite.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/servicetemplates/importCsarWithOverwriteTest_afterOverwrite.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_servicetemplates-ImportCsarWithOverwriteTest",
+    "id": "servicetemplates-ImportCsarWithOverwriteTest",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/servicetemplates/importCsarWithOverwriteTest_initial.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/entitytypes/servicetemplates/importCsarWithOverwriteTest_initial.json
@@ -2,7 +2,7 @@
     "documentation": [],
     "any": [],
     "otherAttributes": {},
-    "id": "winery-defs-for_servicetemplates-ImportCsarWithOverwriteTest",
+    "id": "servicetemplates-ImportCsarWithOverwriteTest",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [],

--- a/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/created_patternrefinementmodel.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/created_patternrefinementmodel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Definitions targetNamespace="http://plain.winery.opentosca.org/test/patternrefinementmodels" id="winery-defs-for_patternrefinementmodels-MyCoolPRM_w1-wip1" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12"
+<Definitions targetNamespace="http://plain.winery.opentosca.org/test/patternrefinementmodels" id="patternrefinementmodels-MyCoolPRM_w1-wip1" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12"
     xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:testwineryopentoscaorg="http://test.winery.opentosca.org">
     <PatternRefinementModel name="MyCoolPRM_w1-wip1" targetNamespace="http://plain.winery.opentosca.org/test/patternrefinementmodels">
         <Detector/>

--- a/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/first_patternrefinementmodel.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/first_patternrefinementmodel.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_patternrefinementmodels-myExample_w1-wip1",
+    "id": "patternrefinementmodels-myExample_w1-wip1",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/first_patternrefinementmodel.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/first_patternrefinementmodel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Definitions targetNamespace="http://winery.opentosca.org/test/concrete/patternrefinementmodels" id="winery-defs-for_patternrefinementmodels-myExample_w1-wip1" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:testwineryopentoscaorg="http://test.winery.opentosca.org">
+<Definitions targetNamespace="http://winery.opentosca.org/test/concrete/patternrefinementmodels" id="patternrefinementmodels-myExample_w1-wip1" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:testwineryopentoscaorg="http://test.winery.opentosca.org">
     <PatternRefinementModel name="myExample_w1-wip1" targetNamespace="http://winery.opentosca.org/test/concrete/patternrefinementmodels">
         <Detector>
             <NodeTemplate name="Infrastructure-As-A-Service_w1" minInstances="1" maxInstances="1" type="ot-patterns:Infrastructure-As-A-Service_w1" id="Infrastructure-As-A-Service_w1" winery:x="541" winery:y="231" xmlns:ot-patterns="http://plain.winery.opentosca.org/patterns"/>

--- a/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/initial_patternrefinementmodel.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/patternrefinementmodels/initial_patternrefinementmodel.json
@@ -8,7 +8,7 @@
     "otherAttributes": {
 
     },
-    "id": "winery-defs-for_patternrefinementmodels-MyCoolPRM_w1-wip1",
+    "id": "patternrefinementmodels-MyCoolPRM_w1-wip1",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/placement/Placement_Test_ServiceTemplate1.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/placement/Placement_Test_ServiceTemplate1.xml
@@ -1,5 +1,5 @@
 <Definitions targetNamespace="http://plain.winery.opentosca.org/placement/servicetemplates"
-             id="winery-defs-for_steIgeneral3-Placement_Test_DataFlow"
+             id="steIgeneral3-Placement_Test_DataFlow"
              xmlns="http://docs.oasis-open.org/tosca/ns/2011/12"
              xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12">
     <ServiceTemplate name="Placement_Test_DataFlow"

--- a/org.eclipse.winery.repository.rest/src/test/resources/placement/Placement_Test_ServiceTemplate2.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/placement/Placement_Test_ServiceTemplate2.xml
@@ -1,5 +1,5 @@
 <Definitions targetNamespace="http://plain.winery.opentosca.org/placement/servicetemplates"
-             id="winery-defs-for_steIgeneral3-Placement_Test_DataFlow"
+             id="steIgeneral3-Placement_Test_DataFlow"
              xmlns="http://docs.oasis-open.org/tosca/ns/2011/12"
              xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12">
     <ServiceTemplate name="Placement_Test_DataFlow"

--- a/org.eclipse.winery.repository.rest/src/test/resources/placement/Placement_Test_ServiceTemplate_Completed1.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/placement/Placement_Test_ServiceTemplate_Completed1.xml
@@ -1,5 +1,5 @@
 <Definitions targetNamespace="http://plain.winery.opentosca.org/placement/servicetemplates"
-             id="winery-defs-for_steIgeneral3-Placement_Test_DataFlow"
+             id="steIgeneral3-Placement_Test_DataFlow"
              xmlns="http://docs.oasis-open.org/tosca/ns/2011/12"
              xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12">
     <ServiceTemplate name="Placement_Test_DataFlow"

--- a/org.eclipse.winery.repository.rest/src/test/resources/placement/Placement_Test_ServiceTemplate_Completed2.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/placement/Placement_Test_ServiceTemplate_Completed2.xml
@@ -1,5 +1,5 @@
 <Definitions targetNamespace="http://plain.winery.opentosca.org/placement/servicetemplates"
-             id="winery-defs-for_steIgeneral3-Placement_Test_DataFlow"
+             id="steIgeneral3-Placement_Test_DataFlow"
              xmlns="http://docs.oasis-open.org/tosca/ns/2011/12"
              xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12">
     <ServiceTemplate name="Placement_Test_DataFlow"

--- a/org.eclipse.winery.repository.rest/src/test/resources/servicetemplate.tosca
+++ b/org.eclipse.winery.repository.rest/src/test/resources/servicetemplate.tosca
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12"
                    xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12"
-                   id="winery-defs-for_ns26-TrustedCloudPresentation" targetNamespace="http://www.opentosca.org">
+                   id="ns26-TrustedCloudPresentation" targetNamespace="http://www.opentosca.org">
     <tosca:NodeType name="ApacheWebserver" targetNamespace="http://www.opentosca.org/types/nodetypes"
                     winery:bordercolor="#3625c9">
         <tosca:Interfaces>

--- a/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/artifacttemplates/instance.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/artifacttemplates/instance.xml
@@ -1,6 +1,6 @@
 <tosca:Definitions
     xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12"
-    id="winery-defs-for_ns8-DressageEquipment_Pony"
+    id="ns8-DressageEquipment_Pony"
                    targetNamespace="http://winery.opentosca.org/test/servicetemplates/ponyuniverse/daspecifier">
     <tosca:Import importType="http://docs.oasis-open.org/tosca/ns/2011/12" location="ns0__DressageEquipment_Pony.tosca"
                   namespace="http://winery.opentosca.org/test/ponyuniverse"/>

--- a/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/newVersion.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/newVersion.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_servicetemplates-ServiceTemplateWithAllReqCapVariants_w1-wip1",
+    "id": "servicetemplates-ServiceTemplateWithAllReqCapVariants_w1-wip1",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/policytemplates/instance.xml
+++ b/org.eclipse.winery.repository.rest/src/test/resources/servicetemplates/policytemplates/instance.xml
@@ -1,6 +1,6 @@
 <tosca:Definitions
     xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12"
-    id="winery-defs-for_wfptmp-german"
+    id="wfptmp-german"
     targetNamespace="http://winery.opentosca.org/test/policytemplates/fruits">
     <tosca:Import namespace="http://winery.opentosca.org/test/policytypes/fruits" location="ns9__european.tosca"
                   importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>

--- a/org.eclipse.winery.repository.rest/src/test/resources/testrefinementmodels/initial_testrefinementmodel.json
+++ b/org.eclipse.winery.repository.rest/src/test/resources/testrefinementmodels/initial_testrefinementmodel.json
@@ -5,7 +5,7 @@
     ],
     "otherAttributes": {
     },
-    "id": "winery-defs-for_testrefinementmodels-MyCoolTRM_w1-wip1",
+    "id": "testrefinementmodels-MyCoolTRM_w1-wip1",
     "serviceTemplateOrNodeTypeOrNodeTypeImplementation": [
         {
             "documentation": [

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
@@ -511,8 +511,8 @@ public class BackendUtils {
         // we do not use UUID to be more human readable and deterministic (for debugging)
         String prefix = repo.getNamespaceManager().getPrefix(tcId.getNamespace());
         String elId = tcId.getXmlId().getDecoded();
-        String id = "winery-defs-for_" + prefix + "-" + elId;
-        defs.setId(id);
+        defs.setId(prefix + "-" + elId);
+
         return defs;
     }
 
@@ -745,7 +745,6 @@ public class BackendUtils {
 
     /**
      * @param ref the file to read from
-     * @param repo
      */
     public static Optional<XSModel> getXSModel(final RepositoryFileReference ref, IRepository repo) {
         Objects.requireNonNull(ref);
@@ -847,7 +846,6 @@ public class BackendUtils {
      *
      * @param ci     the entity type to try to modify the WPDs
      * @param errors the list to add errors to
-     * @param repository
      */
     // FIXME this is specifically for xml backends and therefore broken under the new canonical model
     public static void deriveWPD(TEntityType ci, List<String> errors, IRepository repository) {


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Sometimes, the IDs get really long and unreadable. Thus, we decided to remove the `winery-defs-for` prefix.

@wederbn

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/master/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
