### PR TITLE
Fix Uploading Plan Files

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/PlanFileResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/plans/PlanFileResource.java
@@ -80,9 +80,9 @@ public class PlanFileResource {
         if (oldRef != null && !ref.equals(oldRef)) {
             // new filename sent
             RestUtils.delete(oldRef);
-            PlansResource.setPlanModelReference(this.plan, this.planId, fileName);
-            RestUtils.persist(this.res);
         }
+        PlansResource.setPlanModelReference(this.plan, this.planId, fileName);
+        RestUtils.persist(this.res);
 
         return RestUtils.putContentToFile(ref, uploadedInputStream, org.apache.tika.mime.MediaType.parse(body.getMediaType().toString()));
     }


### PR DESCRIPTION
Sometimes, the upload of files does not update the reference to the plan.

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/main/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
