### PR TITLE
fixes an issue with CSAR imports

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/xml/XmlRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/xml/XmlRepository.java
@@ -112,7 +112,7 @@ public class XmlRepository extends AbstractFileBasedRepository {
             }
         } else {
             // another quick hack; storing the mime type is not required for research object files
-            if (!ref.getParent().getXmlId().getDecoded().equals(Constants.DIRNAME_RESEARCH_OBJECT_FILES) && !ref.getParent().getParent().getXmlId().getDecoded().equals(Constants.DIRNAME_RESEARCH_OBJECT)) {
+            if (ref.getParent() != null && ref.getParent().getParent() != null && !ref.getParent().getXmlId().getDecoded().equals(Constants.DIRNAME_RESEARCH_OBJECT_FILES) && !ref.getParent().getParent().getXmlId().getDecoded().equals(Constants.DIRNAME_RESEARCH_OBJECT)) {
                 this.setMimeType(ref, mediaType);
             }
             Path targetPath = this.ref2AbsolutePath(ref);


### PR DESCRIPTION
CSAR import didn't work when using winery programmatically, e.g., in the OpenTOSCA runtime.
The issue was happening because of some Nullpointer which are fixed now

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/main/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Tests created for changes
- [x] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
