### PR TITLE
Docker: Create repository path if not initialized

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -10,13 +10,14 @@ fi
 mkdir -p .winery
 dockerize -template winery.yml.tpl:.winery/winery.yml
 if [ -d "${WINERY_REPOSITORY_PATH}" ] && [ "$(ls -A ${WINERY_REPOSITORY_PATH})" ]; then
-	echo "Repository at ${WINERY_REPOSITORY_PATH} is already initialized!";
+  echo "Repository at ${WINERY_REPOSITORY_PATH} is already initialized!";
 else
-	if [ ! "x${WINERY_REPOSITORY_URL}" = "x" ]; then
-		git clone ${WINERY_REPOSITORY_URL} ${WINERY_REPOSITORY_PATH};
-	else
-		git init ${WINERY_REPOSITORY_PATH};
-	fi
+  mkdir -p ${WINERY_REPOSITORY_PATH}
+  if [ ! "x${WINERY_REPOSITORY_URL}" = "x" ]; then
+    git clone ${WINERY_REPOSITORY_URL} ${WINERY_REPOSITORY_PATH};
+  else
+    git init ${WINERY_REPOSITORY_PATH};
+  fi
 fi
 if [ ! "x${WINERY_DEPENDENT_REPOSITORIES}" = "x" ]; then
   FILE=${WINERY_REPOSITORY_PATH}/repositories.json
@@ -30,6 +31,6 @@ fi
 cd ${WINERY_REPOSITORY_PATH}
 export CATALINA_OPTS="-Djava.security.egd=file:/dev/./urandom -Xms512m -Xmx${WINERY_HEAP_MAX} -Duser.home=${WINERY_USER_HOME}"
 if [ ! "x${WINERY_JMX_ENABLED}" = "x" ]; then
-	export CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Djava.rmi.server.hostname=0.0.0.0 -Dcom.sun.management.jmxremote.ssl=false"
+  export CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Djava.rmi.server.hostname=0.0.0.0 -Dcom.sun.management.jmxremote.ssl=false"
 fi
 ${CATALINA_HOME}/bin/catalina.sh run


### PR DESCRIPTION

If you overwrite the `WINERY_REPOSITORY_PATH` in the Docker setup, it seems that Winery doesn't start properly in cases where the specified path is not set. For example, Winery prints lots of `java.io.IOException: Creating directories for /var/nfs/winery/repository/default/.git failed` exceptions if the configured path (eg `/var/nfs/winery/repository`) is not present.

This PR tries to fix this by issuing an `mkdir -p` command during container start.

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/master/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
