### PR TITLE
Allow Exporting Topology Templates as EDMM

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The source for the documentation can be found in the [docs](docs) directory.
 ## Acknowledgements
 
 The initial code contribution has been supported by the Federal Ministry for Economic Affairs and Energy as part of the [CloudCycle] project (01MD11023).
-Current development is supported by the [Federal Ministry for Economic Affairs and Climate Action] as part of the [PlanQK] project (01MK20005N), the [DFG] (Deutsche Forschungsgemeinschaft) project [ReSUS] (425911815), as well as the DFG’s Excellence Initiative project [SimTech] (EXC 2075 - 390740016).
+Current development is supported by the [Federal Ministry for Economic Affairs and Climate Action] as part of the [PlanQK] project (01MK20005N), the [DFG] (Deutsche Forschungsgemeinschaft) projects [ReSUS] (425911815) and [IAC²] (314720630), as well as the DFG’s Excellence Initiative project [SimTech] (EXC 2075 - 390740016).
 Additional development has been funded by the Federal Ministry for Economic Affairs and Energy projects [SmartOrchestra] (01MD16001F) and [SePiA.Pro] (01MD16013F), as well as by the DFG projects [SustainLife] (641730) and [ADDCompliance] (636503).
 Further development is also funded by the European Union’s Horizon 2020 project [RADON] (825040).
 
@@ -60,3 +60,4 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   [PlanQK]: https://planqk.de
   [SimTech]: https://www.simtech.uni-stuttgart.de/
   [ReSUS]: https://www.iaas.uni-stuttgart.de/en/projects/resus/
+  [IAC²]: https://www.iaas.uni-stuttgart.de/forschung/projekte/iacc/

--- a/org.eclipse.winery.edmm/src/main/java/org/eclipse/winery/edmm/model/EdmmConverter.java
+++ b/org.eclipse.winery.edmm/src/main/java/org/eclipse/winery/edmm/model/EdmmConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019-2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -40,6 +40,7 @@ import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.TRelationshipType;
 import org.eclipse.winery.model.tosca.TRelationshipTypeImplementation;
 import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.model.tosca.extensions.OTParticipant;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
 
@@ -86,22 +87,26 @@ public class EdmmConverter {
     }
 
     public EntityGraph transform(TServiceTemplate serviceTemplate) {
+        assert serviceTemplate.getTopologyTemplate() != null;
+        return this.transform(serviceTemplate.getTopologyTemplate(), ModelUtilities.getOwnerParticipantOfServiceTemplate(serviceTemplate));
+    }
 
