### PR TITLE
Fix: zipping repository contents not working for MultiPartBuilder

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -90,10 +90,10 @@ Copyright (c) 2021 Marvin Bechtold
 Copyright (c) 2021 Timm Pankratz
 Copyright (c) 2021 Lavinia Stiliadou
 Copyright (c) 2022 Anatoli Babenia
+Copyright (c) 2022 Daniel Vietz
 Copyright (c) 2022 Faisal Khan
 Copyright (c) 2022 Miles Stötzner
 Copyright (c) 2022 Pawel Wójcik
-Copyright (c) 2022 Daniel Vietz
 
 == Third-party Content
 

--- a/NOTICE
+++ b/NOTICE
@@ -93,6 +93,7 @@ Copyright (c) 2022 Anatoli Babenia
 Copyright (c) 2022 Faisal Khan
 Copyright (c) 2022 Miles Stötzner
 Copyright (c) 2022 Pawel Wójcik
+Copyright (c) 2022 Daniel Vietz
 
 == Third-party Content
 

--- a/org.eclipse.winery.model.adaptation/src/main/java/org/eclipse/winery/model/adaptation/substitution/refinement/topologyrefinement/TopologyFragmentRefinement.java
+++ b/org.eclipse.winery.model.adaptation/src/main/java/org/eclipse/winery/model/adaptation/substitution/refinement/topologyrefinement/TopologyFragmentRefinement.java
@@ -282,7 +282,7 @@ public class TopologyFragmentRefinement extends AbstractRefinement {
                     try (final InputStream inputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray())) {
                         MultipartEntityBuilder multipartBuilder = MultipartEntityBuilder.create();
                         multipartBuilder.addBinaryBody(
-                            "files-zip",
+                            "file",
                             inputStream,
                             ContentType.APPLICATION_OCTET_STREAM,
                             "files.zip"


### PR DESCRIPTION
Replace PipedOutputStream with ByteArrayOutputStream for zipping repository contents