### PR TITLE
Fix/Show license when license-engine is activated but not running

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryLicenseModule/wineryLicense.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryLicenseModule/wineryLicense.component.ts
@@ -82,6 +82,7 @@ export class WineryLicenseComponent implements OnInit {
                     (data) => {
                         this.currentLicenseText = data;
                         this.initialLicenseText = data;
+                        this.loading = false;
                     }),
                 catchError(() => {
                     this.handleMissingLicense();
@@ -98,12 +99,15 @@ export class WineryLicenseComponent implements OnInit {
                 secondCtrl: ['', Validators.required]
             });
 
-            // when license engine is used, get licenses from there
+            // when license engine is used and is running, get licenses from there
             observables.push(this.leService.getAllLicenses().pipe(
                 map(
                     (licenses) => {
                         this.options = licenses;
-                    })
+                    }),
+                catchError(() => {
+                    return Observable.of(null);
+                })
             ));
         } else {
             // else, get licenses from the local files


### PR DESCRIPTION
Show the defined license text even when the license-engine is activated but not running.

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/main/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
