### PR TITLE
Signed-Off is not required anymore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,15 +73,11 @@ Please ensure that the email address you use at Eclipse is the same as the "Publ
 
 ### Making the Commit
 
-When making the commit for the pull request it is vital that you "sign-off" on the commit using `git commit -s` option.
-Without this sign-off, your patch cannot be applied to the Winery repository because it will be rejected.
+In the case of multiple authors, please add each additional author to commit message.
+```
+Co-authored-by: Some Bodyelse <somebodyelse@nowhere.com>
+```
 
-You can check out [the guide at GitHub](https://help.github.com/articles/signing-tags-using-gpg) for more information.
-
-One way to think of this is that when you sign the CLA you are indicating that you are free to contribute to eclipse, but that does not mean everything you ever do can be contributed.
-Using the commit signing mechanism indicates that your commit is under the auspices of your agreement.
-
-In the case of multiple authors, plese add `Also-by: Some Bodyelse <somebodyelse@nowhere.com>` for each additional author.
 For more information, see <https://www.eclipse.org/projects/handbook/#resources-commit>.
 
 ### Contributing via GitHub PullRequests


### PR DESCRIPTION
Per discussion in https://github.com/eclipse/winery/pull/646#issuecomment-1020956618
and https://www.eclipse.org/lists/eclipse.org-committers/msg01291.html

<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/main/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [ ] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
