### PR TITLE
This commit solves the problem of duplicates in the repositories due …

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/filebased/RepositoryUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/filebased/RepositoryUtils.java
@@ -72,7 +72,7 @@ public class RepositoryUtils {
     public static boolean checkRepositoryDuplicate(String url, MultiRepository multiRepository) {
         for (IRepository frepo : multiRepository.getRepositoriesMap().keySet()) {
             if ((frepo instanceof GitBasedRepository) && (((GitBasedRepository) frepo).getRepositoryUrl() != null)) {
-                if (((GitBasedRepository) frepo).getRepositoryUrl().equals(url)) {
+                if (((GitBasedRepository) frepo).getRepositoryUrl().equalsIgnoreCase(url)) {
                     return true;
                 }
             }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/filebased/MultiRepositoryManagerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/filebased/MultiRepositoryManagerTest.java
@@ -19,8 +19,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,71 +31,13 @@ import org.eclipse.winery.repository.backend.filebased.RepositoryProperties;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MultiRepositoryManagerTest {
-    protected static final Logger LOGGER = LoggerFactory.getLogger(MultiRepositoryManagerTest.class);
-    static String workspaceRepositoryRoot;
-
-    /**
-     * This sets the repository root to a test directory where the multirepository will be temporarily be initialized.
-     * This additionaly saves the workspace repository root to set it back later.
-     */
-    @BeforeAll
-    static void getRepositoryRootBeforeTestAndSetUpTestRoot() {
-        workspaceRepositoryRoot = Environments.getInstance().getRepositoryConfig().getRepositoryRoot();
-        Path testRepositoryRoot = Paths.get(System.getProperty("java.io.tmpdir")).resolve("test-multi-repository");
-        if (!Files.exists(testRepositoryRoot)) {
-            try {
-                Files.createDirectory(testRepositoryRoot);
-            } catch (IOException ioex) {
-                LOGGER.debug("Error while creating test directory", ioex);
-            }
-        } else {
-            try {
-                FileUtils.cleanDirectory(testRepositoryRoot.toFile());
-            } catch (IOException e) {
-                LOGGER.debug("Error clearing out the test directory before test execution.", e);
-            }
-        }
-        Environments.getInstance().getRepositoryConfig().setRepositoryRoot(testRepositoryRoot.toString());
-    }
-
-    @BeforeEach
-    void cleanDirectory() {
-        try {
-            FileUtils.cleanDirectory(new File(Environments.getInstance().getRepositoryConfig().getRepositoryRoot()));
-        } catch (IOException e) {
-            LOGGER.error("Error while cleaning. Could not clear the temporary directory.", e);
-        }
-        try {
-            RepositoryFactory.reconfigure();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    /**
-     * This sets the repository root in the config back to the workspace repository root.
-     */
-    @AfterAll
-    static void setRepositoryRootBack() {
-        try {
-            FileUtils.deleteDirectory(new File(Environments.getInstance().getRepositoryConfig().getRepositoryRoot()));
-        } catch (IOException e) {
-            LOGGER.error("Error while cleanup. Could not delete temporary directory.", e);
-        }
-        Environments.getInstance().getRepositoryConfig().setRepositoryRoot(workspaceRepositoryRoot);
-    }
+public class MultiRepositoryManagerTest extends RepositoryTest{
+    
 
     /**
      * Tests whenever a file is created for the repository list in the root folder.

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/filebased/MultiRepositoryTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/filebased/MultiRepositoryTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.filebased;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+import org.eclipse.winery.common.configuration.Environments;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.backend.constants.Filename;
+
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MultiRepositoryTest extends RepositoryTest{
+
+    /**
+     * This test checks whether the MultiRepository detects duplicates of GitHub Repositories in the dependencies despite different capitalization
+     */
+    @Test
+    public void testDuplicatesInDependencies() {
+        writeDependencyFile();
+        Path repositoryRoot = Paths.get(Environments.getInstance().getRepositoryConfig().getRepositoryRoot());
+        MultiRepository multiRepro = null;
+        try {
+            multiRepro = new MultiRepository(repositoryRoot);
+        } catch (IOException | GitAPIException e) {
+            LOGGER.debug("Error while initializing MultiRepository", e);
+        }
+        assertNotNull(multiRepro);
+        LOGGER.debug("Repositories: \n\t" + 
+            multiRepro.getRepositories().stream()
+            .map(r -> r.getRepositoryRoot().toString())
+            .collect(Collectors.joining(",\n\t")));
+        assertEquals(3, multiRepro.getRepositories().size());
+    }
+
+    /**
+     * Helper method to place a dummy repositories.json dependency file into the test directory.
+     * Also reconfigures the Factory to a MultiRepository.
+     */
+    void writeDependencyFile() {
+        File dependencyFile = Paths.get(Environments.getInstance().getRepositoryConfig().getRepositoryRoot(), Filename.FILENAME_JSON_REPOSITORIES).toFile();
+        try (FileWriter writer = new FileWriter(dependencyFile)) {
+            writer.write("[\n" +
+                "  {\n" +
+                "    \"name\": \"test\",\n" +
+                "    \"url\": \"https://github.com/winery/mulit-repo-test\",\n" +
+                "    \"branch\": \"master\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"name\": \"test-dependency\",\n" +
+                "    \"url\": \"https://github.com/winery/MULTI-repo-dependency\",\n" +
+                "    \"branch\": \"master\"\n" +
+                "  }\n" +
+                "]");
+        } catch (IOException e) {
+            LOGGER.error("Error creating dependency file.", e);
+        }
+        try {
+            RepositoryFactory.reconfigure();
+        } catch (Exception e) {
+            LOGGER.error("Error reconfiguring Factory.", e);
+        }
+    }
+}

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/filebased/RepositoryTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/filebased/RepositoryTest.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.filebased;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.winery.common.configuration.Environments;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class RepositoryTest {
+    protected static final Logger LOGGER = LoggerFactory.getLogger(MultiRepositoryManagerTest.class);
+    static String workspaceRepositoryRoot;
+
+    /**
+     * This sets the repository root to a test directory where the multirepository will be temporarily be initialized.
+     * This additionaly saves the workspace repository root to set it back later.
+     */
+    @BeforeAll
+    static void getRepositoryRootBeforeTestAndSetUpTestRoot() {
+        workspaceRepositoryRoot = Environments.getInstance().getRepositoryConfig().getRepositoryRoot();
+        Path testRepositoryRoot = Paths.get(System.getProperty("java.io.tmpdir")).resolve("test-multi-repository");
+        if (!Files.exists(testRepositoryRoot)) {
+            try {
+                Files.createDirectory(testRepositoryRoot);
+            } catch (IOException ioex) {
+                LOGGER.debug("Error while creating test directory", ioex);
+            }
+        } else {
+            try {
+                FileUtils.cleanDirectory(testRepositoryRoot.toFile());
+            } catch (IOException e) {
+                LOGGER.debug("Error clearing out the test directory before test execution.", e);
+            }
+        }
+        Environments.getInstance().getRepositoryConfig().setRepositoryRoot(testRepositoryRoot.toString());
+    }
+
+    @BeforeEach
+    void cleanDirectory() {
+        try {
+            FileUtils.cleanDirectory(new File(Environments.getInstance().getRepositoryConfig().getRepositoryRoot()));
+        } catch (IOException e) {
+            LOGGER.error("Error while cleaning. Could not clear the temporary directory.", e);
+        }
+        try {
+            RepositoryFactory.reconfigure();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * This sets the repository root in the config back to the workspace repository root.
+     */
+    @AfterAll
+    static void setRepositoryRootBack() {
+        try {
+            FileUtils.deleteDirectory(new File(Environments.getInstance().getRepositoryConfig().getRepositoryRoot()));
+        } catch (IOException e) {
+            LOGGER.error("Error while cleanup. Could not delete temporary directory.", e);
+        }
+        Environments.getInstance().getRepositoryConfig().setRepositoryRoot(workspaceRepositoryRoot);
+    }
+}


### PR DESCRIPTION
…to the different capitalization of GitHub URLs.

It adds a test, which checks whether the MultiRepository detects duplicates of GitHub repositories in the dependencies despite different capitalization in the URLs.
The shared functionality of MultiRepositoryTest and MultiRepositoryManagerTest is moved to the abstract parent class RepositoryTest.

Signed-off-by: Marvin Bechtold <marvin.bechtold.dev@gmail.com>

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/master/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [ ] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
