### PR TITLE
Fix/yamlsupport

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/YamlCsarImporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/YamlCsarImporter.java
@@ -171,6 +171,10 @@ public class YamlCsarImporter extends CsarImporter {
                 this.adjustNodeType(definitionsPath.getParent().getParent(), (TNodeType) ci, (NodeTypeId) wid, tmf, errors);
             } else if (ci instanceof TRelationshipType) {
                 this.adjustRelationshipType(definitionsPath.getParent().getParent(), (TRelationshipType) ci, (RelationshipTypeId) wid, tmf, errors);
+            } else if (ci instanceof TServiceTemplate) {
+                // tosca yaml doesn't have plans but workflows, therefore this seems not to be working properly
+               // this.adjustServiceTemplate(definitionsPath.getParent().getParent(), tmf, (ServiceTemplateId) wid, (TServiceTemplate) ci, errors);
+                entryServiceTemplate = Optional.of((ServiceTemplateId) wid);
             }
 
             storeDefs(wid, newDefs);

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/export/YamlToscaExportUtil.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/export/YamlToscaExportUtil.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
 
 public class YamlToscaExportUtil extends ToscaExportUtil {
 
-    private static final boolean EXPORT_NORMATIVE_TYPES = false;
+    private static final boolean EXPORT_NORMATIVE_TYPES = true;
     private static final Logger LOGGER = LoggerFactory.getLogger(YamlToscaExportUtil.class);
 
     @Override


### PR DESCRIPTION
Fixes isssue with YAML support as they missed an entry servicetemplate after parsing it (see https://github.com/OpenTOSCA/container/pull/274) or when exporting a YAML CSAR the normative types where missing, making the CSAR not self-contained.

- [ ] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/main/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [ ] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
