### PR TITLE
Add export for Interface Types referenced in Node Types

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
@@ -83,6 +83,7 @@ import org.eclipse.winery.model.tosca.TEntityTypeImplementation;
 import org.eclipse.winery.model.tosca.TExtensibleElements;
 import org.eclipse.winery.model.tosca.TImplementationArtifact;
 import org.eclipse.winery.model.tosca.TImplementationArtifacts;
+import org.eclipse.winery.model.tosca.TInterfaceDefinition;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TNodeType;
 import org.eclipse.winery.model.tosca.TNodeTypeImplementation;
@@ -708,6 +709,14 @@ public interface IRepository extends IWineryRepositoryCommon {
                     capDef.getValidSourceTypes()
                         .forEach(sourceType -> ids.add(new NodeTypeId(sourceType)));
                 }
+            }
+        }
+
+        List<TInterfaceDefinition> interfaceDefinitions = nodeType.getInterfaceDefinitions();
+        if (Objects.nonNull(interfaceDefinitions) && !interfaceDefinitions.isEmpty()) {
+            for (TInterfaceDefinition intDef : interfaceDefinitions) {
+                InterfaceTypeId interfaceTypeId = new InterfaceTypeId(intDef.getType());
+                ids.add(interfaceTypeId);
             }
         }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/reader/YamlBuilder.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/reader/YamlBuilder.java
@@ -589,12 +589,8 @@ public class YamlBuilder {
                 .setClazz(YTInterfaceType.class))
             .setInputs(buildMap(map, "inputs", this::buildPropertyDefinition,
                 YTPropertyDefinition.class, parameter))
-            .setOperations(buildMap(object,
-                new Parameter<YTOperationDefinition>(parameter.getContext()).addContext("(operations)")
-                    .setValue("TInterfaceType")
-                    .setBuilderOO(this::buildOperationDefinition)
-                    .setFilter(this::filterInterfaceTypeOperation)
-            ))
+            .setOperations(buildMap(map, "operations", this::buildOperationDefinition,
+                YTOperationDefinition.class, parameter))
             .setDerivedFrom(buildQName(stringValue(map.get("derived_from"))))
             .build();
     }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/writer/YamlWriter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/writer/YamlWriter.java
@@ -39,7 +39,6 @@ import org.eclipse.winery.model.tosca.yaml.YTCapabilityType;
 import org.eclipse.winery.model.tosca.yaml.YTConstraintClause;
 import org.eclipse.winery.model.tosca.yaml.YTDataType;
 import org.eclipse.winery.model.tosca.yaml.YTEntityType;
-import org.eclipse.winery.model.tosca.yaml.YTSchemaDefinition;
 import org.eclipse.winery.model.tosca.yaml.YTGroupDefinition;
 import org.eclipse.winery.model.tosca.yaml.YTGroupType;
 import org.eclipse.winery.model.tosca.yaml.YTImplementation;
@@ -64,6 +63,7 @@ import org.eclipse.winery.model.tosca.yaml.YTRelationshipType;
 import org.eclipse.winery.model.tosca.yaml.YTRepositoryDefinition;
 import org.eclipse.winery.model.tosca.yaml.YTRequirementAssignment;
 import org.eclipse.winery.model.tosca.yaml.YTRequirementDefinition;
+import org.eclipse.winery.model.tosca.yaml.YTSchemaDefinition;
 import org.eclipse.winery.model.tosca.yaml.YTServiceTemplate;
 import org.eclipse.winery.model.tosca.yaml.YTStatusValue;
 import org.eclipse.winery.model.tosca.yaml.YTSubstitutionMappings;
@@ -277,12 +277,7 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTInterfaceType node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .print(node.getOperations().entrySet().stream()
-                .map(entry ->
-                    printVisitorNode(entry.getValue(), new Parameter(parameter.getIndent()).addContext(entry.getKey()))
-                )
-                .reduce(YamlPrinter::print)
-            )
+            .print(printMap("operations", node.getOperations(), parameter))
             .print(printMap("inputs", node.getInputs(), parameter));
     }
 


### PR DESCRIPTION
This PR adds export of Interface Type definitions referenced in Node Types needed for cases when custom interface types are used.  

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/master/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
