### PR TITLE
YAML spec keywords as constants

### DIFF
--- a/org.eclipse.winery.model/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/YamlSpecKeywords.java
+++ b/org.eclipse.winery.model/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/support/YamlSpecKeywords.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.model.tosca.yaml.support;
+
+public class YamlSpecKeywords {
+    public static final String ACTION = "action";
+    public static final String ARTIFACTS = "artifacts";
+    public static final String ARTIFACT_TYPES = "artifact_types";
+    public static final String ATTRIBUTES = "attributes";
+    public static final String CALL_OPERATION = "call_operation";
+    public static final String CAPABILITIES = "capabilities";
+    public static final String CAPABILITY = "capability";
+    public static final String CAPABILITY_TYPES = "capability_types";
+    public static final String CONSTRAINTS = "constraints";
+    public static final String COPY = "copy";
+    public static final String CREDENTIAL = "credential";
+    public static final String DATA_TYPES = "data_types";
+    public static final String DEFAULT = "default";
+    public static final String DEPENDENCIES = "dependencies";
+    public static final String DEPLOY_PATH = "deploy_path";
+    public static final String DERIVED_FROM = "derived_from";
+    public static final String DESCRIPTION = "description";
+    public static final String DIRECTIVES = "directives";
+    public static final String DSL_DEFINITIONS = "dsl_definitions";
+    public static final String DSL_DEFINITION = "dsl_definition";
+    public static final String ENTRY_SCHEMA = "entry_schema";
+    public static final String EVENT = "event";
+    public static final String FILE = "file";
+    public static final String FILE_EXT = "file_ext";
+    public static final String GROUPS = "groups";
+    public static final String GROUP_TYPES = "group_types";
+    public static final String IMPLEMENTATION = "implementation";
+    public static final String IMPORTS = "imports";
+    public static final String IN_RANGE = "in_range";
+    public static final String INPUTS = "inputs";
+    public static final String INTERFACES = "interfaces";
+    public static final String INTERFACE_TYPES = "interface_types";
+    public static final String KEYS = "keys";
+    public static final String KEY_SCHEMA = "key_schema";
+    public static final String MEMBERS = "members";
+    public static final String METADATA = "metadata";
+    public static final String MIME_TYPE = "mime_type";
+    public static final String NAMESPACE_URI = "namespace_uri";
+    public static final String NAMESPACE_PREFIX = "namespace_prefix";
+    public static final String NODE = "node";
+    public static final String NODE_FILTER = "node_filter";
+    public static final String NODE_TEMPLATES = "node_templates";
+    public static final String NODE_TYPES = "node_types";
+    public static final String NODE_TYPE = "node_type";
+    public static final String OCCURRENCES = "occurrences";
+    public static final String OPERATION_HOST = "operation_host";
+    public static final String OPERATIONS = "operations";
+    public static final String OPERATION = "operation";
+    public static final String OUTPUTS = "outputs";
+    public static final String POLICIES = "policies";
+    public static final String POLICY_TYPES = "policy_types";
+    public static final String PRIMARY = "primary";
+    public static final String PROPERTIES = "properties";
+    public static final String PROTOCOL = "protocol";
+    public static final String RELATIONSHIP = "relationship";
+    public static final String RELATIONSHIP_TEMPLATES = "relationship_templates";
+    public static final String RELATIONSHIP_TYPES = "relationship_types";
+    public static final String REPOSITORIES = "repositories";
+    public static final String REPOSITORY = "repository";
+    public static final String REQUIRED = "required";
+    public static final String REQUIREMENTS = "requirements";
+    public static final String REQUIREMENT = "requirement";
+    public static final String SERVICE_TEMPLATE = "service_template";
+    public static final String STATUS = "status";
+    public static final String SUBSTITUTION_MAPPINGS = "substitution_mappings";
+    public static final String TARGETS = "targets";
+    public static final String TARGET_FILTER = "target_filter";
+    public static final String TIMEOUT = "timeout";
+    public static final String TOKEN = "token";
+    public static final String TOKEN_TYPE = "token_type";
+    public static final String TOPOLOGY_TEMPLATE = "topology_template";
+    public static final String TOSCA_DEF_VERSION = "tosca_definitions_version";
+    public static final String TRIGGERS = "triggers";
+    public static final String TYPE = "type";
+    public static final String URL = "url";
+    public static final String USER = "user";
+    public static final String VALID_VALUES = "valid_values";
+    public static final String VALID_SOURCE_TYPES = "valid_source_types";
+    public static final String VALID_TARGET_TYPES = "valid_target_types";
+    public static final String VALUE = "value";
+    public static final String VERSION = "version";
+}

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/reader/YamlBuilder.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/reader/YamlBuilder.java
@@ -90,6 +90,7 @@ import org.eclipse.winery.model.tosca.yaml.support.YTMapPolicyDefinition;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapPropertyFilterDefinition;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapRequirementAssignment;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapRequirementDefinition;
+import org.eclipse.winery.model.tosca.yaml.support.YamlSpecKeywords;
 import org.eclipse.winery.model.tosca.yaml.tosca.datatypes.Credential;
 import org.eclipse.winery.repository.converter.validator.FieldValidator;
 