+    public EntityGraph transform(TTopologyTemplate topology, String ownerParticipant) {
         EntityGraph entityGraph = new EntityGraph();
-
         setMetadata(entityGraph);
+        List<TNodeTemplate> nodeTemplates = topology.getNodeTemplates();
+        List<TRelationshipTemplate> relationshipTemplates = topology.getRelationshipTemplates();
 
-        List<TNodeTemplate> nodeTemplates = serviceTemplate.getTopologyTemplate().getNodeTemplates();
-        List<TRelationshipTemplate> relationshipTemplates = serviceTemplate.getTopologyTemplate().getRelationshipTemplates();
         if (!nodeTemplates.isEmpty()) {
             entityGraph.addEntity(new MappingEntity(EntityGraph.COMPONENTS, entityGraph));
         }
+
         nodeTemplates.forEach(nodeTemplate -> createNode(nodeTemplate, entityGraph));
         relationshipTemplates.forEach(relationship -> createRelation(relationship, entityGraph));
+        List<OTParticipant> participants = topology.getParticipants();
 
-        List<OTParticipant> participants = serviceTemplate.getTopologyTemplate().getParticipants();
-        if (participants != null && !participants.isEmpty()) {
-            entityGraph.addEntity(new ScalarEntity(ModelUtilities.getOwnerParticipantOfServiceTemplate(serviceTemplate), EntityGraph.OWNER, entityGraph));
+        if (participants != null && !participants.isEmpty() && ownerParticipant != null) {
+            entityGraph.addEntity(new ScalarEntity(ownerParticipant, EntityGraph.OWNER, entityGraph));
             entityGraph.addEntity(new MappingEntity(EntityGraph.PARTICIPANTS, entityGraph));
             participants.forEach(participant -> createParticipant(participant, nodeTemplates, entityGraph));
         }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/edmm/EdmmResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/edmm/EdmmResource.java
@@ -48,6 +48,7 @@ import org.eclipse.winery.model.tosca.TImplementationArtifact;
 import org.eclipse.winery.model.tosca.TInterface;
 import org.eclipse.winery.model.tosca.TOperation;
 import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.repository.backend.IRepository;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.rest.RestUtils;
@@ -84,10 +85,21 @@ public class EdmmResource {
     private static final String LIFECYCLE_NAME = "http://opentosca.org/interfaces/lifecycle";
     private static final String[] LIFECYCLE = {"create", "configure", "start", "stop", "delete"};
 
-    private final TServiceTemplate element;
+    private final TTopologyTemplate element;
 
     public EdmmResource(TServiceTemplate element) {
+        this(element.getTopologyTemplate());
+    }
+
+    public EdmmResource(TTopologyTemplate element) {
         this.element = element;
+    }
+
+    @GET
+    @Path("export")
+    @Produces()
+    public Response exportEdmm(@QueryParam(value = "edmmUseAbsolutePaths") String edmmUseAbsolutePaths) {
+        return RestUtils.getEdmmModel(this.element, edmmUseAbsolutePaths != null);
     }
 
     @GET

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012-2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -75,6 +75,7 @@ import org.eclipse.winery.repository.rest.resources.apiData.NewVersionListElemen
 import org.eclipse.winery.repository.rest.resources.apiData.PropertyDiffList;
 import org.eclipse.winery.repository.rest.resources.apiData.QNameApiData;
 import org.eclipse.winery.repository.rest.resources.apiData.UpdateInfo;
+import org.eclipse.winery.repository.rest.resources.edmm.EdmmResource;
 import org.eclipse.winery.repository.splitting.Splitting;
 import org.eclipse.winery.repository.targetallocation.Allocation;
 import org.eclipse.winery.repository.targetallocation.util.AllocationRequest;
@@ -174,6 +175,11 @@ public class TopologyTemplateResource {
         return Response.noContent().build();
     }
 
+    @Path("edmm")
+    public EdmmResource getTopologyTemplateAsEdmm() {
+        return new EdmmResource(this.topologyTemplate);
+    }
+
     @Path("nodetemplates/")
     public NodeTemplatesResource getNodeTemplatesResource() {
         // FIXME: onDelete will not work as we have a copy of the original list. We have to add a "listener" to remove at the list and route that remove to the original list
@@ -253,7 +259,7 @@ public class TopologyTemplateResource {
         ResourceResult result = new ResourceResult();
         result.setStatus(Response.Status.CREATED);
         result.setMessage(new QNameApiData(splitServiceTemplateId));
-        
+
         return result.getResponse();
     }
 

--- a/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/admin/EdmmTypesResourceTest.java
+++ b/org.eclipse.winery.repository.rest/src/test/java/org/eclipse/winery/repository/rest/resources/admin/EdmmTypesResourceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022-2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -26,7 +26,6 @@ import org.eclipse.winery.edmm.model.EdmmType;
 import org.eclipse.winery.repository.rest.resources.AbstractResourceTest;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
- A compliance rule consists of two topology templates, both of which need to be exportable as EDMM to be consumed by other systems.
- Before this PR, only a whole service template was exportable to EDMM.
- This PR adds a subresource `/edmm` below the topology resource that returns an `EdmmResource`.
- This PR also adds an `/export` GET operation inside the `EdmmResouce` to allow exporting it.


<!-- describe the changes you have made here: what, why, ... -->

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/main/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [x] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
