### PR TITLE
Extend ConsistencyChecker with additional Tests

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
@@ -423,12 +423,12 @@ public interface IRepository extends IWineryRepositoryCommon {
         return elements;
     }
 
-    default <S extends TExtensibleElements> Map<QName, S> getAllQNameToElementMapping() {
-        Map<QName, S> elements = new HashMap<>();
+    default Map<QName, TDefinitions> getAllQNameToDefinitionsMapping() {
+        Map<QName, TDefinitions> elements = new HashMap<>();
         DefinitionsChildId.ALL_TOSCA_COMPONENT_ID_CLASSES.forEach((idClass) ->
             getAllDefinitionsChildIds(idClass)
                 .forEach(id ->
-                    elements.put(id.getQName(), getElement(id))
+                    elements.put(id.getQName(), this.getDefinitions(id))
                 )
         );
         return elements;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/consistencycheck/QNameValidator.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/consistencycheck/QNameValidator.java
@@ -18,11 +18,11 @@ import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import org.eclipse.winery.model.tosca.TDefinitions;
 import org.eclipse.winery.model.tosca.TDeploymentArtifact;
 import org.eclipse.winery.model.tosca.TEntityTemplate;
 import org.eclipse.winery.model.tosca.TEntityType;
 import org.eclipse.winery.model.tosca.TEntityTypeImplementation;
-import org.eclipse.winery.model.tosca.TExtensibleElements;
 import org.eclipse.winery.model.tosca.TImplementationArtifact;
 import org.eclipse.winery.model.tosca.visitor.Visitor;
 
@@ -31,9 +31,9 @@ import org.apache.commons.lang3.StringUtils;
 public class QNameValidator extends Visitor {
 
     private final ErrorLogger errorLogger;
-    private final Map<QName, TExtensibleElements> allQNameToElementMapping;
+    private final Map<QName, TDefinitions> allQNameToElementMapping;
 
-    public QNameValidator(ErrorLogger errorLogger, Map<QName, TExtensibleElements> allQNameToElementMapping) {
+    public QNameValidator(ErrorLogger errorLogger, Map<QName, TDefinitions> allQNameToElementMapping) {
         this.errorLogger = errorLogger;
         this.allQNameToElementMapping = allQNameToElementMapping;
     }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyCheckerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyCheckerTest.java
@@ -400,8 +400,25 @@ public class ConsistencyCheckerTest extends TestWithGitBackedRepository {
                 "304b62b06556afa1a7227164a9c0d2c9a1178b8f",
                 // origin/fruits in a non-working version
                 getErrorsFor304b62b06556afa1a7227164a9c0d2c9a1178b8f()
+            ),
+            Arguments.of(
+                "c09263f4fa112ff9093f9d52c6dc756f03d710b9",
+                getErrorsForc09263f4fa112ff9093f9d52c6dc756f03d710b9()
             )
         );
+    }
+
+    private static Map<QName, ElementErrorList> getErrorsForc09263f4fa112ff9093f9d52c6dc756f03d710b9() {
+        Map<QName, ElementErrorList> expected = new HashMap<>();
+        ElementErrorList elementErrorList;
+
+        elementErrorList = new ElementErrorList("ArtifactTemplate");
+        elementErrorList.addError("Corrupt: Namespace in the TOSCA-file does not match the folder's name!");
+        elementErrorList.addError("Corrupt: Wrapping Definitions Id in the TOSCA-file does not match the folder's name!");
+        elementErrorList.addError("Corrupt: Id/Name in the TOSCA-file does not match the folder's name!");
+        expected.put(new QName("http://plain.winery.opentosca.org/artifacttemplates", "ArtifactTemplateWithWrongTargetNamespace"), elementErrorList);
+        
+        return expected;
     }
 
     /**


### PR DESCRIPTION
Add assertions if the folder structure does not reflect the definition's contents.
This mostly only appears, if the contents are changed outside of Winery, however.

A more detailed example is explained in OpenTOSCA/winery#249.

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/master/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