@@ -165,34 +166,34 @@ public class YamlBuilder {
 
     @Nullable
     public YTServiceTemplate buildServiceTemplate(Object object) throws MultiException {
-        if (Objects.isNull(object) || !validate(YTServiceTemplate.class, object, new Parameter<>().addContext("service_template"))) {
+        if (Objects.isNull(object) || !validate(YTServiceTemplate.class, object, new Parameter<>().addContext(YamlSpecKeywords.SERVICE_TEMPLATE))) {
             return null;
         }
         Parameter<Object> parameter = new Parameter<>();
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
         // build map between prefix and namespaces
-        initPrefix2Namespace(map.get("imports"));
+        initPrefix2Namespace(map.get(YamlSpecKeywords.IMPORTS));
 
         YTServiceTemplate.Builder builder = new YTServiceTemplate.Builder(stringValue(
-            map.getOrDefault("tosca_definitions_version", "")
-        )).setMetadata(buildMetadata(map.get("metadata")))
-            .setDescription(buildDescription(map.get("description")))
-            .setDslDefinitions(buildMap(map.get("dsl_definitions"),
-                parameter.copy().addContext("dsl_definition").setBuilderOO((obj, p) -> obj)
+            map.getOrDefault(YamlSpecKeywords.TOSCA_DEF_VERSION, "")
+        )).setMetadata(buildMetadata(map.get(YamlSpecKeywords.METADATA)))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setDslDefinitions(buildMap(map.get(YamlSpecKeywords.DSL_DEFINITIONS),
+                parameter.copy().addContext(YamlSpecKeywords.DSL_DEFINITION).setBuilderOO((obj, p) -> obj)
             ))
-            .setRepositories(buildMap(map, "repositories", this::buildRepositoryDefinition, parameter))
-            .setImports(buildList(map, "imports", this::buildMapImportDefinition, parameter))
-            .setArtifactTypes(buildMap(map, "artifact_types", this::buildArtifactType, parameter))
-            .setDataTypes(buildMap(map, "data_types", this::buildDataType, parameter))
-            .setCapabilityTypes(buildMap(map, "capability_types", this::buildCapabilityType, parameter))
-            .setInterfaceTypes(buildMap(map, "interface_types", this::buildInterfaceType, parameter))
-            .setRelationshipTypes(buildMap(map, "relationship_types", this::buildRelationshipType, parameter))
-            .setNodeTypes(buildMap(map, "node_types", this::buildNodeType, parameter))
-            .setGroupTypes(buildMap(map, "group_types", this::buildGroupType, parameter))
-            .setPolicyTypes(buildMap(map, "policy_types", this::buildPolicyType, parameter))
-            .setTopologyTemplate(buildTopologyTemplate(map.get("topology_template"),
-                parameter.copy().addContext("topology_template")
+            .setRepositories(buildMap(map, YamlSpecKeywords.REPOSITORIES, this::buildRepositoryDefinition, parameter))
+            .setImports(buildList(map, YamlSpecKeywords.IMPORTS, this::buildMapImportDefinition, parameter))
+            .setArtifactTypes(buildMap(map, YamlSpecKeywords.ARTIFACT_TYPES, this::buildArtifactType, parameter))
+            .setDataTypes(buildMap(map, YamlSpecKeywords.DATA_TYPES, this::buildDataType, parameter))
+            .setCapabilityTypes(buildMap(map, YamlSpecKeywords.CAPABILITY_TYPES, this::buildCapabilityType, parameter))
+            .setInterfaceTypes(buildMap(map, YamlSpecKeywords.INTERFACE_TYPES, this::buildInterfaceType, parameter))
+            .setRelationshipTypes(buildMap(map, YamlSpecKeywords.RELATIONSHIP_TYPES, this::buildRelationshipType, parameter))
+            .setNodeTypes(buildMap(map, YamlSpecKeywords.NODE_TYPES, this::buildNodeType, parameter))
+            .setGroupTypes(buildMap(map, YamlSpecKeywords.GROUP_TYPES, this::buildGroupType, parameter))
+            .setPolicyTypes(buildMap(map, YamlSpecKeywords.POLICY_TYPES, this::buildPolicyType, parameter))
+            .setTopologyTemplate(buildTopologyTemplate(map.get(YamlSpecKeywords.TOPOLOGY_TEMPLATE),
+                parameter.copy().addContext(YamlSpecKeywords.TOPOLOGY_TEMPLATE)
             ));
         if (this.exception.hasException()) {
             throw this.exception;
@@ -208,15 +209,15 @@ public class YamlBuilder {
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
         return new YTTopologyTemplateDefinition.Builder()
-            .setDescription(buildDescription(map.get("description")))
-            .setInputs(buildMap(map, "inputs", this::buildParameterDefinition, parameter))
-            .setNodeTemplates(buildMap(map, "node_templates", this::buildNodeTemplate, parameter))
-            .setRelationshipTemplates(buildMap(map, "relationship_templates", this::buildRelationshipTemplate, parameter))
-            .setGroups(buildMap(map, "groups", this::buildGroupDefinition, parameter))
-            .setPolicies(buildListMap(map, "policies", this::buildPolicyDefinition, parameter))
-            .setOutputs(buildMap(map, "outputs", this::buildParameterDefinition, parameter))
-            .setSubstitutionMappings(buildSubstitutionMappings(map.get("substitution_mappings"),
-                parameter.copy().addContext("substitution_mappings")
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setInputs(buildMap(map, YamlSpecKeywords.INPUTS, this::buildParameterDefinition, parameter))
+            .setNodeTemplates(buildMap(map, YamlSpecKeywords.NODE_TEMPLATES, this::buildNodeTemplate, parameter))
+            .setRelationshipTemplates(buildMap(map, YamlSpecKeywords.RELATIONSHIP_TEMPLATES, this::buildRelationshipTemplate, parameter))
+            .setGroups(buildMap(map, YamlSpecKeywords.GROUPS, this::buildGroupDefinition, parameter))
+            .setPolicies(buildListMap(map, YamlSpecKeywords.POLICIES, this::buildPolicyDefinition, parameter))
+            .setOutputs(buildMap(map, YamlSpecKeywords.OUTPUTS, this::buildParameterDefinition, parameter))
+            .setSubstitutionMappings(buildSubstitutionMappings(map.get(YamlSpecKeywords.SUBSTITUTION_MAPPINGS),
+                parameter.copy().addContext(YamlSpecKeywords.SUBSTITUTION_MAPPINGS)
             ))
             .build();
     }
@@ -263,10 +264,10 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTRepositoryDefinition.Builder(stringValue(map.get("url")))
-            .setDescription(buildDescription(map.get("description")))
-            .setCredential(buildCredential(map.get("credential"),
-                new Parameter<Credential>(parameter.getContext()).addContext("credential")
+        return new YTRepositoryDefinition.Builder(stringValue(map.get(YamlSpecKeywords.URL)))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setCredential(buildCredential(map.get(YamlSpecKeywords.CREDENTIAL),
+                new Parameter<Credential>(parameter.getContext()).addContext(YamlSpecKeywords.CREDENTIAL)
             ))
             .build();
     }
@@ -283,11 +284,11 @@ public class YamlBuilder {
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
         @SuppressWarnings("unchecked")
-        Map<String, String> keys = (Map<String, String>) map.get("keys");
-        return new Credential.Builder(stringValue(map.get("token_type")))
-            .setProtocol(stringValue(map.get("protocol")))
-            .setToken(stringValue(map.get("token")))
-            .setUser(stringValue(map.get("user")))
+        Map<String, String> keys = (Map<String, String>) map.get(YamlSpecKeywords.KEYS);
+        return new Credential.Builder(stringValue(map.get(YamlSpecKeywords.TOKEN_TYPE)))
+            .setProtocol(stringValue(map.get(YamlSpecKeywords.PROTOCOL)))
+            .setToken(stringValue(map.get(YamlSpecKeywords.TOKEN)))
+            .setUser(stringValue(map.get(YamlSpecKeywords.USER)))
             .setKeys(keys)
             .build();
     }
@@ -314,10 +315,10 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTImportDefinition.Builder(stringValue(map.get("file")))
-            .setRepository(buildQName(stringValue(map.get("repository"))))
-            .setNamespaceUri(stringValue(map.get("namespace_uri")))
-            .setNamespacePrefix(stringValue(map.get("namespace_prefix")))
+        return new YTImportDefinition.Builder(stringValue(map.get(YamlSpecKeywords.FILE)))
+            .setRepository(buildQName(stringValue(map.get(YamlSpecKeywords.REPOSITORY))))
+            .setNamespaceUri(stringValue(map.get(YamlSpecKeywords.NAMESPACE_URI)))
+            .setNamespacePrefix(stringValue(map.get(YamlSpecKeywords.NAMESPACE_PREFIX)))
             .build();
     }
 
@@ -352,9 +353,9 @@ public class YamlBuilder {
             new Parameter<YTArtifactType.Builder>(parameter.getContext())
                 .setBuilder(new YTArtifactType.Builder())
                 .setClazz(YTArtifactType.class))
-            .setMimeType(stringValue(map.get("mime_type")))
-            .setFileExt(buildListString(map.get("file_ext"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("file_ext")
+            .setMimeType(stringValue(map.get(YamlSpecKeywords.MIME_TYPE)))
+            .setFileExt(buildListString(map.get(YamlSpecKeywords.FILE_EXT),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.FILE_EXT)
             ))
             .build();
     }
@@ -367,12 +368,12 @@ public class YamlBuilder {
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
         return parameter.getBuilder()
-            .setDescription(buildDescription(map.get("description")))
-            .setVersion(buildVersion(map.get("version")))
-            .setDerivedFrom(buildQName(stringValue(map.get("derived_from"))))
-            .setProperties(buildMap(map, "properties", this::buildPropertyDefinition, YTPropertyDefinition.class, parameter))
-            .setAttributes(buildMap(map, "attributes", this::buildAttributeDefinition, parameter))
-            .setMetadata(buildMetadata(map.get("metadata")));
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setVersion(buildVersion(map.get(YamlSpecKeywords.VERSION)))
+            .setDerivedFrom(buildQName(stringValue(map.get(YamlSpecKeywords.DERIVED_FROM))))
+            .setProperties(buildMap(map, YamlSpecKeywords.PROPERTIES, this::buildPropertyDefinition, YTPropertyDefinition.class, parameter))
+            .setAttributes(buildMap(map, YamlSpecKeywords.ATTRIBUTES, this::buildAttributeDefinition, parameter))
+            .setMetadata(buildMetadata(map.get(YamlSpecKeywords.METADATA)));
     }
 
     @Nullable
@@ -390,21 +391,21 @@ public class YamlBuilder {
             return null;
         }
         Map<String, Object> map = (Map<String, Object>) object;
-        String type = stringValue(map.get("type"));
+        String type = stringValue(map.get(YamlSpecKeywords.TYPE));
         if (type == null) {
             type = "string";
         }
         return new YTPropertyDefinition.Builder(buildQName(type))
-            .setDescription(buildDescription(map.get("description")))
-            .setRequired(buildRequired(map.get("required")))
-            .setDefault(map.get("default"))
-            .setStatus(buildStatus(map.get("status")))
-            .addConstraints(buildList(map, "constraints", this::buildConstraintClause, parameter))
-            .setEntrySchema(buildSchemaDefinition(map.get("entry_schema"),
-                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext("entry_schema")
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setRequired(buildRequired(map.get(YamlSpecKeywords.REQUIRED)))
+            .setDefault(map.get(YamlSpecKeywords.DEFAULT))
+            .setStatus(buildStatus(map.get(YamlSpecKeywords.STATUS)))
+            .addConstraints(buildList(map, YamlSpecKeywords.CONSTRAINTS, this::buildConstraintClause, parameter))
+            .setEntrySchema(buildSchemaDefinition(map.get(YamlSpecKeywords.ENTRY_SCHEMA),
+                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.ENTRY_SCHEMA)
             ))
-            .setKeySchema(buildSchemaDefinition(map.get("key_schema"),
-                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext("key_schema")))
+            .setKeySchema(buildSchemaDefinition(map.get(YamlSpecKeywords.KEY_SCHEMA),
+                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.KEY_SCHEMA)))
             .build();
     }
 
@@ -451,13 +452,13 @@ public class YamlBuilder {
         YTConstraintClause.Builder builder = new YTConstraintClause.Builder();
         builder.setKey(parameter.getValue());
         switch (parameter.getValue()) {
-            case "in_range":
+            case YamlSpecKeywords.IN_RANGE:
                 builder.setList(buildListString(object,
-                    new Parameter<List<String>>(parameter.getContext()).addContext("in_range")));
+                    new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.IN_RANGE)));
                 break;
-            case "valid_values":
+            case YamlSpecKeywords.VALID_VALUES:
                 builder.setList(buildListString(object,
-                    new Parameter<List<String>>(parameter.getContext()).addContext("valid_values")));
+                    new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.VALID_VALUES)));
                 break;
             default:
                 builder.setKey(parameter.getValue());
@@ -486,13 +487,13 @@ public class YamlBuilder {
         } else {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) object;
-            return new YTSchemaDefinition.Builder(buildQName(stringValue(map.get("type"))))
-                .setDescription(buildDescription(map.get("description")))
-                .setConstraints(buildList(map, "constraints", this::buildConstraintClause, parameter))
-                .setEntrySchema(buildSchemaDefinition(map.get("entry_schema"),
-                    new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext("entry_schema")))
-                .setKeySchema(buildSchemaDefinition(map.get("key_schema"),
-                    new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext("key_schema")))
+            return new YTSchemaDefinition.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+                .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+                .setConstraints(buildList(map, YamlSpecKeywords.CONSTRAINTS, this::buildConstraintClause, parameter))
+                .setEntrySchema(buildSchemaDefinition(map.get(YamlSpecKeywords.ENTRY_SCHEMA),
+                    new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.ENTRY_SCHEMA)))
+                .setKeySchema(buildSchemaDefinition(map.get(YamlSpecKeywords.KEY_SCHEMA),
+                    new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.KEY_SCHEMA)))
                 .build();
         }
     }
@@ -507,15 +508,15 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTAttributeDefinition.Builder(buildQName(stringValue(map.get("type"))))
-            .setDescription(buildDescription(map.get("description")))
-            .setDefault(map.get("default"))
-            .setStatus(buildStatus(map.get("status")))
-            .setEntrySchema(buildSchemaDefinition(map.get("entry_schema"),
-                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext("entry_schema")
+        return new YTAttributeDefinition.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setDefault(map.get(YamlSpecKeywords.DEFAULT))
+            .setStatus(buildStatus(map.get(YamlSpecKeywords.STATUS)))
+            .setEntrySchema(buildSchemaDefinition(map.get(YamlSpecKeywords.ENTRY_SCHEMA),
+                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.ENTRY_SCHEMA)
             ))
-            .setKeySchema(buildSchemaDefinition(map.get("key_schema"),
-                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext("key_schema")))
+            .setKeySchema(buildSchemaDefinition(map.get(YamlSpecKeywords.KEY_SCHEMA),
+                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.KEY_SCHEMA)))
             .build();
     }
 
@@ -550,7 +551,7 @@ public class YamlBuilder {
             new Parameter<YTDataType.Builder>(parameter.getContext())
                 .setBuilder(new YTDataType.Builder())
                 .setClazz(YTDataType.class))
-            .setConstraints(buildList(map, "constraints", this::buildConstraintClause, parameter))
+            .setConstraints(buildList(map, YamlSpecKeywords.CONSTRAINTS, this::buildConstraintClause, parameter))
             .build();
     }
 
@@ -565,8 +566,8 @@ public class YamlBuilder {
             new Parameter<YTCapabilityType.Builder>(parameter.getContext())
                 .setBuilder(new YTCapabilityType.Builder())
                 .setClazz(YTCapabilityType.class))
-            .setValidSourceTypes(buildListQName(buildListString(map.get("valid_source_types"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("valid_source_types")
+            .setValidSourceTypes(buildListQName(buildListString(map.get(YamlSpecKeywords.VALID_SOURCE_TYPES),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.VALID_SOURCE_TYPES)
             )))
             .build();
     }
@@ -592,11 +593,11 @@ public class YamlBuilder {
             new Parameter<YTInterfaceType.Builder>(parameter.getContext())
                 .setBuilder(new YTInterfaceType.Builder())
                 .setClazz(YTInterfaceType.class))
-            .setInputs(buildMap(map, "inputs", this::buildPropertyDefinition,
+            .setInputs(buildMap(map, YamlSpecKeywords.INPUTS, this::buildPropertyDefinition,
                 YTPropertyDefinition.class, parameter))
-            .setOperations(buildMap(map, "operations", this::buildOperationDefinition,
+            .setOperations(buildMap(map, YamlSpecKeywords.OPERATIONS, this::buildOperationDefinition,
                 YTOperationDefinition.class, parameter))
-            .setDerivedFrom(buildQName(stringValue(map.get("derived_from"))))
+            .setDerivedFrom(buildQName(stringValue(map.get(YamlSpecKeywords.DERIVED_FROM))))
             .build();
     }
 
@@ -619,15 +620,15 @@ public class YamlBuilder {
             return null;
         }
         Map<String, Object> map = (Map<String, Object>) object;
-        String description = buildDescription(map.get("description"));
-        Map<String, YTParameterDefinition> inputs = buildParameterDefinitions(map.get("inputs"),
-            new Parameter<>(parameter.getContext()).addContext("inputs").setValue(parameter.getValue())
+        String description = buildDescription(map.get(YamlSpecKeywords.DESCRIPTION));
+        Map<String, YTParameterDefinition> inputs = buildParameterDefinitions(map.get(YamlSpecKeywords.INPUTS),
+            new Parameter<>(parameter.getContext()).addContext(YamlSpecKeywords.INPUTS).setValue(parameter.getValue())
         );
-        Map<String, YTParameterDefinition> outputs = buildParameterDefinitions(map.get("outputs"),
-            new Parameter<>(parameter.getContext()).addContext("outputs").setValue(parameter.getValue())
+        Map<String, YTParameterDefinition> outputs = buildParameterDefinitions(map.get(YamlSpecKeywords.OUTPUTS),
+            new Parameter<>(parameter.getContext()).addContext(YamlSpecKeywords.OUTPUTS).setValue(parameter.getValue())
         );
-        YTImplementation implementation = buildImplementation(map.get("implementation"),
-            new Parameter<YTImplementation>(parameter.getContext()).addContext("implementation")
+        YTImplementation implementation = buildImplementation(map.get(YamlSpecKeywords.IMPLEMENTATION),
+            new Parameter<YTImplementation>(parameter.getContext()).addContext(YamlSpecKeywords.IMPLEMENTATION)
         );
         return new YTOperationDefinition.Builder()
             .setDescription(description)
@@ -694,12 +695,12 @@ public class YamlBuilder {
         if (object instanceof Map) {
             Map<String, Object> map = (Map<String, Object>) object;
             YTImplementation.Builder builder = new YTImplementation.Builder();
-            builder.setPrimaryArtifactName(stringValue(map.get("primary")));
-            builder.setDependencyArtifactNames(buildListString(map.get("dependencies"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("dependencies")
+            builder.setPrimaryArtifactName(stringValue(map.get(YamlSpecKeywords.PRIMARY)));
+            builder.setDependencyArtifactNames(buildListString(map.get(YamlSpecKeywords.DEPENDENCIES),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.DEPENDENCIES)
             ));
-            builder.setOperationHost(stringValue(map.get("operation_host")));
-            String timeout = stringValue(map.get("timeout"));
+            builder.setOperationHost(stringValue(map.get(YamlSpecKeywords.OPERATION_HOST)));
+            String timeout = stringValue(map.get(YamlSpecKeywords.TIMEOUT));
             builder.setTimeout(timeout == null ? null : Integer.valueOf(timeout));
             return builder.build();
         }
@@ -716,11 +717,11 @@ public class YamlBuilder {
         return buildEntityType(object, new Parameter<YTRelationshipType.Builder>(parameter.getContext())
             .setBuilder(new YTRelationshipType.Builder())
             .setClazz(YTRelationshipType.class))
-            .setValidTargetTypes(buildListQName(buildListString(map.get("valid_target_types"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("valid_target_types")
+            .setValidTargetTypes(buildListQName(buildListString(map.get(YamlSpecKeywords.VALID_TARGET_TYPES),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.VALID_TARGET_TYPES)
             )))
-            .setInterfaces(buildMap(map.get("interfaces"),
-                new Parameter<YTInterfaceDefinition>(parameter.getContext()).addContext("interfaces")
+            .setInterfaces(buildMap(map.get(YamlSpecKeywords.INTERFACES),
+                new Parameter<YTInterfaceDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.INTERFACES)
                     .setValue("TRelationshipType")
                     .setBuilderOO(this::buildInterfaceDefinition)
             ))
@@ -735,12 +736,12 @@ public class YamlBuilder {
         }
         Map<String, Object> map = (Map<String, Object>) object;
         YTInterfaceDefinition.Builder<?> output = new YTInterfaceDefinition.Builder<>()
-            .setType(buildQName(stringValue(map.get("type"))))
-            .setInputs(buildParameterDefinitions(map.get("inputs"),
-                new Parameter<>(parameter.getContext()).addContext("inputs")
+            .setType(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setInputs(buildParameterDefinitions(map.get(YamlSpecKeywords.INPUTS),
+                new Parameter<>(parameter.getContext()).addContext(YamlSpecKeywords.INPUTS)
                     .setValue(parameter.getValue())
             ));
-        Map<String, YTOperationDefinition> operations = buildMap(map.get("operations"),
+        Map<String, YTOperationDefinition> operations = buildMap(map.get(YamlSpecKeywords.OPERATIONS),
             new Parameter<YTOperationDefinition>(parameter.getContext())
                 .setValue(parameter.getValue())
                 .addContext("(operation)")
@@ -761,14 +762,14 @@ public class YamlBuilder {
         return buildEntityType(object, new Parameter<YTNodeType.Builder>(parameter.getContext())
             .setBuilder(new YTNodeType.Builder())
             .setClazz(YTNodeType.class))
-            .setRequirements(buildList(map, "requirements", this::buildMapRequirementDefinition, parameter))
-            .setCapabilities(buildMap(map, "capabilities", this::buildCapabilityDefinition, parameter))
-            .setInterfaces(buildMap(map.get("interfaces"),
-                new Parameter<YTInterfaceDefinition>(parameter.getContext()).addContext("interfaces")
+            .setRequirements(buildList(map, YamlSpecKeywords.REQUIREMENTS, this::buildMapRequirementDefinition, parameter))
+            .setCapabilities(buildMap(map, YamlSpecKeywords.CAPABILITIES, this::buildCapabilityDefinition, parameter))
+            .setInterfaces(buildMap(map.get(YamlSpecKeywords.INTERFACES),
+                new Parameter<YTInterfaceDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.INTERFACES)
                     .setValue("TNodeType")
                     .setBuilderOO(this::buildInterfaceDefinition)
             ))
-            .setArtifacts(buildMap(map, "artifacts", this::buildArtifactDefinition, parameter))
+            .setArtifacts(buildMap(map, YamlSpecKeywords.ARTIFACTS, this::buildArtifactDefinition, parameter))
             .build();
     }
 
@@ -792,13 +793,13 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTRequirementDefinition.Builder(buildQName(stringValue(map.get("capability"))))
-            .setNode(buildQName(stringValue(map.get("node"))))
-            .setRelationship(buildRelationshipDefinition(map.get("relationship"),
-                new Parameter<YTRelationshipDefinition>(parameter.getContext()).addContext("relationship")
+        return new YTRequirementDefinition.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.CAPABILITY))))
+            .setNode(buildQName(stringValue(map.get(YamlSpecKeywords.NODE))))
+            .setRelationship(buildRelationshipDefinition(map.get(YamlSpecKeywords.RELATIONSHIP),
+                new Parameter<YTRelationshipDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.RELATIONSHIP)
             ))
-            .setOccurrences(buildListString(map.get("occurrences"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("occurrences")
+            .setOccurrences(buildListString(map.get(YamlSpecKeywords.OCCURRENCES),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.OCCURRENCES)
             ))
             .build();
     }
@@ -816,9 +817,9 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTRelationshipDefinition.Builder(buildQName(stringValue(map.get("type"))))
-            .setInterfaces(buildMap(map.get("interfaces"),
-                new Parameter<YTInterfaceDefinition>(parameter.getContext()).addContext("interfaces")
+        return new YTRelationshipDefinition.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setInterfaces(buildMap(map.get(YamlSpecKeywords.INTERFACES),
+                new Parameter<YTInterfaceDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.INTERFACES)
                     .setValue("TRelationshipDefinition")
                     .setBuilderOO(this::buildInterfaceDefinition)
             ))
@@ -838,20 +839,20 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTCapabilityDefinition.Builder(buildQName(stringValue(map.get("type"))))
-            .setDescription(buildDescription(map.get("description")))
-            .setOccurrences(buildListString(map.get("occurrences"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("occurrences")
+        return new YTCapabilityDefinition.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setOccurrences(buildListString(map.get(YamlSpecKeywords.OCCURRENCES),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.OCCURRENCES)
             ))
-            .setValidSourceTypes(buildListQName(buildListString(map.get("valid_source_types"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("valid_source_types")
+            .setValidSourceTypes(buildListQName(buildListString(map.get(YamlSpecKeywords.VALID_SOURCE_TYPES),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.VALID_SOURCE_TYPES)
             )))
-            .setProperties(buildMap(map.get("properties"),
-                new Parameter<YTPropertyDefinition>(parameter.getContext()).addContext("properties")
+            .setProperties(buildMap(map.get(YamlSpecKeywords.PROPERTIES),
+                new Parameter<YTPropertyDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.PROPERTIES)
                     .setClazz(YTPropertyDefinition.class)
                     .setBuilderOO(this::buildPropertyDefinition)
             ))
-            .setAttributes(buildMap(map, "attributes", this::buildAttributeDefinition, parameter))
+            .setAttributes(buildMap(map, YamlSpecKeywords.ATTRIBUTES, this::buildAttributeDefinition, parameter))
             .build();
     }
 
@@ -876,18 +877,18 @@ public class YamlBuilder {
         Map<String, Object> map = (Map<String, Object>) object;
 
         String file;
-        if (map.get("file") instanceof String) {
-            file = stringValue(map.get("file"));
+        if (map.get(YamlSpecKeywords.FILE) instanceof String) {
+            file = stringValue(map.get(YamlSpecKeywords.FILE));
         } else {
             file = null;
             assert false;
         }
-        return new YTArtifactDefinition.Builder(buildQName(stringValue(map.get("type"))), file)
-            .setRepository(stringValue(map.get("repository")))
-            .setDescription(buildDescription(map.get("description")))
-            .setDeployPath(stringValue(map.get("deploy_path")))
-            .setProperties(buildMap(map.get("properties"),
-                new Parameter<YTPropertyAssignment>().addContext("properties")
+        return new YTArtifactDefinition.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))), file)
+            .setRepository(stringValue(map.get(YamlSpecKeywords.REPOSITORY)))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setDeployPath(stringValue(map.get(YamlSpecKeywords.DEPLOY_PATH)))
+            .setProperties(buildMap(map.get(YamlSpecKeywords.PROPERTIES),
+                new Parameter<YTPropertyAssignment>().addContext(YamlSpecKeywords.PROPERTIES)
                     .setBuilderOO(this::buildPropertyAssignment)
             ))
             .build();
@@ -903,8 +904,8 @@ public class YamlBuilder {
         return buildEntityType(object, new Parameter<YTGroupType.Builder>(parameter.getContext())
             .setBuilder(new YTGroupType.Builder())
             .setClazz(YTGroupType.class))
-            .setMembers(buildListQName(buildListString(map.get("members"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("members")
+            .setMembers(buildListQName(buildListString(map.get(YamlSpecKeywords.MEMBERS),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.MEMBERS)
             )))
             .build();
     }
@@ -919,10 +920,10 @@ public class YamlBuilder {
         return buildEntityType(object, new Parameter<YTPolicyType.Builder>(parameter.getContext())
             .setBuilder(new YTPolicyType.Builder())
             .setClazz(YTPolicyType.class))
-            .setTargets(buildListQName(buildListString(map.get("targets"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("targets")
+            .setTargets(buildListQName(buildListString(map.get(YamlSpecKeywords.TARGETS),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.TARGETS)
             )))
-            .setTriggers(buildMap(map, "triggers", this::buildTriggerDefinition,
+            .setTriggers(buildMap(map, YamlSpecKeywords.TRIGGERS, this::buildTriggerDefinition,
                 YTTriggerDefinition.class, parameter))
             .build();
     }
@@ -934,16 +935,16 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        if (Objects.isNull(map.get("event"))) {
+        if (Objects.isNull(map.get(YamlSpecKeywords.EVENT))) {
             return null;
         }
-        YTTriggerDefinition.Builder output = new YTTriggerDefinition.Builder(stringValue(map.get("event")))
-            .setDescription(buildDescription(map.get("description")))
-            .setTargetFilter(buildEventFilterDefinition(map.get("target_filter"),
-                new Parameter<YTEventFilterDefinition>(parameter.getContext()).addContext("target_filter")
+        YTTriggerDefinition.Builder output = new YTTriggerDefinition.Builder(stringValue(map.get(YamlSpecKeywords.EVENT)))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setTargetFilter(buildEventFilterDefinition(map.get(YamlSpecKeywords.TARGET_FILTER),
+                new Parameter<YTEventFilterDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.TARGET_FILTER)
             ))
-            .setAction(buildList(map, "action", this::buildMapActivityDefinition,
-                new Parameter<YTMapActivityDefinition>(parameter.getContext()).addContext("action"))
+            .setAction(buildList(map, YamlSpecKeywords.ACTION, this::buildMapActivityDefinition,
+                new Parameter<YTMapActivityDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.ACTION))
             );
 
         return output.build();
@@ -952,7 +953,7 @@ public class YamlBuilder {
     @Nullable
     public YTMapActivityDefinition buildMapActivityDefinition(Object object, Parameter<YTMapActivityDefinition> parameter) {
         YTMapActivityDefinition result = new YTMapActivityDefinition();
-        if ("call_operation".equals(parameter.getValue())) {
+        if (YamlSpecKeywords.CALL_OPERATION.equals(parameter.getValue())) {
             put(result, parameter.getValue(), buildCallOperationActivityDefinition(object, new Parameter<>(parameter.getContext())));
         } else {
             // other types YTActivityDefinition can go here
@@ -971,9 +972,9 @@ public class YamlBuilder {
                 return new YTCallOperationActivityDefinition((String) object);
             }
             Map<String, Object> map = (Map<String, Object>) object;
-            YTCallOperationActivityDefinition callOperation = new YTCallOperationActivityDefinition(stringValue(map.get("operation")));
-            Map<String, YTParameterDefinition> inputs = buildParameterDefinitions(map.get("inputs"),
-                new Parameter<>(parameter.getContext()).addContext("inputs").setValue(parameter.getValue())
+            YTCallOperationActivityDefinition callOperation = new YTCallOperationActivityDefinition(stringValue(map.get(YamlSpecKeywords.OPERATION)));
+            Map<String, YTParameterDefinition> inputs = buildParameterDefinitions(map.get(YamlSpecKeywords.INPUTS),
+                new Parameter<>(parameter.getContext()).addContext(YamlSpecKeywords.INPUTS).setValue(parameter.getValue())
             );
             callOperation.setInputs(inputs);
             return callOperation;
@@ -990,9 +991,9 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        YTEventFilterDefinition.Builder output = new YTEventFilterDefinition.Builder(stringValue(map.get("node")))
-            .setRequirement(stringValue(map.get("requirement")))
-            .setCapability(stringValue(map.get("capability")));
+        YTEventFilterDefinition.Builder output = new YTEventFilterDefinition.Builder(stringValue(map.get(YamlSpecKeywords.NODE)))
+            .setRequirement(stringValue(map.get(YamlSpecKeywords.REQUIREMENT)))
+            .setCapability(stringValue(map.get(YamlSpecKeywords.CAPABILITY)));
 
         return output.build();
     }
@@ -1004,23 +1005,23 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        String type = stringValue(map.get("type"));
+        String type = stringValue(map.get(YamlSpecKeywords.TYPE));
         if (type == null) {
             type = "string";
         }
         return new YTParameterDefinition.Builder()
             .setType(buildQName(type))
-            .setDescription(buildDescription(map.get("description")))
-            .setRequired(buildRequired(map.get("required")))
-            .setDefault(map.get("default"))
-            .setStatus(buildStatus(map.get("status")))
-            .setConstraints(buildList(map, "constraints", this::buildConstraintClause, parameter))
-            .setEntrySchema(buildSchemaDefinition(map.get("entry_schema"),
-                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext("entry_schema")
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setRequired(buildRequired(map.get(YamlSpecKeywords.REQUIRED)))
+            .setDefault(map.get(YamlSpecKeywords.DEFAULT))
+            .setStatus(buildStatus(map.get(YamlSpecKeywords.STATUS)))
+            .setConstraints(buildList(map, YamlSpecKeywords.CONSTRAINTS, this::buildConstraintClause, parameter))
+            .setEntrySchema(buildSchemaDefinition(map.get(YamlSpecKeywords.ENTRY_SCHEMA),
+                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.ENTRY_SCHEMA)
             ))
-            .setKeySchema(buildSchemaDefinition(map.get("key_schema"),
-                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext("key_schema")))
-            .setValue(map.get("value"))
+            .setKeySchema(buildSchemaDefinition(map.get(YamlSpecKeywords.KEY_SCHEMA),
+                new Parameter<YTSchemaDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.KEY_SCHEMA)))
+            .setValue(map.get(YamlSpecKeywords.VALUE))
             .build();
     }
 
@@ -1045,26 +1046,26 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTNodeTemplate.Builder(buildQName(stringValue(map.get("type"))))
-            .setDescription(buildDescription(map.get("description")))
-            .setMetadata(buildMetadata(map.get("metadata")))
-            .setDirectives(buildListString(map.get("directives"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("directives")
+        return new YTNodeTemplate.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setMetadata(buildMetadata(map.get(YamlSpecKeywords.METADATA)))
+            .setDirectives(buildListString(map.get(YamlSpecKeywords.DIRECTIVES),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.DIRECTIVES)
             ))
-            .setProperties(buildMap(map, "properties", this::buildPropertyAssignment, parameter))
-            .setAttributes(buildMap(map, "attributes", this::buildAttributeAssignment, parameter))
-            .setRequirements(buildList(map, "requirements", this::buildMapRequirementAssignment, parameter))
-            .setCapabilities(buildMap(map, "capabilities", this::buildCapabilityAssignment, parameter))
-            .setInterfaces(buildMap(map.get("interfaces"),
-                new Parameter<YTInterfaceAssignment>(parameter.getContext()).addContext("interfaces")
+            .setProperties(buildMap(map, YamlSpecKeywords.PROPERTIES, this::buildPropertyAssignment, parameter))
+            .setAttributes(buildMap(map, YamlSpecKeywords.ATTRIBUTES, this::buildAttributeAssignment, parameter))
+            .setRequirements(buildList(map, YamlSpecKeywords.REQUIREMENTS, this::buildMapRequirementAssignment, parameter))
+            .setCapabilities(buildMap(map, YamlSpecKeywords.CAPABILITIES, this::buildCapabilityAssignment, parameter))
+            .setInterfaces(buildMap(map.get(YamlSpecKeywords.INTERFACES),
+                new Parameter<YTInterfaceAssignment>(parameter.getContext()).addContext(YamlSpecKeywords.INTERFACES)
                     .setValue("TNodeTemplate")
                     .setBuilderOO(this::buildInterfaceAssignment)
             ))
-            .setArtifacts(buildMap(map, "artifacts", this::buildArtifactDefinition, parameter))
-            .setNodeFilter(buildNodeFilterDefinition(map.get("node_filter"),
-                new Parameter<YTNodeFilterDefinition>(parameter.getContext()).addContext("node_filter")
+            .setArtifacts(buildMap(map, YamlSpecKeywords.ARTIFACTS, this::buildArtifactDefinition, parameter))
+            .setNodeFilter(buildNodeFilterDefinition(map.get(YamlSpecKeywords.NODE_FILTER),
+                new Parameter<YTNodeFilterDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.NODE_FILTER)
             ))
-            .setCopy(buildQName(stringValue(map.get("copy"))))
+            .setCopy(buildQName(stringValue(map.get(YamlSpecKeywords.COPY))))
             .build();
     }
 
@@ -1076,16 +1077,16 @@ public class YamlBuilder {
         if (!(object instanceof Map)) {
             // Attribute assignment with simple value
             return new YTAttributeAssignment.Builder().setValue(object).build();
-        } else if (!((Map) object).containsKey("value")) {
+        } else if (!((Map) object).containsKey(YamlSpecKeywords.VALUE)) {
             // Attribute assignment with <attribute_value_expression>
             return new YTAttributeAssignment.Builder().setValue(object).build();
-        } else if (((Map) object).containsKey("value") && validate(YTAttributeAssignment.class, object, parameter)) {
+        } else if (((Map) object).containsKey(YamlSpecKeywords.VALUE) && validate(YTAttributeAssignment.class, object, parameter)) {
             // Attribute assignment with extended notation
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) object;
             return new YTAttributeAssignment.Builder()
-                .setDescription(buildDescription(map.get("description")))
-                .setValue(map.get("value"))
+                .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+                .setValue(map.get(YamlSpecKeywords.VALUE))
                 .build();
         } else {
             return null;
@@ -1118,16 +1119,16 @@ public class YamlBuilder {
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
         return new YTRequirementAssignment.Builder()
-            .setCapability(buildQName(stringValue(map.get("capability"))))
-            .setNode(buildQName(stringValue(map.get("node"))))
-            .setRelationship(buildRelationshipAssignment(map.get("relationship"),
-                new Parameter<YTRelationshipAssignment>(parameter.getContext()).addContext("relationship")
+            .setCapability(buildQName(stringValue(map.get(YamlSpecKeywords.CAPABILITY))))
+            .setNode(buildQName(stringValue(map.get(YamlSpecKeywords.NODE))))
+            .setRelationship(buildRelationshipAssignment(map.get(YamlSpecKeywords.RELATIONSHIP),
+                new Parameter<YTRelationshipAssignment>(parameter.getContext()).addContext(YamlSpecKeywords.RELATIONSHIP)
             ))
-            .setNodeFilter(buildNodeFilterDefinition(map.get("node_filter"),
-                new Parameter<YTNodeFilterDefinition>(parameter.getContext()).addContext("node_filter")
+            .setNodeFilter(buildNodeFilterDefinition(map.get(YamlSpecKeywords.NODE_FILTER),
+                new Parameter<YTNodeFilterDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.NODE_FILTER)
             ))
-            .setOccurrences(buildListString(map.get("occurrences"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("occurrences")
+            .setOccurrences(buildListString(map.get(YamlSpecKeywords.OCCURRENCES),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.OCCURRENCES)
             ))
             .build();
     }
@@ -1145,9 +1146,9 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTRelationshipAssignment.Builder(buildQName(stringValue(map.get("type"))))
-            .setProperties(buildMap(map, "properties", this::buildPropertyAssignment, parameter))
-            .setInterfaces(buildMap(map, "interfaces", this::buildInterfaceAssignment, parameter))
+        return new YTRelationshipAssignment.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setProperties(buildMap(map, YamlSpecKeywords.PROPERTIES, this::buildPropertyAssignment, parameter))
+            .setInterfaces(buildMap(map, YamlSpecKeywords.INTERFACES, this::buildInterfaceAssignment, parameter))
             .build();
     }
 
@@ -1159,12 +1160,12 @@ public class YamlBuilder {
         }
         Map<String, Object> map = (Map<String, Object>) object;
         return new YTInterfaceAssignment.Builder()
-            .setType(buildQName(stringValue(map.get("type"))))
-            .setInputs(buildParameterDefinitions(map.get("inputs"),
+            .setType(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setInputs(buildParameterDefinitions(map.get(YamlSpecKeywords.INPUTS),
                 new Parameter<>(parameter.getContext())
                     .setValue("TInterfaceAssignment")
             ))
-            .setOperations(buildMap(map.get("operations"),
+            .setOperations(buildMap(map.get(YamlSpecKeywords.OPERATIONS),
                 new Parameter<YTOperationDefinition>(parameter.getContext()).addContext("(operations)")
                     .setBuilderOO(this::buildOperationDefinition)
                     // .setFilter(this::filterInterfaceAssignmentOperation)
@@ -1177,7 +1178,7 @@ public class YamlBuilder {
         if (Objects.isNull(entry.getKey())) {
             return false;
         }
-        Set<String> keys = Stream.of("type", "inputs").collect(Collectors.toSet());
+        Set<String> keys = Stream.of(YamlSpecKeywords.TYPE, YamlSpecKeywords.INPUTS).collect(Collectors.toSet());
         return !keys.contains(entry.getKey());
     }
 
@@ -1189,8 +1190,8 @@ public class YamlBuilder {
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
         return new YTNodeFilterDefinition.Builder()
-            .setProperties(buildList(map, "properties", this::buildMapPropertyDefinition, parameter))
-            .setCapabilities(buildList(map, "capabilities", this::buildMapObjectValue, parameter))
+            .setProperties(buildList(map, YamlSpecKeywords.PROPERTIES, this::buildMapPropertyDefinition, parameter))
+            .setCapabilities(buildList(map, YamlSpecKeywords.CAPABILITIES, this::buildMapObjectValue, parameter))
             .build();
     }
 
@@ -1213,7 +1214,7 @@ public class YamlBuilder {
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
         return new YTPropertyFilterDefinition.Builder()
-            .setConstraints(buildList(map, "constraints", this::buildConstraintClause, parameter))
+            .setConstraints(buildList(map, YamlSpecKeywords.CONSTRAINTS, this::buildConstraintClause, parameter))
             .build();
     }
 
@@ -1235,8 +1236,8 @@ public class YamlBuilder {
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
         return new YTCapabilityAssignment.Builder()
-            .setProperties(buildMap(map, "properties", this::buildPropertyAssignment, parameter))
-            .setAttributes(buildMap(map, "attributes", this::buildAttributeAssignment, parameter))
+            .setProperties(buildMap(map, YamlSpecKeywords.PROPERTIES, this::buildPropertyAssignment, parameter))
+            .setAttributes(buildMap(map, YamlSpecKeywords.ATTRIBUTES, this::buildAttributeAssignment, parameter))
             .build();
     }
 
@@ -1250,17 +1251,17 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTRelationshipTemplate.Builder(buildQName(stringValue(map.get("type"))))
-            .setDescription(buildDescription(map.get("description")))
-            .setMetadata(buildMetadata(map.get("metadata")))
-            .setProperties(buildMap(map, "properties", this::buildPropertyAssignment, parameter))
-            .setAttributes(buildMap(map, "attributes", this::buildAttributeAssignment, parameter))
-            .setInterfaces(buildMap(map.get("interfaces"),
-                new Parameter<YTInterfaceDefinition>(parameter.getContext()).addContext("interfaces")
+        return new YTRelationshipTemplate.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setMetadata(buildMetadata(map.get(YamlSpecKeywords.METADATA)))
+            .setProperties(buildMap(map, YamlSpecKeywords.PROPERTIES, this::buildPropertyAssignment, parameter))
+            .setAttributes(buildMap(map, YamlSpecKeywords.ATTRIBUTES, this::buildAttributeAssignment, parameter))
+            .setInterfaces(buildMap(map.get(YamlSpecKeywords.INTERFACES),
+                new Parameter<YTInterfaceDefinition>(parameter.getContext()).addContext(YamlSpecKeywords.INTERFACES)
                     .setValue("TRelationshipTemplate")
                     .setBuilderOO(this::buildInterfaceDefinition)
             ))
-            .setCopy(buildQName(stringValue(map.get("copy"))))
+            .setCopy(buildQName(stringValue(map.get(YamlSpecKeywords.COPY))))
             .build();
     }
 
@@ -1274,12 +1275,12 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTGroupDefinition.Builder(buildQName(stringValue(map.get("type"))))
-            .setDescription(buildDescription(map.get("description")))
-            .setMetadata(buildMetadata(map.get("metadata")))
-            .setProperties(buildMap(map, "properties", this::buildPropertyAssignment, parameter))
-            .setMembers(buildListQName(buildListString(map.get("members"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("members")
+        return new YTGroupDefinition.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setMetadata(buildMetadata(map.get(YamlSpecKeywords.METADATA)))
+            .setProperties(buildMap(map, YamlSpecKeywords.PROPERTIES, this::buildPropertyAssignment, parameter))
+            .setMembers(buildListQName(buildListString(map.get(YamlSpecKeywords.MEMBERS),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.MEMBERS)
             )))
             .build();
     }
@@ -1301,12 +1302,12 @@ public class YamlBuilder {
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
-        return new YTPolicyDefinition.Builder(buildQName(stringValue(map.get("type"))))
-            .setDescription(buildDescription(map.get("description")))
-            .setMetadata(buildMetadata(map.get("metadata")))
-            .setProperties(buildMap(map, "properties", this::buildPropertyAssignment, parameter))
-            .setTargets(buildListQName(buildListString(map.get("targets"),
-                new Parameter<List<String>>(parameter.getContext()).addContext("targets")
+        return new YTPolicyDefinition.Builder(buildQName(stringValue(map.get(YamlSpecKeywords.TYPE))))
+            .setDescription(buildDescription(map.get(YamlSpecKeywords.DESCRIPTION)))
+            .setMetadata(buildMetadata(map.get(YamlSpecKeywords.METADATA)))
+            .setProperties(buildMap(map, YamlSpecKeywords.PROPERTIES, this::buildPropertyAssignment, parameter))
+            .setTargets(buildListQName(buildListString(map.get(YamlSpecKeywords.TARGETS),
+                new Parameter<List<String>>(parameter.getContext()).addContext(YamlSpecKeywords.TARGETS)
             )))
             .build();
     }
@@ -1319,9 +1320,9 @@ public class YamlBuilder {
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) object;
         return new YTSubstitutionMappings.Builder()
-            .setNodeType(buildQName(stringValue(map.get("node_type"))))
-            .setCapabilities(buildMap(map, "capabilities", this::buildStringList, parameter))
-            .setRequirements(buildMap(map, "requirements", this::buildStringList, parameter))
+            .setNodeType(buildQName(stringValue(map.get(YamlSpecKeywords.NODE_TYPE))))
+            .setCapabilities(buildMap(map, YamlSpecKeywords.CAPABILITIES, this::buildStringList, parameter))
+            .setRequirements(buildMap(map, YamlSpecKeywords.REQUIREMENTS, this::buildStringList, parameter))
             .build();
     }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/writer/YamlWriter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/writer/YamlWriter.java
@@ -82,6 +82,7 @@ import org.eclipse.winery.model.tosca.yaml.support.YTMapObject;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapPropertyFilterDefinition;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapRequirementAssignment;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapRequirementDefinition;
+import org.eclipse.winery.model.tosca.yaml.support.YamlSpecKeywords;
 import org.eclipse.winery.model.tosca.yaml.tosca.datatypes.Credential;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractVisitor;
@@ -144,44 +145,43 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTServiceTemplate node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("tosca_definitions_version", node.getToscaDefinitionsVersion())
+            .printKeyValue(YamlSpecKeywords.TOSCA_DEF_VERSION, node.getToscaDefinitionsVersion())
             .printNewLine()
             .print(node.getMetadata().accept(this, parameter))
-            .print(printList("imports",
+            .print(printList(YamlSpecKeywords.IMPORTS,
                 node.getImports().stream().map(YTMapImportDefinition::values).flatMap(Collection::stream).collect(Collectors.toList()),
                 parameter))
             // .printKeyValue("description", node.getDescription())
-            .print(printMapObject("dsl_definitions", node.getDslDefinitions(), parameter))
-            .print(printMap("repositories", node.getRepositories(), parameter))
-            .print(printMap("artifact_types", node.getArtifactTypes(), parameter))
-            .print(printMap("data_types", node.getDataTypes(), parameter))
-            .print(printMap("capability_types", node.getCapabilityTypes(), parameter))
-            .print(printMap("interface_types", node.getInterfaceTypes(), parameter))
-            .print(printMap("relationship_types", node.getRelationshipTypes(), parameter))
-            .print(printMap("node_types", node.getNodeTypes(), parameter))
-            .print(printMap("group_types", node.getGroupTypes(), parameter))
-            .print(printMap("policy_types", node.getPolicyTypes(), parameter))
-            .print(printVisitorNode(node.getTopologyTemplate(), new Parameter(parameter.getIndent()).addContext("topology_template")));
+            .print(printMapObject(YamlSpecKeywords.DSL_DEFINITIONS, node.getDslDefinitions(), parameter))
+            .print(printMap(YamlSpecKeywords.REPOSITORIES, node.getRepositories(), parameter))
+            .print(printMap(YamlSpecKeywords.ARTIFACT_TYPES, node.getArtifactTypes(), parameter))
+            .print(printMap(YamlSpecKeywords.DATA_TYPES, node.getDataTypes(), parameter))
+            .print(printMap(YamlSpecKeywords.CAPABILITY_TYPES, node.getCapabilityTypes(), parameter))
+            .print(printMap(YamlSpecKeywords.INTERFACE_TYPES, node.getInterfaceTypes(), parameter))
+            .print(printMap(YamlSpecKeywords.RELATIONSHIP_TYPES, node.getRelationshipTypes(), parameter))
+            .print(printMap(YamlSpecKeywords.NODE_TYPES, node.getNodeTypes(), parameter))
+            .print(printMap(YamlSpecKeywords.GROUP_TYPES, node.getGroupTypes(), parameter))
+            .print(printMap(YamlSpecKeywords.POLICY_TYPES, node.getPolicyTypes(), parameter))
+            .print(printVisitorNode(node.getTopologyTemplate(), new Parameter(parameter.getIndent()).addContext(YamlSpecKeywords.TOPOLOGY_TEMPLATE)));
     }
 
     public YamlPrinter visit(YTTopologyTemplateDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("description", node.getDescription())
-            .print(printMap("inputs", node.getInputs(), parameter))
-            .print(printMap("node_templates", node.getNodeTemplates(), parameter))
-            .print(printMap("relationship_templates", node.getRelationshipTemplates(), parameter))
-            .print(printMap("groups", node.getGroups(), parameter))
-            .print(printListMap("policies",
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .print(printMap(YamlSpecKeywords.INPUTS, node.getInputs(), parameter))
+            .print(printMap(YamlSpecKeywords.NODE_TEMPLATES, node.getNodeTemplates(), parameter))
+            .print(printMap(YamlSpecKeywords.RELATIONSHIP_TEMPLATES, node.getRelationshipTemplates(), parameter))
+            .print(printMap(YamlSpecKeywords.GROUPS, node.getGroups(), parameter))
+            .print(printListMap(YamlSpecKeywords.POLICIES,
                 node.getPolicies().size() > 0 ? Collections.singletonList(node.getPolicies()) : new ArrayList<>(), parameter))
-            .print(printMap("outputs", node.getOutputs(), parameter))
-            .print(printVisitorNode(node.getSubstitutionMappings(), new Parameter(parameter.getIndent()).addContext("substitution_mappings")));
+            .print(printMap(YamlSpecKeywords.OUTPUTS, node.getOutputs(), parameter))
+            .print(printVisitorNode(node.getSubstitutionMappings(), new Parameter(parameter.getIndent()).addContext(YamlSpecKeywords.SUBSTITUTION_MAPPINGS)));
     }
 
     public YamlPrinter visit(Metadata node, Parameter parameter) {
         YamlPrinter printer = new YamlPrinter(parameter.getIndent());
         if (!node.isEmpty()) {
-            printer.printKey("metadata")
-                .indent(INDENT_SIZE);
+            printer.printKey(YamlSpecKeywords.METADATA).indent(INDENT_SIZE);
             node.forEach((key, value) -> printer.printKeyValue(key, value, true));
             printer.indent(-INDENT_SIZE);
         }
@@ -190,17 +190,17 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTRepositoryDefinition node, Parameter parameter) {
         YamlPrinter printer = new YamlPrinter(parameter.getIndent())
-            .printKeyValue("description", node.getDescription())
-            .printKeyValue("url", node.getUrl());
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .printKeyValue(YamlSpecKeywords.URL, node.getUrl());
         if (Objects.nonNull(node.getCredential())) {
             Credential credential = node.getCredential();
-            printer.printKey("credential")
+            printer.printKey(YamlSpecKeywords.CREDENTIAL)
                 .indent(INDENT_SIZE)
-                .printKeyValue("protocol", credential.getProtocol())
-                .printKeyValue("token_type", credential.getTokenType())
-                .printKeyValue("token", credential.getToken())
-                .printKeyObject("keys", credential.getKeys())
-                .printKeyValue("user", credential.getUser())
+                .printKeyValue(YamlSpecKeywords.PROTOCOL, credential.getProtocol())
+                .printKeyValue(YamlSpecKeywords.TOKEN_TYPE, credential.getTokenType())
+                .printKeyValue(YamlSpecKeywords.TOKEN, credential.getToken())
+                .printKeyObject(YamlSpecKeywords.KEYS, credential.getKeys())
+                .printKeyValue(YamlSpecKeywords.USER, credential.getUser())
                 .indent(-INDENT_SIZE);
         }
         return printer;
@@ -208,48 +208,48 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTImportDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("file", node.getFile())
-            .printKeyValue("repository", node.getRepository())
-            .printKeyValue("namespace_uri", node.getNamespaceUri())
+            .printKeyValue(YamlSpecKeywords.FILE, node.getFile())
+            .printKeyValue(YamlSpecKeywords.REPOSITORY, node.getRepository())
+            .printKeyValue(YamlSpecKeywords.NAMESPACE_URI, node.getNamespaceUri())
             // .printKeyValue("namespace_uri", node.getNamespaceUri(), !node.getNamespaceUri().equals(Namespaces.DEFAULT_NS))
-            .printKeyValue("namespace_prefix", node.getNamespacePrefix());
+            .printKeyValue(YamlSpecKeywords.NAMESPACE_PREFIX, node.getNamespacePrefix());
     }
 
     public YamlPrinter visit(YTArtifactType node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("mime_type", node.getMimeType())
-            .printKeyValue("file_ext", node.getFileExt());
+            .printKeyValue(YamlSpecKeywords.MIME_TYPE, node.getMimeType())
+            .printKeyValue(YamlSpecKeywords.FILE_EXT, node.getFileExt());
     }
 
     public YamlPrinter visit(YTEntityType node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("description", node.getDescription())
-            .printKeyValue("version", node.getVersion())
-            .printKeyValue("derived_from", node.getDerivedFrom())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .printKeyValue(YamlSpecKeywords.VERSION, node.getVersion())
+            .printKeyValue(YamlSpecKeywords.DERIVED_FROM, node.getDerivedFrom())
             .print(node.getMetadata().accept(this, parameter))
-            .print(printMap("attributes", node.getAttributes(), parameter))
-            .print(printMap("properties", node.getProperties(), parameter));
+            .print(printMap(YamlSpecKeywords.ATTRIBUTES, node.getAttributes(), parameter))
+            .print(printMap(YamlSpecKeywords.PROPERTIES, node.getProperties(), parameter));
     }
 
     public YamlPrinter visit(YTPropertyDefinition node, Parameter parameter) {
         YamlPrinter printer = new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
-            .printKeyValue("description", node.getDescription());
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription());
         // do not print the default value for required to avoid bloating the output
         if (!node.getRequired()) {
-            printer.printKeyValue("required", node.getRequired());
+            printer.printKeyValue(YamlSpecKeywords.REQUIRED, node.getRequired());
         }
-        printer.printYamlValue("default", node.getDefault());
+        printer.printYamlValue(YamlSpecKeywords.DEFAULT, node.getDefault());
         // do not print the default value for status to avoid bloating the output
         if (node.getStatus() != YTStatusValue.supported) {
-            printer.printKeyValue("status", node.getStatus());
+            printer.printKeyValue(YamlSpecKeywords.STATUS, node.getStatus());
         }
-        printer.print(printList("constraints", node.getConstraints(), parameter));
+        printer.print(printList(YamlSpecKeywords.CONSTRAINTS, node.getConstraints(), parameter));
         if (node.getEntrySchema() != null) {
-            printer.printKey("entry_schema").print(visit(node.getEntrySchema(), new Parameter(parameter.getIndent() + INDENT_SIZE)));
+            printer.printKey(YamlSpecKeywords.ENTRY_SCHEMA).print(visit(node.getEntrySchema(), new Parameter(parameter.getIndent() + INDENT_SIZE)));
         }
         if (node.getKeySchema() != null) {
-            printer.printKey("key_schema").print(visit(node.getKeySchema(), new Parameter(parameter.getIndent() + INDENT_SIZE)));
+            printer.printKey(YamlSpecKeywords.KEY_SCHEMA).print(visit(node.getKeySchema(), new Parameter(parameter.getIndent() + INDENT_SIZE)));
         }
 
         return printer;
@@ -257,67 +257,66 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTSchemaDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
-            .printKeyValue("description", node.getDescription())
-            .print(printList("constraints", node.getConstraints(), parameter));
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .print(printList(YamlSpecKeywords.CONSTRAINTS, node.getConstraints(), parameter));
     }
 
     public YamlPrinter visit(YTAttributeDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("description", node.getDescription())
-            .printKeyValue("type", node.getType())
-            .printYamlValue("default", node.getDefault())
-            .printKeyValue("status", node.getStatus())
-            .print(printVisitorNode(node.getEntrySchema(), parameter.addContext("entry_schema")));
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .printYamlValue(YamlSpecKeywords.DEFAULT, node.getDefault())
+            .printKeyValue(YamlSpecKeywords.STATUS, node.getStatus())
+            .print(printVisitorNode(node.getEntrySchema(), parameter.addContext(YamlSpecKeywords.ENTRY_SCHEMA)));
     }
 
     public YamlPrinter visit(YTDataType node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .print(printList("constraints", node.getConstraints(), parameter));
+            .print(printList(YamlSpecKeywords.CONSTRAINTS, node.getConstraints(), parameter));
     }
 
     public YamlPrinter visit(YTCapabilityType node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("valid_source_types", node.getValidSourceTypes());
+            .printKeyValue(YamlSpecKeywords.VALID_SOURCE_TYPES, node.getValidSourceTypes());
     }
 
     public YamlPrinter visit(YTInterfaceType node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .print(printMap("operations", node.getOperations(), parameter))
-            .print(printMap("inputs", node.getInputs(), parameter));
+            .print(printMap(YamlSpecKeywords.OPERATIONS, node.getOperations(), parameter))
+            .print(printMap(YamlSpecKeywords.INPUTS, node.getInputs(), parameter));
     }
 
     public YamlPrinter visit(YTOperationDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("description", node.getDescription())
-            .print(printMap("inputs", node.getInputs(), new Parameter(parameter.getIndent())))
-            .print(printMap("outputs", node.getOutputs(), new Parameter(parameter.getIndent())))
-            .print(printVisitorNode(node.getImplementation(), new Parameter(parameter.getIndent()).addContext("implementation")));
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .print(printMap(YamlSpecKeywords.INPUTS, node.getInputs(), new Parameter(parameter.getIndent())))
+            .print(printMap(YamlSpecKeywords.OUTPUTS, node.getOutputs(), new Parameter(parameter.getIndent())))
+            .print(printVisitorNode(node.getImplementation(), new Parameter(parameter.getIndent()).addContext(YamlSpecKeywords.IMPLEMENTATION)));
     }
 
     public YamlPrinter visit(YTImplementation node, Parameter parameter) {
         YamlPrinter printer = new YamlPrinter(parameter.getIndent())
-            .printKeyValue("primary", node.getPrimaryArtifactName())
-            .printKeyValue("dependencies", node.getDependencyArtifactNames())
-            .printKeyValue("operation_host", node.getOperationHost());
+            .printKeyValue(YamlSpecKeywords.PRIMARY, node.getPrimaryArtifactName())
+            .printKeyValue(YamlSpecKeywords.DEPENDENCIES, node.getDependencyArtifactNames())
+            .printKeyValue(YamlSpecKeywords.OPERATION_HOST, node.getOperationHost());
         if (node.getTimeout() != null) {
-            printer.printKeyValue("timeout", node.getTimeout().toString());
+            printer.printKeyValue(YamlSpecKeywords.TIMEOUT, node.getTimeout().toString());
         }
         return printer;
     }
 
     public YamlPrinter visit(YTRelationshipType node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("valid_target_types", node.getValidTargetTypes())
-            .print(printMap("interfaces", node.getInterfaces(), parameter));
+            .printKeyValue(YamlSpecKeywords.VALID_TARGET_TYPES, node.getValidTargetTypes())
+            .print(printMap(YamlSpecKeywords.INTERFACES, node.getInterfaces(), parameter));
     }
 
     public YamlPrinter visit(YTInterfaceDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
-            .print(printMap("inputs", node.getInputs(), parameter))
-
-            .print(printMap("operations", node.getOperations(), parameter));
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .print(printMap(YamlSpecKeywords.INPUTS, node.getInputs(), parameter))
+            .print(printMap(YamlSpecKeywords.OPERATIONS, node.getOperations(), parameter));
 
 //            .print(node.getOperations().entrySet().stream()
 //                .filter(entry -> Objects.nonNull(entry) && Objects.nonNull(entry.getValue()))
@@ -330,85 +329,85 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTNodeType node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .print(printListMap("requirements", node.getRequirements().stream().map(YTMapRequirementDefinition::getMap).collect(Collectors.toList()), parameter))
-            .print(printMap("capabilities", node.getCapabilities(), parameter))
-            .print(printMap("interfaces", node.getInterfaces(), parameter))
-            .print(printMap("artifacts", node.getArtifacts(), parameter));
+            .print(printListMap(YamlSpecKeywords.REQUIREMENTS, node.getRequirements().stream().map(YTMapRequirementDefinition::getMap).collect(Collectors.toList()), parameter))
+            .print(printMap(YamlSpecKeywords.CAPABILITIES, node.getCapabilities(), parameter))
+            .print(printMap(YamlSpecKeywords.INTERFACES, node.getInterfaces(), parameter))
+            .print(printMap(YamlSpecKeywords.ARTIFACTS, node.getArtifacts(), parameter));
     }
 
     public YamlPrinter visit(YTRequirementDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("capability", node.getCapability())
-            .printKeyValue("node", node.getNode())
-            .print(printVisitorNode(node.getRelationship(), new Parameter(parameter.getIndent()).addContext("relationship")))
-            .printKeyValue("occurrences", node.getOccurrences())
-            .printKeyValue("description", node.getDescription());
+            .printKeyValue(YamlSpecKeywords.CAPABILITY, node.getCapability())
+            .printKeyValue(YamlSpecKeywords.NODE, node.getNode())
+            .print(printVisitorNode(node.getRelationship(), new Parameter(parameter.getIndent()).addContext(YamlSpecKeywords.RELATIONSHIP)))
+            .printKeyValue(YamlSpecKeywords.OCCURRENCES, node.getOccurrences())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription());
     }
 
     public YamlPrinter visit(YTRelationshipDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
             // Removed to support short notations
             // .printKeyValue("type", node.getType())
-            .print(printMap("interfaces", node.getInterfaces(), parameter));
+            .print(printMap(YamlSpecKeywords.INTERFACES, node.getInterfaces(), parameter));
     }
 
     public YamlPrinter visit(YTCapabilityDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("description", node.getDescription())
-            .printKeyValue("occurrences", node.getOccurrences())
-            .printKeyValue("valid_source_types", node.getValidSourceTypes())
-            .printKeyValue("type", node.getType())
-            .print(printMap("properties", node.getProperties(), parameter))
-            .print(printMap("attributes", node.getAttributes(), parameter));
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .printKeyValue(YamlSpecKeywords.OCCURRENCES, node.getOccurrences())
+            .printKeyValue(YamlSpecKeywords.VALID_SOURCE_TYPES, node.getValidSourceTypes())
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .print(printMap(YamlSpecKeywords.PROPERTIES, node.getProperties(), parameter))
+            .print(printMap(YamlSpecKeywords.ATTRIBUTES, node.getAttributes(), parameter));
     }
 
     public YamlPrinter visit(YTArtifactDefinition node, Parameter parameter) {
         YamlPrinter output = new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
-            .printKeyValue("repository", node.getRepository())
-            .printKeyValue("description", node.getDescription())
-            .printKeyValue("deploy_path", node.getDeployPath());
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .printKeyValue(YamlSpecKeywords.REPOSITORY, node.getRepository())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .printKeyValue(YamlSpecKeywords.DEPLOY_PATH, node.getDeployPath());
         if (node.getFile() != null) {
-            output.printKeyValue("file", node.getFile());
+            output.printKeyValue(YamlSpecKeywords.FILE, node.getFile());
         }
         return output;
     }
 
     public YamlPrinter visit(YTGroupType node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("members", node.getMembers());
+            .printKeyValue(YamlSpecKeywords.MEMBERS, node.getMembers());
     }
 
     public YamlPrinter visit(YTPolicyType node, Parameter parameter) {
         YamlPrinter printer = new YamlPrinter(parameter.getIndent())
-            .printKeyValue("targets", node.getTargets());
+            .printKeyValue(YamlSpecKeywords.TARGETS, node.getTargets());
 
         Map<String, YTTriggerDefinition> validTriggers = node.getTriggers().entrySet()
             .stream()
             .filter(entry -> Objects.nonNull(entry.getValue().getEvent()))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        return printer.print(printMap("triggers", validTriggers, parameter));
+        return printer.print(printMap(YamlSpecKeywords.TRIGGERS, validTriggers, parameter));
     }
 
     public YamlPrinter visit(YTTriggerDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("description", node.getDescription())
-            .printKeyValue("event", node.getEvent())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .printKeyValue(YamlSpecKeywords.EVENT, node.getEvent())
             .print(node.getTargetFilter().accept(this, parameter))
-            .print(printListMap("action", node.getAction().stream().map(YTMapActivityDefinition::getMap).collect(Collectors.toList()), parameter));
+            .print(printListMap(YamlSpecKeywords.ACTION, node.getAction().stream().map(YTMapActivityDefinition::getMap).collect(Collectors.toList()), parameter));
     }
 
     public YamlPrinter visit(YTEventFilterDefinition node, Parameter parameter) {
         YamlPrinter printer = new YamlPrinter(parameter.getIndent());
         if (Objects.nonNull(node) && Objects.nonNull(node.getNode())) {
-            printer.printKey("target_filter").indent(INDENT_SIZE);
-            printer.printKeyValue("node", node.getNode());
+            printer.printKey(YamlSpecKeywords.TARGET_FILTER).indent(INDENT_SIZE);
+            printer.printKeyValue(YamlSpecKeywords.NODE, node.getNode());
             if (Objects.nonNull(node.getRequirement())) {
-                printer.printKeyValue("requirement", node.getRequirement());
+                printer.printKeyValue(YamlSpecKeywords.REQUIREMENT, node.getRequirement());
             }
             if (Objects.nonNull(node.getRequirement())) {
-                printer.printKeyValue("capability", node.getCapability());
+                printer.printKeyValue(YamlSpecKeywords.CAPABILITY, node.getCapability());
             }
             printer.indent(-INDENT_SIZE);
         }
@@ -417,10 +416,9 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTCallOperationActivityDefinition node, Parameter parameter) {
         YamlPrinter printer = new YamlPrinter(parameter.getIndent())
-            .printKeyValue("operation", node.getOperation());
+            .printKeyValue(YamlSpecKeywords.OPERATION, node.getOperation());
         if (Objects.nonNull(node.getInputs()) && !node.getInputs().isEmpty()) {
-            printer.printKey("inputs")
-                .indent(INDENT_SIZE);
+            printer.printKey(YamlSpecKeywords.INPUTS).indent(INDENT_SIZE);
             SortedSet<String> keys = new TreeSet<>(node.getInputs().keySet());
             for (String key : keys) {
                 Object value = node.getInputs().get(key).getValue();
@@ -440,36 +438,36 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTNodeTemplate node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
-            .printKeyValue("description", node.getDescription())
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
             .print(node.getMetadata().accept(this, parameter))
-            .printKeyValue("directives", node.getDirectives())
-            .print(printMap("properties", node.getProperties(), parameter))
-            .print(printMap("attributes", node.getAttributes(), parameter))
-            .print(printListMap("requirements", node.getRequirements().stream().map(YTMapRequirementAssignment::getMap).collect(Collectors.toList()), parameter))
-            .print(printMap("capabilities", node.getCapabilities(), parameter))
-            .print(printMap("interfaces", node.getInterfaces(), parameter))
-            .print(printMap("artifacts", node.getArtifacts(), parameter))
+            .printKeyValue(YamlSpecKeywords.DIRECTIVES, node.getDirectives())
+            .print(printMap(YamlSpecKeywords.PROPERTIES, node.getProperties(), parameter))
+            .print(printMap(YamlSpecKeywords.ATTRIBUTES, node.getAttributes(), parameter))
+            .print(printListMap(YamlSpecKeywords.REQUIREMENTS, node.getRequirements().stream().map(YTMapRequirementAssignment::getMap).collect(Collectors.toList()), parameter))
+            .print(printMap(YamlSpecKeywords.CAPABILITIES, node.getCapabilities(), parameter))
+            .print(printMap(YamlSpecKeywords.INTERFACES, node.getInterfaces(), parameter))
+            .print(printMap(YamlSpecKeywords.ARTIFACTS, node.getArtifacts(), parameter))
             .print(printVisitorNode(node.getNodeFilter(), parameter))
-            .printKeyValue("copy", node.getCopy());
+            .printKeyValue(YamlSpecKeywords.COPY, node.getCopy());
     }
 
     public YamlPrinter visit(YTGroupDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
-            .printKeyValue("description", node.getDescription())
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
             .print(node.getMetadata().accept(this, parameter))
-            .print(printMap("properties", node.getProperties(), parameter))
-            .printKeyValue("members", node.getMembers());
+            .print(printMap(YamlSpecKeywords.PROPERTIES, node.getProperties(), parameter))
+            .printKeyValue(YamlSpecKeywords.MEMBERS, node.getMembers());
     }
 
     public YamlPrinter visit(YTPolicyDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
-            .printKeyValue("description", node.getDescription())
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
             .print(node.getMetadata().accept(this, parameter))
-            .print(printMap("properties", node.getProperties(), parameter))
-            .printKeyValue("targets", node.getTargets());
+            .print(printMap(YamlSpecKeywords.PROPERTIES, node.getProperties(), parameter))
+            .printKeyValue(YamlSpecKeywords.TARGETS, node.getTargets());
     }
 
     public YamlPrinter visit(YTPropertyAssignment node, Parameter parameter) {
@@ -531,7 +529,7 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTAttributeAssignment node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("description", node.getDescription())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
             .printYamlValue(parameter.getKey(), node.getValue(), true);
     }
 
@@ -541,14 +539,14 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTParameterDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
-            .printKeyValue("description", node.getDescription())
-            .printKeyValue("required", node.getRequired())
-            .printYamlValue("default", node.getDefault())
-            .printKeyValue("status", node.getStatus())
-            .print(printList("constraints", node.getConstraints(), parameter))
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
+            .printKeyValue(YamlSpecKeywords.REQUIRED, node.getRequired())
+            .printYamlValue(YamlSpecKeywords.DEFAULT, node.getDefault())
+            .printKeyValue(YamlSpecKeywords.STATUS, node.getStatus())
+            .print(printList(YamlSpecKeywords.CONSTRAINTS, node.getConstraints(), parameter))
             .print(printVisitorNode(node.getEntrySchema(), parameter))
-            .printYamlValue("value", node.getValue());
+            .printYamlValue(YamlSpecKeywords.VALUE, node.getValue());
     }
 
     public YamlPrinter visit(YTConstraintClause node, Parameter parameter) {
@@ -564,17 +562,17 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTCapabilityAssignment node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .print(printMap("properties", node.getProperties(), parameter))
-            .print(printMap("attributes", node.getAttributes(), parameter));
+            .print(printMap(YamlSpecKeywords.PROPERTIES, node.getProperties(), parameter))
+            .print(printMap(YamlSpecKeywords.ATTRIBUTES, node.getAttributes(), parameter));
     }
 
     public YamlPrinter visit(YTNodeFilterDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .print(printListMap("properties",
+            .print(printListMap(YamlSpecKeywords.PROPERTIES,
                 node.getProperties().stream().map(YTMapPropertyFilterDefinition::getMap).collect(Collectors.toList()),
                 parameter)
             )
-            .print(printListMap("capabilities",
+            .print(printListMap(YamlSpecKeywords.CAPABILITIES,
                 node.getCapabilities().stream().map(YTMapObject::getMap).collect(Collectors.toList()),
                 parameter)
             );
@@ -582,41 +580,41 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(YTRelationshipTemplate node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
-            .printKeyValue("description", node.getDescription())
+            .printKeyValue(YamlSpecKeywords.TYPE, node.getType())
+            .printKeyValue(YamlSpecKeywords.DESCRIPTION, node.getDescription())
             .print(node.getMetadata().accept(this, parameter))
-            .print(printMap("properties", node.getProperties(), parameter))
-            .print(printMap("attributes", node.getAttributes(), parameter))
-            .print(printMap("interfaces", node.getInterfaces(), parameter))
-            .printKeyValue("copy", node.getCopy());
+            .print(printMap(YamlSpecKeywords.PROPERTIES, node.getProperties(), parameter))
+            .print(printMap(YamlSpecKeywords.ATTRIBUTES, node.getAttributes(), parameter))
+            .print(printMap(YamlSpecKeywords.INTERFACES, node.getInterfaces(), parameter))
+            .printKeyValue(YamlSpecKeywords.COPY, node.getCopy());
     }
 
     public YamlPrinter visit(YTSubstitutionMappings node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("node_type", node.getNodeType())
-            .print(printMapInlineStringList("capabilities", node.getCapabilities(), parameter));
+            .printKeyValue(YamlSpecKeywords.NODE_TYPE, node.getNodeType())
+            .print(printMapInlineStringList(YamlSpecKeywords.CAPABILITIES, node.getCapabilities(), parameter));
     }
 
     public YamlPrinter visit(YTRequirementAssignment node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("node", node.getNode())
-            .print(printVisitorNode(node.getRelationship(), new Parameter(parameter.getIndent()).addContext("relationship")))
-            .printKeyValue("capability", node.getCapability())
-            .print(printVisitorNode(node.getNodeFilter(), new Parameter(parameter.getIndent()).addContext("node_filter")))
-            .printKeyValue("occurrences", node.getOccurrences());
+            .printKeyValue(YamlSpecKeywords.NODE, node.getNode())
+            .print(printVisitorNode(node.getRelationship(), new Parameter(parameter.getIndent()).addContext(YamlSpecKeywords.RELATIONSHIP)))
+            .printKeyValue(YamlSpecKeywords.CAPABILITY, node.getCapability())
+            .print(printVisitorNode(node.getNodeFilter(), new Parameter(parameter.getIndent()).addContext(YamlSpecKeywords.NODE_FILTER)))
+            .printKeyValue(YamlSpecKeywords.OCCURRENCES, node.getOccurrences());
     }
 
     public YamlPrinter visit(YTRelationshipAssignment node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
             // Removed to support short notations
             // .printKeyValue("type", node.getType())
-            .print(printMap("properties", node.getProperties(), parameter))
-            .print(printMap("interfaces", node.getInterfaces(), parameter));
+            .print(printMap(YamlSpecKeywords.PROPERTIES, node.getProperties(), parameter))
+            .print(printMap(YamlSpecKeywords.INTERFACES, node.getInterfaces(), parameter));
     }
 
     public YamlPrinter visit(YTPropertyFilterDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .print(printList("constraints", node.getConstraints(), parameter));
+            .print(printList(YamlSpecKeywords.CONSTRAINTS, node.getConstraints(), parameter));
     }
 
     public YamlPrinter printVisitorNode(VisitorNode node, Parameter parameter) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/FromCanonical.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/FromCanonical.java
@@ -130,6 +130,7 @@ import org.eclipse.winery.model.tosca.yaml.support.YTMapActivityDefinition;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapImportDefinition;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapRequirementAssignment;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapRequirementDefinition;
+import org.eclipse.winery.model.tosca.yaml.support.YamlSpecKeywords;
 import org.eclipse.winery.repository.yaml.YamlRepository;
 import org.eclipse.winery.repository.yaml.export.YamlExporter;
 
@@ -592,7 +593,7 @@ public class FromCanonical {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             yamlDef.setInputs(inputs);
 
-            return new YTMapActivityDefinition().setMap(Collections.singletonMap("call_operation", yamlDef));
+            return new YTMapActivityDefinition().setMap(Collections.singletonMap(YamlSpecKeywords.CALL_OPERATION, yamlDef));
         }
         return new YTMapActivityDefinition();
     }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/support/SchemaVisitor.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/support/SchemaVisitor.java
@@ -24,18 +24,22 @@ import java.util.Objects;
 
 import javax.xml.namespace.QName;
 
-import org.eclipse.jdt.annotation.NonNull;
-
 import org.eclipse.winery.model.converter.support.Namespaces;
 import org.eclipse.winery.model.converter.support.exception.MultiException;
 import org.eclipse.winery.model.ids.EncodingUtil;
-import org.eclipse.winery.model.tosca.yaml.*;
+import org.eclipse.winery.model.tosca.yaml.YTDataType;
+import org.eclipse.winery.model.tosca.yaml.YTEntityType;
+import org.eclipse.winery.model.tosca.yaml.YTImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.YTPropertyDefinition;
+import org.eclipse.winery.model.tosca.yaml.YTServiceTemplate;
 import org.eclipse.winery.model.tosca.yaml.support.YTMapImportDefinition;
+import org.eclipse.winery.model.tosca.yaml.support.YamlSpecKeywords;
 import org.eclipse.winery.repository.converter.reader.YamlReader;
 import org.eclipse.winery.repository.converter.validator.support.ExceptionVisitor;
 import org.eclipse.winery.repository.converter.validator.support.Result;
 import org.eclipse.winery.repository.converter.writer.WriterUtils;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.w3c.dom.Document;
 
 public class SchemaVisitor extends ExceptionVisitor<Result, Parameter> {
@@ -121,7 +125,7 @@ public class SchemaVisitor extends ExceptionVisitor<Result, Parameter> {
                 }
             }
 
-            visitChildes(node, parameter);
+            visitChildren(node, parameter);
         }
         // Optimized: parameter.datatype is set and defined in this service template 
         else if (type.getNamespaceURI().equals(parameter.getNamespace())
@@ -240,46 +244,46 @@ public class SchemaVisitor extends ExceptionVisitor<Result, Parameter> {
     }
 
     /**
-     * Visit all childes of ServiceTemplates except from metadata, repositories, imports, data_types
+     * Visit all children of ServiceTemplates except from metadata, repositories, imports, data_types
      */
-    private void visitChildes(YTServiceTemplate node, Parameter parameter) {
+    private void visitChildren(YTServiceTemplate node, Parameter parameter) {
         node.getArtifactTypes().entrySet().stream()
             .filter(entry -> Objects.nonNull(entry) && Objects.nonNull(entry.getValue()))
             .forEach(entry ->
-                entry.getValue().accept(this, parameter.copy().addContext("artifact_types", entry.getKey()))
+                entry.getValue().accept(this, parameter.copy().addContext(YamlSpecKeywords.ARTIFACT_TYPES, entry.getKey()))
             );
         node.getCapabilityTypes().entrySet().stream()
             .filter(entry -> Objects.nonNull(entry) && Objects.nonNull(entry.getValue()))
             .forEach(entry ->
-                entry.getValue().accept(this, parameter.copy().addContext("capability_types", entry.getKey()))
+                entry.getValue().accept(this, parameter.copy().addContext(YamlSpecKeywords.CAPABILITY_TYPES, entry.getKey()))
             );
         node.getInterfaceTypes().entrySet().stream()
             .filter(entry -> Objects.nonNull(entry) && Objects.nonNull(entry.getValue()))
             .forEach(entry ->
-                entry.getValue().accept(this, parameter.copy().addContext("interface_types", entry.getKey()))
+                entry.getValue().accept(this, parameter.copy().addContext(YamlSpecKeywords.INTERFACE_TYPES, entry.getKey()))
             );
         node.getRelationshipTypes().entrySet().stream()
             .filter(entry -> Objects.nonNull(entry) && Objects.nonNull(entry.getValue()))
             .forEach(entry ->
-                entry.getValue().accept(this, parameter.copy().addContext("relationship_types", entry.getKey()))
+                entry.getValue().accept(this, parameter.copy().addContext(YamlSpecKeywords.RELATIONSHIP_TYPES, entry.getKey()))
             );
         node.getNodeTypes().entrySet().stream()
             .filter(entry -> Objects.nonNull(entry) && Objects.nonNull(entry.getValue()))
             .forEach(entry ->
-                entry.getValue().accept(this, parameter.copy().addContext("node_types", entry.getKey()))
+                entry.getValue().accept(this, parameter.copy().addContext(YamlSpecKeywords.NODE_TYPES, entry.getKey()))
             );
         node.getGroupTypes().entrySet().stream()
             .filter(entry -> Objects.nonNull(entry) && Objects.nonNull(entry.getValue()))
             .forEach(entry ->
-                entry.getValue().accept(this, parameter.copy().addContext("group_types", entry.getKey()))
+                entry.getValue().accept(this, parameter.copy().addContext(YamlSpecKeywords.GROUP_TYPES, entry.getKey()))
             );
         node.getPolicyTypes().entrySet().stream()
             .filter(entry -> Objects.nonNull(entry) && Objects.nonNull(entry.getValue()))
             .forEach(entry ->
-                entry.getValue().accept(this, parameter.copy().addContext("policy_types", entry.getKey()))
+                entry.getValue().accept(this, parameter.copy().addContext(YamlSpecKeywords.POLICY_TYPES, entry.getKey()))
             );
         if (Objects.nonNull(node.getTopologyTemplate())) {
-            node.getTopologyTemplate().accept(this, parameter.copy().addContext("topology_template"));
+            node.getTopologyTemplate().accept(this, parameter.copy().addContext(YamlSpecKeywords.TOPOLOGY_TEMPLATE));
         }
     }
 }


### PR DESCRIPTION
This PR intends to store and use TOSCA YAML keywords as constants

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/master/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
